### PR TITLE
Increase max group message length by four bytes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
 
 install:
   - set PATH=C:\Python311-x64\Scripts;%PATH%
-  - py -3 -m pip install conan
+  - py -3 -m pip install conan==1.59.0
   - git submodule update --init --recursive
 
 for:

--- a/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
+++ b/other/bootstrap_daemon/docker/tox-bootstrapd.sha256
@@ -1,1 +1,1 @@
-b0fafb30bffe21889f06a95edd3867f29a2203d30c2d7e7bf3ef646267f08d64  /usr/local/bin/tox-bootstrapd
+62d2c7ab2a14d1f9b00acaf13813b3ea916ccfb2173c9ba95ac82a843a258119  /usr/local/bin/tox-bootstrapd

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -21,7 +21,7 @@
 #define MAX_GC_TOPIC_SIZE 512
 #define MAX_GC_GROUP_NAME_SIZE 48
 #define GC_MESSAGE_PSEUDO_ID_SIZE 4
-#define GROUP_MAX_MESSAGE_LENGTH  1368
+#define GROUP_MAX_MESSAGE_LENGTH  1372
 
 /* Max size of a packet chunk. Packets larger than this must be split up.
  *

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -3301,7 +3301,7 @@ uint32_t tox_group_max_part_length(void);
 /**
  * Maximum length of a group text message.
  */
-#define TOX_GROUP_MAX_MESSAGE_LENGTH    1368
+#define TOX_GROUP_MAX_MESSAGE_LENGTH    1372
 
 /**
  * Maximum length of a group custom lossy packet.


### PR DESCRIPTION
The max message length was reduced by 4 bytes to account for the pseudo message ID, which had unintended effects on clients. It makes more sense to increase the raw packet length by four and keep the max group message length the same as the max message length for friend chats.