### PR TITLE
[AIassisted] Add persistent signed group-roster middleware for NGC

### DIFF
--- a/.localrun/generate_amalgamation.sh
+++ b/.localrun/generate_amalgamation.sh
@@ -92,6 +92,8 @@ toxcore/util.h \
 \
 toxutil/toxutil.h \
 \
+ngc_ppeerlist/mid_roster.h \
+\
 toxav/ring_buffer.h \
 toxav/bwcontroller.h \
 toxav/msi.h \
@@ -108,6 +110,7 @@ toxav/codecs/toxav_codecs.h \
     toxcore/*.c toxcore/*/*.c toxencryptsave/*.c \
     toxav/*.c toxav/codecs/*/*.c third_party/cmp/*.c \
     toxutil/toxutil.c \
+    ngc_ppeerlist/mid_roster.c \
     |grep -v '#include "' >> amalgamation/toxcore_amalgamation.c
 #
 #
@@ -194,9 +197,12 @@ toxcore/util.h \
 \
 toxutil/toxutil.h \
 \
+ngc_ppeerlist/mid_roster.h \
+\
     toxcore/*.c toxcore/*/*.c toxencryptsave/*.c \
     third_party/cmp/*.c \
     toxutil/toxutil.c \
+    ngc_ppeerlist/mid_roster.c \
     |grep -v '#include "' >> amalgamation/toxcore_amalgamation_no_toxav.c
 #
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set_source_files_properties(
   toxcore/tox.c
   toxcore/util.c
   toxutil/toxutil.c
+  ngc_ppeerlist/mid_roster.c
   PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 
 ################################################################################
@@ -332,12 +333,15 @@ set(toxcore_SOURCES
   toxcore/util.c
   toxcore/util.h
   toxutil/toxutil.c
-  toxutil/toxutil.h)
+  toxutil/toxutil.h
+  ngc_ppeerlist/mid_roster.c
+  ngc_ppeerlist/mid_roster.h)
 set(toxcore_LINK_MODULES ${toxcore_LINK_MODULES} ${LIBSODIUM_LIBRARIES})
 set(toxcore_PKGCONFIG_REQUIRES ${toxcore_PKGCONFIG_REQUIRES} libsodium)
 set(toxcore_API_HEADERS
   ${toxcore_SOURCE_DIR}/toxcore/tox.h^tox
   ${toxcore_SOURCE_DIR}/toxutil/toxutil.h^tox
+  ${toxcore_SOURCE_DIR}/ngc_ppeerlist/mid_roster.h^tox
   ${toxcore_SOURCE_DIR}/toxcore/tox_events.h^tox
   ${toxcore_SOURCE_DIR}/toxcore/tox_dispatch.h^tox)
 

--- a/amalgamation/toxcore_amalgamation.c
+++ b/amalgamation/toxcore_amalgamation.c
@@ -9545,6 +9545,19 @@ uint32_t tox_group_chat_id_size(void);
 
 uint32_t tox_group_peer_public_key_size(void);
 
+/**
+ * The size of an Ed25519 group signing public key.
+ */
+#define TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE 32
+
+/**
+ * The size of a peer's group secret signing key.
+ *
+ * This is the size of the Ed25519 secret signing key used for the client's
+ * group identity in an NGC group.
+ */
+#define TOX_GROUP_SIGNING_SECRET_KEY_SIZE 64
+
 
 /*******************************************************************************
  *
@@ -10126,6 +10139,53 @@ uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_E
 bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
                                    Tox_Err_Group_Self_Query *error);
 
+/**
+ * Write the client's group Ed25519 signing public key designated by the given
+ * group number to a byte array.
+ *
+ * This is the public signing key that corresponds to the group secret signing
+ * key returned by tox_group_self_get_signing_secret_key().
+ *
+ * `public_key` should have room for at least TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE
+ * bytes.
+ *
+ * If `public_key` is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_self_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Self_Query *error);
+
+/**
+ * Write the client's group secret signing key designated by the given group
+ * number to a byte array.
+ *
+ * This key is the Ed25519 secret signing key for the client's group identity.
+ * It is permanently tied to the client's identity for this particular group
+ * until the client explicitly leaves the group.
+ *
+ * This key can be used to sign application-level group packets, for example
+ * membership / presence events.
+ *
+ * `secret_key` should have room for at least TOX_GROUP_SIGNING_SECRET_KEY_SIZE
+ * bytes.
+ *
+ * If `secret_key` is NULL, this function call has no effect.
+ *
+ * @param secret_key A valid memory region large enough to store the secret key.
+ *   If this parameter is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_self_get_signing_secret_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *secret_key,
+                                           Tox_Err_Group_Self_Query *error);
+
+
+
 
 /*******************************************************************************
  *
@@ -10253,6 +10313,26 @@ bool tox_group_peer_get_public_key(const Tox *tox, uint32_t group_number, uint32
 
 bool tox_group_savedpeer_get_public_key(const Tox *tox, uint32_t group_number, uint32_t slot_number, uint8_t *public_key,
                                    Tox_Err_Group_Peer_Query *error);
+
+/**
+ * Write the Ed25519 signing public key of the peer designated by `peer_id`
+ * to `public_key`.
+ *
+ * This key can be used to verify signatures created by that peer's group
+ * secret signing key.
+ *
+ * `public_key` should have room for at least TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE
+ * bytes.
+ *
+ * If `public_key` is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_peer_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint32_t peer_id,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Peer_Query *error);
 
 /**
  * @brief Return the peer number associated with that NGC Peer Public Key.
@@ -10399,6 +10479,24 @@ bool tox_group_set_topic(const Tox *tox, uint32_t group_number, const uint8_t *t
  * `group_topic` callback.
  */
 size_t tox_group_get_topic_size(const Tox *tox, uint32_t group_number, Tox_Err_Group_State_Queries *error);
+
+/**
+ * Write the group founder's public key designated by the given group number to a byte array.
+ *
+ * This key is permanently tied to the group's identity and represents the peer who originally
+ * created the group. It remains valid for the entire lifetime of the group and cannot be
+ * changed or reassigned. This key allows peers to reliably identify the group founder even
+ * when the founder is offline.
+ *
+ * `public_key` should have room for at least TOX_GROUP_PEER_PUBLIC_KEY_SIZE bytes.
+ *
+ * @param public_key A valid memory region large enough to store the public key.
+ *   If this parameter is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_get_founder_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
+                                      Tox_Err_Group_State_Queries *error);
 
 /**
  * Write the topic designated by the given group number to a byte array.
@@ -13055,6 +13153,35 @@ uint32_t gc_get_self_peer_id(const GC_Chat *chat);
 non_null(1) nullable(2)
 void gc_get_self_public_key(const GC_Chat *chat, uint8_t *public_key);
 
+/**
+ * Copies the client's group Ed25519 secret signing key to `secret_key`.
+ *
+ * `secret_key` must have room for SIG_SECRET_KEY_SIZE bytes.
+ */
+non_null() nullable(2)
+void gc_get_self_signing_secret_key(const GC_Chat *chat, uint8_t *secret_key);
+
+/**
+ * Copies self Ed25519 group signing public key to `public_key`.
+ *
+ * If `public_key` is null this function has no effect.
+ */
+non_null(1) nullable(2)
+void gc_get_self_signing_public_key(const GC_Chat *chat, uint8_t *public_key);
+
+/**
+ * Copies the Ed25519 signing public key of peer `peer_id` to `public_key`.
+ *
+ * If `public_key` is null this function has no effect.
+ *
+ * Returns true on success.
+ * Returns false if the peer is not found.
+ */
+non_null(1) nullable(3)
+bool gc_get_peer_signing_public_key(const GC_Chat *chat,
+                                    uint32_t peer_id,
+                                    uint8_t *public_key);
+
 /** @brief Copies nick designated by `peer_id` to `name`.
  *
  * Call `gc_get_peer_nick_size` to determine the allocation size for the `name` parameter.
@@ -13141,6 +13268,10 @@ uint8_t gc_get_status(const GC_Chat *chat, uint32_t peer_id);
  */
 non_null()
 uint8_t gc_get_role(const GC_Chat *chat, uint32_t peer_id);
+
+
+void gc_get_founder_public_key(const GC_Chat *chat, uint8_t *public_key);
+
 
 /** @brief Sets the role of peer_id. role must be one of: GR_MODERATOR, GR_USER, GR_OBSERVER
  *
@@ -15926,6 +16057,381 @@ bool tox_utils_friend_delete(Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_DE
 //!TOKSTYLE+
 
 #endif
+/*
+mid_roster.h
+Minimal persistent group-roster middleware for Tox NGC.
+This header exposes a very simple API. All internal state, heartbeats,
+online-state synchronization, and roster requests are hidden inside
+the middleware. The client only needs to forward Toxcore events to
+the middleware hooks and call mid_iterate() in its main loop.
+*/
+
+#ifndef MID_ROSTER_H
+#define MID_ROSTER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+/*
+Opaque middleware state.
+A single MidState instance can manage multiple groups simultaneously.
+
+THREAD-SAFETY:
+All public functions in this header are thread-safe and may be called
+concurrently from any thread. Internally a single non-recursive
+pthread_mutex_t protects all mutable state (similar to tox_lock/tox_unlock
+in Toxcore). Callbacks are always fired WITHOUT the lock held, so it is
+safe to call any mid_* function from within a callback without deadlock.
+
+mid_new() and mid_free() are NOT thread-safe with respect to each other
+or to concurrent users. The caller must ensure mid_free() is only called
+after all other threads have stopped using the MidState.
+*/
+typedef struct MidState MidState;
+
+/* Hard limit for stored peers per group. */
+#define MID_MAX_PEERS_PER_GROUP 1024
+
+#define MID_PROTOCOL_VERSION    1
+
+/* NGC custom packet ID */
+#define MID_MAGIC_0  0x66      // was before: 0xA0
+#define MID_MAGIC_1  0x77      // was before: 0x91
+#define MID_MAGIC_2  0x92
+
+#define MID_MAGIC_BYTES_TOTAL 3
+/* Total header size: Magic bytes + Protocol Version (1 byte) + Message Type (1 byte) */
+#define MID_HEADER_SIZE (MID_MAGIC_BYTES_TOTAL + 2)
+
+/******************************************************************************
+Key-size constants (needed by MidPeerInfo below)
+******************************************************************************/
+
+#ifndef MID_IDENTITY_KEY_SIZE
+#define MID_IDENTITY_KEY_SIZE TOX_GROUP_PEER_PUBLIC_KEY_SIZE
+#endif
+
+#ifndef MID_SIGNING_KEY_SIZE
+#define MID_SIGNING_KEY_SIZE 32
+#endif
+
+#ifndef MID_MAX_NICK_SIZE
+#define MID_MAX_NICK_SIZE 128
+#endif
+
+/******************************************************************************
+Lifecycle
+******************************************************************************/
+
+/*
+Create a new middleware state.
+
+Parameters:
+  save_path      File path to load/save state. Pass NULL for a clean,
+                 in-memory only state.
+
+  passphrase     Optional passphrase to encrypt/decrypt the save file on disk.
+                 Pass NULL (with passphrase_len = 0) to save in plaintext
+                 (file permissions will be set to 0600).
+                 The passphrase can be any arbitrary length. It is fed
+                 directly to tox_pass_key_derive() internally.
+                 The passphrase is NOT stored in the middleware state.
+                 You must provide the same passphrase on every call to
+                 mid_save() to produce a readable encrypted file.
+
+  passphrase_len Length of the passphrase in bytes. Pass 0 if passphrase
+                 is NULL.
+
+Behavior on load:
+  If a save file exists at save_path:
+    - If the file is encrypted, the passphrase MUST be correct, otherwise
+      decryption fails and the file is ignored (clean state is started).
+    - If the file is unencrypted, it is loaded regardless of passphrase.
+    - If the file is corrupted or has an unsupported version, it is ignored.
+
+Returns:
+  A new MidState instance, or NULL on fatal error.
+*/
+MidState *mid_new(const char *save_path, const uint8_t *passphrase, size_t passphrase_len);
+
+/*
+Save the current state to disk. Thread-safe.
+
+The state is written atomically: data is written to a temporary file first,
+then renamed over the target path. This prevents corruption if the process
+is killed mid-write.
+
+Parameters:
+  s              The middleware state. Must not be NULL.
+
+  passphrase     Optional passphrase to encrypt the save file on disk.
+                 Pass NULL (with passphrase_len = 0) to save in plaintext.
+                 Must match the passphrase used when the file was originally
+                 encrypted if you intend to load it later with a passphrase.
+                 The passphrase is NOT stored. It is used only for this
+                 single save operation.
+
+  passphrase_len Length of the passphrase in bytes. Pass 0 if passphrase
+                 is NULL.
+
+Note:
+  The save_path used here is the one provided to mid_new(). There is no
+  separate configuration function. If save_path was NULL at creation,
+  this function returns false immediately.
+
+Returns:
+  true on success, false on failure.
+*/
+bool mid_save(MidState *s, const uint8_t *passphrase, size_t passphrase_len);
+
+void mid_free(MidState *s);
+
+/******************************************************************************
+Group Hooks
+******************************************************************************/
+
+/*
+Call this when the client successfully joins a group (or creates one).
+The middleware will fetch keys, announce the client, and request the roster.
+*/
+void mid_on_group_self_join(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len);
+
+/*
+Call this when the client leaves or deletes a group.
+The middleware will securely wipe keys and free the roster for this group.
+*/
+void mid_on_group_delete(MidState *s, Tox *tox, uint32_t group_number);
+
+/******************************************************************************
+Peer Event Hooks
+******************************************************************************/
+
+/*
+Call this when a new peer joins the group.
+The middleware will record them as online, refresh their name, and
+automatically re-sync the roster if we have already announced ourselves.
+*/
+void mid_on_group_peer_join(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id);
+
+/*
+ * Call this when a peer exits the group (via Toxcore's peer_exit callback).
+ * 
+ * NOTE: The `exit_type` parameter is intentionally ignored. 
+ * To maintain a stable, persistent roster that includes offline peers, 
+ * we do not delete peers simply because they disconnected or quit. 
+ * 
+ * Instead, this triggers a state-sync (`mid_sync_online_state_group`). 
+ * The middleware will query Toxcore to confirm the peer is gone and mark 
+ * them as offline (`TOX_CONNECTION_NONE`). 
+ * 
+ * If a peer actually intends to leave permanently, they should broadcast 
+ * a signed LEFT tombstone (MID_STATUS_LEFT) via custom packets before 
+ * disconnecting. The middleware will process that tombstone and keep the 
+ * peer in the roster for 7 days (MID_TOMBSTONE_TTL_SEC) to allow offline 
+ * peers to sync the departure.
+ */
+void mid_on_group_peer_exit(MidState *s, Tox *tox, uint32_t group_number, Tox_Group_Exit_Type exit_type);
+
+/*
+Call this when a peer changes their nickname.
+The middleware will update the unsigned local observation of their name.
+*/
+void mid_on_group_peer_name(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id);
+
+/******************************************************************************
+Moderation Hook
+******************************************************************************/
+
+/*
+Call this when a group moderation event is received.
+The middleware hides all kick-related roster logic internally:
+If we were the target of the kick, the middleware securely wipes the group
+state (keys and roster) and returns true. The client should then clear its
+own local group reference (group_number / group_connected).
+If another peer was kicked, the middleware deletes that peer from the
+roster and returns false.
+
+NOTE:
+The peer who INITIATES a kick does NOT receive the group_moderation event
+(see tox_group_mod_kick_peer / tox_callback_group_moderation in tox.h).
+Therefore the middleware cannot delete the kicked peer on the kicker's side
+from this hook. The kicker must explicitly call mid_delete_peer_by_identity()
+for the peer it kicked.
+
+Returns true if we ourselves were kicked.
+*/
+bool mid_on_group_moderation(MidState *s, Tox *tox, uint32_t group_number,
+                             uint32_t source_peer_id, uint32_t target_peer_id,
+                             Tox_Group_Mod_Event mod_type);
+
+/******************************************************************************
+Network Hook
+******************************************************************************/
+
+/*
+Call this when a group custom packet is received.
+The middleware will verify signatures, upsert records, and respond to
+roster requests automatically.
+*/
+void mid_on_group_custom_packet(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data, size_t length);
+
+/******************************************************************************
+Main Loop Hook
+******************************************************************************/
+
+/*
+Call this in your main loop alongside tox_iterate().
+The middleware will handle periodic heartbeats and continuously sync
+the online state of all peers across all managed groups.
+*/
+void mid_iterate(MidState *s, Tox *tox);
+
+/******************************************************************************
+Queries
+******************************************************************************/
+
+size_t mid_group_count(MidState *s);
+size_t mid_peer_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+size_t mid_signed_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+size_t mid_online_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+size_t mid_offline_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+
+/*
+Find a peer by NGC identity public key in a specific group.
+Returns:
+>= 0   peer index in the middleware roster for that group
+-1     peer not found, or group not found
+*/
+int mid_find_peer(MidState *s,
+                  const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                  const uint8_t identity_key[TOX_GROUP_PEER_PUBLIC_KEY_SIZE]);
+
+/*
+Delete a peer from the middleware roster by identity key.
+This is needed for kick handling.
+The kicker does not receive a group_peer_exit event for the peer it kicked,
+so the client must explicitly delete the kicked peer.
+*/
+bool mid_delete_peer_by_identity(MidState *s,
+                                 const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                                 const uint8_t identity_key[TOX_GROUP_PEER_PUBLIC_KEY_SIZE]);
+
+/*
+Returns true if the middleware has a signed LEFT tombstone for this
+identity key in the given group.
+*/
+bool mid_peer_is_signed_left(MidState *s,
+                             const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                             const uint8_t identity_key[MID_IDENTITY_KEY_SIZE]);
+
+/*
+Call this IMMEDIATELY BEFORE calling tox_group_leave().
+This broadcasts a signed "LEFT" tombstone to the group.
+When other peers (including those who were offline and just synced)
+receive this signed record, they will permanently delete this peer
+from their persistent rosters.
+*/
+bool mid_announce_leave(MidState *s, Tox *tox, uint32_t group_number);
+
+
+bool mid_self_set_name(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len);
+
+/******************************************************************************
+Peer List Query API (for C / JNI clients)
+Flat, fixed-size, index-based access. No dynamic allocation.
+Safe pattern:
+
+    size_t n = mid_peer_list_count(s, chat_id);
+    for (size_t i = 0; i < n; i++) {
+        MidPeerInfo info;
+        if (mid_peer_list_get(s, chat_id, i, &info)) {
+            // use info
+        }
+    }
+******************************************************************************/
+
+/*
+Flat representation of one peer in the roster.
+All fields are fixed-size. No pointers. NUL-terminated nickname.
+Suitable for direct mapping to JNI structs or flatbuffers.
+*/
+typedef struct {
+    uint8_t  identity_key[MID_IDENTITY_KEY_SIZE];   /*  NGC group identity key  */
+    uint8_t  signing_key[MID_SIGNING_KEY_SIZE];     /*  Ed25519 signing key    */
+    uint8_t  status;          /*  0 = ACTIVE, 1 = LEFT  */
+    uint8_t  connection_status; /* Tox_Connection: 0=NONE(offline), 1=TCP, 2=UDP */
+    uint8_t  role;            /* Tox_Group_Role: 0=FOUNDER, 1=MOD, 2=USER, 3=OBSERVER */
+    uint8_t  has_signature;   /*  1 if record is cryptographically signed  */
+    uint8_t  reserved;        /*  padding for alignment  */
+    uint64_t last_seen;       /*  unix timestamp, 0 if never seen  */
+    uint16_t nickname_len;    /*  length of nickname in bytes (without NUL)  */
+    /* CRUCIAL: +1 byte to safely hold the NUL terminator for JNI/C strings */
+    uint8_t nickname[MID_MAX_NICK_SIZE + 1];
+} MidPeerInfo;
+
+/*
+Return the number of peers in the middleware roster for a group.
+Returns 0 if the group is not found.
+*/
+size_t mid_peer_list_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+
+/*
+Fill `out` with the peer at `index` in the roster for the given group.
+Returns true on success.
+Returns false if s is NULL, out is NULL, group not found, or index >= count.
+The caller provides the MidPeerInfo storage. No memory is allocated.
+All fields are written; the struct is fully initialised on success.
+*/
+bool mid_peer_list_get(MidState *s,
+                       const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                       size_t index,
+                       MidPeerInfo *out);
+
+/******************************************************************************
+Peer List Changed Callback
+Register a callback to be notified whenever the peer roster for any group
+managed by this MidState has changed. The client should then call
+mid_peer_list_count() / mid_peer_list_get() to refresh its view.
+The callback receives the chat_id whose list changed, plus the
+user_data pointer.
+
+Thread-safety: the callback is invoked WITHOUT the middleware lock held.
+It is safe to call mid_peer_list_get() from within the callback.
+******************************************************************************/
+
+typedef void (*mid_peer_list_changed_cb)(const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], void *user_data);
+
+/*
+Register the peer-list-changed callback.
+Pass NULL for cb to unregister.
+*/
+void mid_set_peer_list_changed_cb(MidState *s,
+                                  mid_peer_list_changed_cb cb,
+                                  void *user_data);
+
+/******************************************************************************
+Network Stats
+******************************************************************************/
+
+/*
+Query the total bytes sent and received by the middleware custom packets.
+Pass NULL for either pointer if you only want to query one of them.
+Thread-safe.
+*/
+void mid_get_network_stats(MidState *s, uint64_t *sent_bytes, uint64_t *recv_bytes);
+
+/******************************************************************************
+Debug
+******************************************************************************/
+
+void mid_print_peer_table(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const char *title);
+
+#endif /* MID_ROSTER_H */
 /* SPDX-License-Identifier: GPL-3.0-or-later
  * Copyright © 2016-2018 The TokTok team.
  * Copyright © 2013 Tox project.
@@ -29444,6 +29950,33 @@ void gc_get_self_public_key(const GC_Chat *chat, uint8_t *public_key)
     }
 }
 
+void gc_get_self_signing_secret_key(const GC_Chat *chat, uint8_t *secret_key)
+{
+    if (secret_key != nullptr) {
+        memcpy(secret_key, get_sig_sk(chat->self_secret_key), SIG_SECRET_KEY_SIZE);
+    }
+}
+
+void gc_get_self_signing_public_key(const GC_Chat *chat, uint8_t *public_key)
+{
+    if (public_key == nullptr) {
+        return;
+    }
+
+    /*
+     * Peer 0 is always self.
+     */
+    const GC_Connection *gconn = get_gc_connection(chat, 0);
+
+    if (gconn == nullptr) {
+        return;
+    }
+
+    memcpy(public_key,
+           get_sig_pk(gconn->addr.public_key),
+           SIG_PUBLIC_KEY_SIZE);
+}
+
 /** @brief Sets self extended public key to `ext_public_key`.
  *
  * If `ext_public_key` is null this function has no effect.
@@ -29781,6 +30314,31 @@ static int get_peer_number_of_peer_id(const GC_Chat *chat, uint32_t peer_id)
     }
 
     return -1;
+}
+
+bool gc_get_peer_signing_public_key(const GC_Chat *chat,
+                                    uint32_t peer_id,
+                                    uint8_t *public_key)
+{
+    const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
+
+    if (peer_number == -1) {
+        return false;
+    }
+
+    const GC_Connection *gconn = get_gc_connection(chat, peer_number);
+
+    if (gconn == nullptr) {
+        return false;
+    }
+
+    if (public_key != nullptr) {
+        memcpy(public_key,
+               get_sig_pk(gconn->addr.public_key),
+               SIG_PUBLIC_KEY_SIZE);
+    }
+
+    return true;
 }
 
 /** @brief Returns a unique peer ID.
@@ -31628,6 +32186,13 @@ uint8_t gc_get_role(const GC_Chat *chat, uint32_t peer_id)
     }
 
     return peer->role;
+}
+
+void gc_get_founder_public_key(const GC_Chat *chat, uint8_t *public_key)
+{
+    if (public_key != nullptr) {
+        memcpy(public_key, get_enc_key(chat->shared_state.founder_public_key), ENC_PUBLIC_KEY_SIZE);
+    }
 }
 
 void gc_get_chat_id(const GC_Chat *chat, uint8_t *dest)
@@ -63963,6 +64528,7 @@ Tox_Group_Role tox_group_self_get_role(const Tox *tox, uint32_t group_number, To
     return (Tox_Group_Role)role;
 }
 
+
 uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_Err_Group_Self_Query *error)
 {
     assert(tox != nullptr);
@@ -64001,6 +64567,105 @@ bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_
     SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
 
     gc_get_self_public_key(chat, public_key);
+    tox_unlock(tox);
+
+    return true;
+}
+
+bool tox_group_self_get_signing_secret_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *secret_key,
+                                           Tox_Err_Group_Self_Query *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
+
+    gc_get_self_signing_secret_key(chat, secret_key);
+    tox_unlock(tox);
+
+    return true;
+}
+
+bool tox_group_self_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Self_Query *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
+
+    gc_get_self_signing_public_key(chat, public_key);
+    tox_unlock(tox);
+
+    return true;
+}
+
+bool tox_group_peer_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint32_t peer_id,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Peer_Query *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_PEER_QUERY_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    const bool ret = gc_get_peer_signing_public_key(chat, peer_id, public_key);
+    tox_unlock(tox);
+
+    if (!ret) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_PEER_QUERY_PEER_NOT_FOUND);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_PEER_QUERY_OK);
+    return true;
+}
+
+bool tox_group_get_founder_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
+                                      Tox_Err_Group_State_Queries *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_STATE_QUERIES_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_STATE_QUERIES_OK);
+
+    gc_get_founder_public_key(chat, public_key);
     tox_unlock(tox);
 
     return true;
@@ -90504,3 +91169,3817 @@ int64_t tox_util_friend_send_message_v2(Tox *tox, uint32_t friend_number, TOX_ME
 #pragma GCC diagnostic pop
 
 //!TOKSTYLE+
+/*
+mid_roster.c
+Minimal persistent group-roster middleware for Tox NGC.
+
+Goal:
+Maintain a stable peer list that can include offline peers.
+This is a best-effort, eventually consistent P2P solution.
+
+Transport:
+Uses only tox_group_send_custom_packet().
+
+Crypto:
+Uses libsodium Ed25519 signatures.
+Each peer signs their own JOIN / LEAVE / presence updates.
+
+KEY MODEL -- VERY IMPORTANT
+
+Tox NGC has multiple keys. This middleware uses three distinct keys:
+
+identity_key
+This is the normal 32-byte Tox NGC group peer public key.
+Tox NGC exposes a 32-byte group identity public key:
+tox_group_self_get_public_key()
+tox_group_peer_get_public_key()
+This key is used as the main roster lookup key.
+It is the persistent peer identity inside the group.
+In typical NGC extended-key layout, this is the Curve25519 encryption
+public key derived from the peer's Ed25519 signing key.
+
+signing_key
+This is the 32-byte Ed25519 public signing key belonging to the same
+NGC group identity.
+For signing/verification we also need Ed25519 keys:
+tox_group_self_get_signing_secret_key()      [patched]
+tox_group_self_get_signing_public_key()      [patched]
+For other peers we need:
+tox_group_peer_get_signing_public_key()      [patched]
+This key is used to verify signatures made by that peer.
+
+self_secret_signing_key
+This is the Ed25519 secret signing key for our own NGC group identity.
+It is obtained from the patched API:
+tox_group_self_get_signing_secret_key()
+This is NOT:
+the long-term Tox one-to-one secret key
+the NGC encryption secret key
+the group shared secret
+It is specifically the Ed25519 signing secret key.
+
+Signed presence records
+A presence record contains:
+status          ACTIVE / LEFT
+timestamp       sender-generated timestamp / logical version
+nickname        optional peer nickname
+identity_key    normal Tox NGC identity public key
+signing_key     Ed25519 public signing key
+The record is signed with the peer's Ed25519 signing secret key.
+The signature is verified with the Ed25519 signing public key.
+The identity_key and signing_key are both included in the signed body so
+that offline peers can be verified later as long as their signing key is
+known.
+
+Key binding:
+This middleware checks that the Ed25519 signing key belongs to the Tox
+NGC identity key.
+In normal NGC extended-key design:
+identity_key == curve25519_from_ed25519(signing_key)
+For compatibility, direct equality is also accepted:
+identity_key == signing_key
+
+Storage:
+No storage backend is implemented.
+Use:
+mid_peer_count()
+mid_signed_count()
+mid_online_count()
+to attach any storage backend later.
+
+Nickname safety:
+Toxcore nicknames are raw uint8_t buffers. They are NOT guaranteed to be
+valid UTF-8, NOT guaranteed to be printable ASCII, and NOT guaranteed to
+be NUL-terminated. They may contain embedded NUL bytes or arbitrary binary.
+This middleware treats all nicknames as opaque byte arrays with an
+explicit length. No C-string functions (strlen, strcmp, strcpy, printf %s)
+are ever used on nickname data. All copies are bounded by explicit lengths
+and destination buffers are zero-filled before use.
+
+Thread-safety model:
+All public API functions acquire a single non-recursive pthread_mutex_t
+(similar to tox_lock/tox_unlock in Toxcore) before touching any internal
+state. Internal "_internal" helper functions assume the lock is ALREADY
+held and must NEVER be called without it. Callbacks are always invoked
+AFTER the lock is released to prevent deadlocks when the client calls
+back into the middleware from within the callback.
+
+IMPORTANT: Internal functions must only call other "_internal" functions,
+never the public (locking) wrappers. This guarantees no deadlock with a
+non-recursive mutex.
+
+Requirements:
+Toxcore NGC
+tox_group_send_custom_packet()
+tox_group_self_get_public_key()
+tox_group_peer_get_public_key()
+tox_group_self_get_signing_secret_key()      [patched]
+tox_group_self_get_signing_public_key()      [patched]
+tox_group_peer_get_signing_public_key()      [patched]
+libsodium
+*/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <sodium.h>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+#ifndef MID_DEBUG_LOGGING
+#define printf(...) ((void)0)
+#define fflush(x)   ((void)0)
+#endif
+
+
+/******************************************************************************
+Tox key-size constants
+******************************************************************************/
+
+#ifndef TOX_GROUP_PEER_PUBLIC_KEY_SIZE
+#define TOX_GROUP_PEER_PUBLIC_KEY_SIZE 32
+#endif
+
+#ifndef TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE
+#define TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE 32
+#endif
+
+#ifndef TOX_GROUP_SIGNING_SECRET_KEY_SIZE
+#define TOX_GROUP_SIGNING_SECRET_KEY_SIZE 64
+#endif
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+/******************************************************************************
+Middleware key-size constants
+******************************************************************************/
+
+static const uint8_t MID_MAGIC[MID_MAGIC_BYTES_TOTAL] = {
+    MID_MAGIC_0,
+    MID_MAGIC_1,
+    MID_MAGIC_2
+};
+
+#define MID_SAVE_MAGIC       "MIDR"
+#define MID_SAVE_MAGIC_SIZE  4
+#define MID_SAVE_VERSION     3
+#define MID_MAX_GROUPS       1000
+
+#define MID_BUF_INIT_CAP 4096
+#define MID_MAX_CHANGED_GROUPS_PER_ITERATE 256
+
+#define MID_SIGNING_SECRET_KEY_SIZE TOX_GROUP_SIGNING_SECRET_KEY_SIZE
+
+#if MID_IDENTITY_KEY_SIZE != 32
+#error "mid_roster.c currently requires TOX_GROUP_PEER_PUBLIC_KEY_SIZE == 32"
+#endif
+
+#if MID_SIGNING_KEY_SIZE != 32
+#error "mid_roster.c currently requires TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE == 32"
+#endif
+
+#if MID_SIGNING_SECRET_KEY_SIZE != 64
+#error "mid_roster.c requires TOX_GROUP_SIGNING_SECRET_KEY_SIZE == 64"
+#endif
+
+#define MID_SIG_SIZE            64
+#define MID_MAX_PACKET_SIZE     1200
+#define MID_ROSTER_COOLDOWN_SEC 30
+/* FIX 4: Increased heartbeat interval from 50s to 300s (5 mins) to save traffic */
+#define MID_HEARTBEAT_SEC       300
+
+#define MID_RECORD_STATUS_SIZE    sizeof(uint8_t)
+#define MID_RECORD_TIMESTAMP_SIZE sizeof(uint64_t)
+#define MID_RECORD_NICKLEN_SIZE   sizeof(uint16_t)
+
+#define MID_RECORD_FIXED_BODY_SIZE (MID_RECORD_STATUS_SIZE + MID_RECORD_TIMESTAMP_SIZE + MID_RECORD_NICKLEN_SIZE)
+
+#define MID_HEARTBEAT_BODY_SIZE (MID_RECORD_STATUS_SIZE + MID_RECORD_TIMESTAMP_SIZE + MID_IDENTITY_KEY_SIZE)
+
+
+/*
+Throttle for the heavy sync/cleanup loop in mid_iterate().
+xx second is fast enough for responsive UI, but slow enough to avoid
+hammering Toxcore on every 50ms tox_iterate() tick.
+*/
+#define MID_SYNC_INTERVAL_SEC   5
+
+
+#define MID_MAX_BODY_SIZE (MID_RECORD_FIXED_BODY_SIZE + MID_MAX_NICK_SIZE + \
+                           MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE)
+
+/*
+Time-To-Live for LEFT tombstones.
+We keep them in the roster for 7 days so that offline peers who come
+back online can sync and receive cryptographic proof of the departure.
+*/
+#define MID_TOMBSTONE_TTL_SEC (7 * 24 * 60 * 60)
+
+/*
+Time-To-Live for "Zombie" peers (offline ACTIVE peers who never sent a LEFT tombstone).
+30 days is safe because Toxcore's network timeout is much shorter, and our 5-minute
+heartbeats guarantee last_seen stays fresh for actually active peers.
+*/
+#define MID_STALE_PEER_TTL_SEC (30 * 24 * 60 * 60)
+
+
+typedef enum {
+    MID_STATUS_ACTIVE = 0,
+    MID_STATUS_LEFT   = 1
+} MidStatus;
+
+typedef enum {
+    MID_MSG_PRESENCE       = 1,
+    MID_MSG_ROSTER_REQUEST = 2,
+    MID_MSG_HEARTBEAT      = 3, /* FIX 3: Lightweight heartbeat message */
+    MID_MSG_ROSTER_BATCH   = 4  /* FIX 5: Batched roster response message */
+} MidMsg;
+
+typedef struct {
+    uint8_t identity_key[MID_IDENTITY_KEY_SIZE];
+    uint8_t signing_key[MID_SIGNING_KEY_SIZE];
+    uint8_t  status;
+    uint64_t timestamp;
+    uint8_t  nickname[MID_MAX_NICK_SIZE];
+    uint16_t nickname_len;
+    uint8_t  signature[MID_SIG_SIZE];
+    bool     has_signature;
+    Tox_Connection connection_status;
+    Tox_Group_Role role;
+    uint64_t last_seen;
+} MidPeerRecord;
+
+typedef struct {
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    uint8_t self_identity_key[MID_IDENTITY_KEY_SIZE];
+    uint8_t self_signing_key[MID_SIGNING_KEY_SIZE];
+    uint8_t self_secret_signing_key[MID_SIGNING_SECRET_KEY_SIZE];
+    bool     have_keys;
+    uint8_t  self_nickname[MID_MAX_NICK_SIZE];
+    uint16_t self_nickname_len;
+    bool     self_active;
+    bool     announced;
+    MidPeerRecord *records;
+    size_t         count;
+    size_t         capacity;
+    uint64_t last_announce;
+    uint64_t last_roster_response;
+    uint64_t roster_reply_deadline; /* FIX 2: Multicast suppression timer */
+    uint8_t  roster_fingerprint[MID_IDENTITY_KEY_SIZE]; /* Incremental XOR sum of all signed identity keys */
+} MidGroupState;
+
+/*
+The actual definition of the opaque MidState struct.
+*/
+struct MidState {
+    MidGroupState *groups;
+    size_t         group_count;
+    size_t         group_capacity;
+
+    /*
+     * Peer-list-changed callback.
+     * Called whenever the roster for any group is mutated.
+     */
+    mid_peer_list_changed_cb peer_list_changed_cb;
+    void                    *peer_list_changed_user_data;
+
+    /*
+     * Thread-safety mutex (non-recursive).
+     * Protects all internal state. Modeled after tox->mutex in Toxcore.
+     * All public entry points call mid_lock()/mid_unlock().
+     * Internal "_internal" functions assume the lock is already held.
+     */
+    pthread_mutex_t *mutex;
+
+    /*
+     * Timestamp of the last heavy sync/cleanup pass in mid_iterate().
+     */
+    uint64_t last_sync_time;
+
+    /*
+     * Network statistics (custom packets only).
+     */
+    uint64_t sent_bytes;
+    uint64_t recv_bytes;
+
+    char *save_path;
+};
+
+/******************************************************************************
+Thread-safety helpers
+Modeled after tox_lock()/tox_unlock() in Toxcore.
+The mutex is non-recursive; internal code paths must never re-lock.
+******************************************************************************/
+
+static void mid_lock(MidState *s)
+{
+    if (s != NULL && s->mutex != NULL) {
+        pthread_mutex_lock(s->mutex);
+    }
+}
+
+static void mid_unlock(MidState *s)
+{
+    if (s != NULL && s->mutex != NULL) {
+        pthread_mutex_unlock(s->mutex);
+    }
+}
+
+/******************************************************************************
+Small helper functions
+******************************************************************************/
+
+static uint64_t mid_now_or_time(uint64_t now)
+{
+    if (now != 0) {
+        return now;
+    }
+    return (uint64_t)time(NULL);
+}
+
+static void mid_put_u16_be(uint8_t *p, uint16_t v)
+{
+    p[0] = (uint8_t)(v >> 8);
+    p[1] = (uint8_t)(v & 0xFF);
+}
+
+static void mid_put_u64_be(uint8_t *p, uint64_t v)
+{
+    p[0] = (uint8_t)(v >> 56);
+    p[1] = (uint8_t)(v >> 48);
+    p[2] = (uint8_t)(v >> 40);
+    p[3] = (uint8_t)(v >> 32);
+    p[4] = (uint8_t)(v >> 24);
+    p[5] = (uint8_t)(v >> 16);
+    p[6] = (uint8_t)(v >> 8);
+    p[7] = (uint8_t)(v & 0xFF);
+}
+
+static uint16_t mid_get_u16_be(const uint8_t *p)
+{
+    return (uint16_t)((uint16_t)p[0] << 8 | p[1]);
+}
+
+static uint64_t mid_get_u64_be(const uint8_t *p)
+{
+    uint64_t v = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); i++) {
+        v = (v << 8) | p[i];
+    }
+    return v;
+}
+
+static char *mid_strdup(const char *s) {
+    if (!s) return NULL;
+    size_t len = strlen(s) + 1;
+    char *d = (char *)malloc(len);
+    if (d) memcpy(d, s, len);
+    return d;
+}
+
+static void mid_put_u32_be(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v >> 24); p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);  p[3] = (uint8_t)(v & 0xFF);
+}
+
+static uint32_t mid_get_u32_be(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8)  | ((uint32_t)p[3]);
+}
+
+/* Dynamic Buffer for Serialization */
+typedef struct { uint8_t *data; size_t len; size_t cap; } MidBuf;
+
+static void mid_buf_init(MidBuf *b) { b->data = NULL; b->len = 0; b->cap = 0; }
+
+static void mid_buf_free(MidBuf *b) { free(b->data); b->data = NULL; b->len = 0; b->cap = 0; }
+
+static bool mid_buf_ensure(MidBuf *b, size_t extra) {
+    if (b->len + extra <= b->cap) return true;
+
+    // Prevent overflow in b->len + extra
+    if (extra > SIZE_MAX - b->len) return false;
+    size_t required = b->len + extra;
+
+    size_t new_cap = (b->cap == 0) ? MID_BUF_INIT_CAP : b->cap;
+    while (new_cap < required) {
+        if (new_cap > SIZE_MAX / 2) return false; // Prevent overflow
+        new_cap *= 2;
+    }
+
+    uint8_t *tmp = realloc(b->data, new_cap);
+    if (!tmp) return false;
+    b->data = tmp; b->cap = new_cap; return true;
+}
+
+static void mid_buf_append(MidBuf *b, const void *data, size_t len) {
+    if (len == 0) return;
+    if (mid_buf_ensure(b, len)) { memcpy(b->data + b->len, data, len); b->len += len; }
+}
+
+static void mid_buf_append_u8(MidBuf *b, uint8_t v) { mid_buf_append(b, &v, 1); }
+static void mid_buf_append_u16(MidBuf *b, uint16_t v) { uint8_t tmp[2]; mid_put_u16_be(tmp, v); mid_buf_append(b, tmp, 2); }
+static void mid_buf_append_u32(MidBuf *b, uint32_t v) { uint8_t tmp[4]; mid_put_u32_be(tmp, v); mid_buf_append(b, tmp, 4); }
+static void mid_buf_append_u64(MidBuf *b, uint64_t v) { uint8_t tmp[8]; mid_put_u64_be(tmp, v); mid_buf_append(b, tmp, 8); }
+
+/* Binary Reader for Deserialization */
+typedef struct { const uint8_t *data; size_t len; size_t pos; } MidReader;
+
+static bool mid_reader_has(MidReader *r, size_t need) { return r->pos + need <= r->len; }
+
+static bool mid_reader_read(MidReader *r, void *out, size_t len) {
+    if (!mid_reader_has(r, len)) return false;
+    memcpy(out, r->data + r->pos, len); r->pos += len; return true;
+}
+
+static bool mid_reader_read_u8(MidReader *r, uint8_t *out) { return mid_reader_read(r, out, 1); }
+
+static bool mid_reader_read_u16(MidReader *r, uint16_t *out) {
+    uint8_t tmp[2]; if (!mid_reader_read(r, tmp, 2)) return false;
+    *out = mid_get_u16_be(tmp); return true;
+}
+
+static bool mid_reader_read_u32(MidReader *r, uint32_t *out) {
+    uint8_t tmp[4]; if (!mid_reader_read(r, tmp, 4)) return false;
+    *out = mid_get_u32_be(tmp); return true;
+}
+
+static bool mid_reader_read_u64(MidReader *r, uint64_t *out) {
+    uint8_t tmp[8]; if (!mid_reader_read(r, tmp, 8)) return false;
+    *out = mid_get_u64_be(tmp); return true;
+}
+
+static bool mid_key_is_zero(const uint8_t key[32])
+{
+    for (int i = 0; i < 32; i++) {
+        if (key[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void mid_xor_fingerprint(uint8_t fp[MID_IDENTITY_KEY_SIZE], const uint8_t key[MID_IDENTITY_KEY_SIZE])
+{
+    for (size_t i = 0; i < MID_IDENTITY_KEY_SIZE; i++) {
+        fp[i] ^= key[i];
+    }
+}
+
+static bool mid_same_identity(const uint8_t a[MID_IDENTITY_KEY_SIZE],
+                              const uint8_t b[MID_IDENTITY_KEY_SIZE])
+{
+    return memcmp(a, b, MID_IDENTITY_KEY_SIZE) == 0;
+}
+
+static bool mid_same_signing_key(const uint8_t a[MID_SIGNING_KEY_SIZE],
+                                 const uint8_t b[MID_SIGNING_KEY_SIZE])
+{
+    return memcmp(a, b, MID_SIGNING_KEY_SIZE) == 0;
+}
+
+static bool mid_valid_key_binding(const uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                                  const uint8_t signing_key[MID_SIGNING_KEY_SIZE])
+{
+    if (mid_key_is_zero(identity_key) || mid_key_is_zero(signing_key)) {
+        printf("[MID] valid_key_binding: rejected, zero key\n"); fflush(stdout);
+        return false;
+    }
+
+    uint8_t derived_curve_pk[32];
+    if (crypto_sign_ed25519_pk_to_curve25519(derived_curve_pk, signing_key) != 0) {
+        printf("[MID] valid_key_binding: rejected, curve25519 derivation failed\n"); fflush(stdout);
+        return false;
+    }
+
+    if (mid_same_identity(identity_key, derived_curve_pk)) {
+        printf("[MID] valid_key_binding: accepted, curve25519 derived match\n"); fflush(stdout);
+        return true;
+    }
+
+    printf("[MID] valid_key_binding: rejected, no match\n"); fflush(stdout);
+    return false;
+}
+
+static uint32_t mid_chat_id_to_group_number(const Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (tox == NULL || chat_id == NULL) return UINT32_MAX;
+    Tox_Err_Group_State_Queries err;
+    uint32_t gnum = tox_group_by_chat_id(tox, chat_id, &err);
+    if (err != TOX_ERR_GROUP_STATE_QUERIES_OK) {
+        return UINT32_MAX;
+    }
+    return gnum;
+}
+
+static MidGroupState *mid_find_group(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (s == NULL || chat_id == NULL) return NULL;
+    for (size_t i = 0; i < s->group_count; i++) {
+        if (memcmp(s->groups[i].chat_id, chat_id, TOX_GROUP_CHAT_ID_SIZE) == 0) {
+            return &s->groups[i];
+        }
+    }
+    return NULL;
+}
+
+static const MidGroupState *mid_find_group_const(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    return mid_find_group((MidState *)s, chat_id);
+}
+
+static MidGroupState *mid_add_group(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (s == NULL || chat_id == NULL) return NULL;
+
+    if (s->group_count >= s->group_capacity) {
+        size_t new_cap = (s->group_capacity == 0) ? 4 : s->group_capacity * 2;
+        MidGroupState *tmp = realloc(s->groups, new_cap * sizeof(MidGroupState));
+        if (tmp == NULL) return NULL;
+        s->groups = tmp;
+        s->group_capacity = new_cap;
+    }
+
+    MidGroupState *g = &s->groups[s->group_count++];
+    memset(g, 0, sizeof(*g));
+    memcpy(g->chat_id, chat_id, TOX_GROUP_CHAT_ID_SIZE);
+    return g;
+}
+
+static bool mid_evict_oldest_offline_active(MidGroupState *g)
+{
+    if (g == NULL || g->count == 0) {
+        return false;
+    }
+
+    size_t oldest = g->count;
+    uint64_t oldest_seen = 0;
+
+    for (size_t i = 0; i < g->count; i++) {
+        const MidPeerRecord *r = &g->records[i];
+
+        /* Only ACTIVE peers that are currently offline are evictable. */
+        if (r->status != MID_STATUS_ACTIVE ||
+            r->connection_status != TOX_CONNECTION_NONE) {
+            continue;
+        }
+
+        /* Never evict our own record. */
+        if (!mid_key_is_zero(g->self_identity_key) &&
+            mid_same_identity(r->identity_key, g->self_identity_key)) {
+            continue;
+        }
+
+        /* last_seen == 0 is treated as the oldest possible value. */
+        if (oldest == g->count || r->last_seen < oldest_seen) {
+            oldest = i;
+            oldest_seen = r->last_seen;
+        }
+    }
+
+    if (oldest == g->count) {
+        return false;
+    }
+
+    printf("[MID] evict_peer: evicting oldest offline ACTIVE peer %zu\n", oldest); fflush(stdout);
+
+    if (g->records[oldest].has_signature) {
+        printf("[MID] evict_peer: XOR OUT evicted peer. Old FP[0..3]=%02X%02X%02X%02X\n",
+               g->roster_fingerprint[0],
+               g->roster_fingerprint[1],
+               g->roster_fingerprint[2],
+               g->roster_fingerprint[3]);
+        fflush(stdout);
+
+        mid_xor_fingerprint(g->roster_fingerprint, g->records[oldest].identity_key);
+
+        printf("[MID] evict_peer: New FP[0..3]=%02X%02X%02X%02X\n",
+               g->roster_fingerprint[0],
+               g->roster_fingerprint[1],
+               g->roster_fingerprint[2],
+               g->roster_fingerprint[3]);
+        fflush(stdout);
+    }
+
+    for (size_t k = oldest; k + 1 < g->count; k++) {
+        g->records[k] = g->records[k + 1];
+    }
+
+    g->count--;
+
+    return true;
+}
+
+static bool mid_ensure_capacity(MidGroupState *g)
+{
+    if (g == NULL) {
+        return false;
+    }
+
+    if (g->count >= MID_MAX_PEERS_PER_GROUP) {
+        printf("[MID] ensure_capacity: peer limit %d reached, trying eviction\n", MID_MAX_PEERS_PER_GROUP); fflush(stdout);
+
+        if (!mid_evict_oldest_offline_active(g)) {
+            printf("[MID] ensure_capacity: rejected, peer limit %d reached and no offline ACTIVE peer to evict\n", MID_MAX_PEERS_PER_GROUP); fflush(stdout);
+            return false;
+        }
+
+        if (g->count >= MID_MAX_PEERS_PER_GROUP) {
+            printf("[MID] ensure_capacity: still at peer limit after eviction\n"); fflush(stdout);
+            return false;
+        }
+    }
+
+    if (g->count < g->capacity) {
+        return true;
+    }
+
+    size_t new_capacity = (g->capacity == 0) ? 16 : g->capacity * 2;
+
+    if (new_capacity > MID_MAX_PEERS_PER_GROUP) {
+        new_capacity = MID_MAX_PEERS_PER_GROUP;
+        printf("[MID] ensure_capacity: new_capacity cut to limit\n"); fflush(stdout);
+    }
+
+    printf("[MID] ensure_capacity: reallocating from %zu to %zu\n", g->capacity, new_capacity); fflush(stdout);
+
+    MidPeerRecord *tmp = realloc(g->records, new_capacity * sizeof(MidPeerRecord));
+    if (tmp == NULL) {
+        printf("[MID] ensure_capacity: realloc failed\n"); fflush(stdout);
+        return false;
+    }
+
+    g->records = tmp;
+    g->capacity = new_capacity;
+    return true;
+}
+
+static int mid_find_identity(const MidGroupState *g,
+                             const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    for (size_t i = 0; i < g->count; i++) {
+        if (mid_same_identity(g->records[i].identity_key, identity_key)) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+/******************************************************************************
+Record serialization and crypto
+******************************************************************************/
+
+static bool mid_pack_record_body(uint8_t *buf,
+                                 size_t cap,
+                                 const MidPeerRecord *r,
+                                 size_t *out_len)
+{
+    if (r->nickname_len > MID_MAX_NICK_SIZE) {
+        return false;
+    }
+
+    if (mid_key_is_zero(r->identity_key)) {
+        return false;
+    }
+
+    size_t need = MID_RECORD_FIXED_BODY_SIZE + r->nickname_len + MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE;
+
+    if (need > cap) {
+        printf("[MID] pack_record_body: rejected, need %zu > cap %zu\n", need, cap); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] pack_record_body: packing %zu bytes\n", need); fflush(stdout);
+
+    size_t o = 0;
+    buf[o++] = r->status;
+    mid_put_u64_be(buf + o, r->timestamp);
+    o += 8;
+    mid_put_u16_be(buf + o, r->nickname_len);
+    o += 2;
+    if (r->nickname_len > 0) {
+        memcpy(buf + o, r->nickname, r->nickname_len);
+        o += r->nickname_len;
+    }
+    memcpy(buf + o, r->identity_key, MID_IDENTITY_KEY_SIZE);
+    o += MID_IDENTITY_KEY_SIZE;
+    memcpy(buf + o, r->signing_key, MID_SIGNING_KEY_SIZE);
+    o += MID_SIGNING_KEY_SIZE;
+
+    if (out_len != NULL) {
+        *out_len = o;
+    }
+    return true;
+}
+
+static bool mid_unpack_record_body(MidPeerRecord *r,
+                                   const uint8_t *buf,
+                                   size_t len)
+{
+    memset(r, 0, sizeof(*r));
+
+    size_t o = 0;
+    size_t min_len = MID_RECORD_FIXED_BODY_SIZE + MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE;
+
+    if (len < min_len) {
+        printf("[MID] unpack_record_body: rejected, len %zu < min_len %zu\n", len, min_len); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] unpack_record_body: unpacking %zu bytes\n", len); fflush(stdout);
+
+    r->status = buf[o++];
+    if (r->status != MID_STATUS_ACTIVE && r->status != MID_STATUS_LEFT) {
+        return false;
+    }
+
+    r->timestamp = mid_get_u64_be(buf + o);
+    o += 8;
+
+    r->nickname_len = mid_get_u16_be(buf + o);
+    o += 2;
+
+    if (r->nickname_len > MID_MAX_NICK_SIZE) {
+        return false;
+    }
+
+    if (o + r->nickname_len + MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE > len) {
+        return false;
+    }
+
+    if (r->nickname_len > 0) {
+        memcpy(r->nickname, buf + o, r->nickname_len);
+        o += r->nickname_len;
+    }
+
+    memcpy(r->identity_key, buf + o, MID_IDENTITY_KEY_SIZE);
+    o += MID_IDENTITY_KEY_SIZE;
+
+    memcpy(r->signing_key, buf + o, MID_SIGNING_KEY_SIZE);
+    o += MID_SIGNING_KEY_SIZE;
+
+    if (mid_key_is_zero(r->identity_key)) {
+        return false;
+    }
+
+    r->has_signature = false;
+    r->connection_status = TOX_CONNECTION_NONE;
+    r->role = TOX_GROUP_ROLE_USER;
+    r->last_seen = 0;
+    return true;
+}
+
+static bool mid_verify_record(const MidPeerRecord *r)
+{
+    if (!r->has_signature) {
+        printf("[MID] verify_record: rejected, no signature\n"); fflush(stdout);
+        return false;
+    }
+
+    if (!mid_valid_key_binding(r->identity_key, r->signing_key)) {
+        printf("[MID] verify_record: rejected, invalid key binding\n"); fflush(stdout);
+        return false;
+    }
+
+    uint8_t body[MID_MAX_BODY_SIZE];
+    size_t body_len = 0;
+    if (!mid_pack_record_body(body, sizeof(body), r, &body_len)) {
+        return false;
+    }
+
+    int res = crypto_sign_verify_detached(r->signature,
+                                          body,
+                                          body_len,
+                                          r->signing_key);
+
+    if (res == 0) {
+        printf("[MID] verify_record: signature VALID\n"); fflush(stdout);
+        return true;
+    } else {
+        printf("[MID] verify_record: signature INVALID\n"); fflush(stdout);
+        return false;
+    }
+}
+
+static bool mid_sign_record(MidGroupState *g, MidPeerRecord *r)
+{
+    if (!g->have_keys) {
+        printf("[MID] sign_record: failed, no keys\n"); fflush(stdout);
+        return false;
+    }
+
+    uint8_t body[MID_MAX_BODY_SIZE];
+    size_t body_len = 0;
+    if (!mid_pack_record_body(body, sizeof(body), r, &body_len)) {
+        return false;
+    }
+
+    unsigned long long sig_len = 0;
+    if (crypto_sign_detached(r->signature,
+                             &sig_len,
+                             body,
+                             body_len,
+                             g->self_secret_signing_key) != 0) {
+        printf("[MID] sign_record: crypto_sign_detached failed\n"); fflush(stdout);
+        return false;
+    }
+
+    if (sig_len != MID_SIG_SIZE) {
+        printf("[MID] sign_record: unexpected sig_len %llu\n", sig_len); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] sign_record: successfully signed %zu bytes\n", body_len); fflush(stdout);
+    r->has_signature = true;
+    return true;
+}
+
+/******************************************************************************
+Roster record upsert
+Returns true if the roster was actually modified (inserted or updated).
+
+This version maintains g->roster_fingerprint by XORing the 32-byte 
+identity_key of every peer that has a valid signature. 
+
+This means the fingerprint tracks the SET of signed peers. It changes when:
+  - a signed peer is added
+  - a signed peer is removed
+  - an unsigned peer becomes signed
+  
+It does NOT change when a signed peer updates their nickname or timestamp.
+******************************************************************************/
+
+static bool mid_upsert_record(MidGroupState *g, const MidPeerRecord *in)
+{
+    printf("[MID] upsert_record: processing record\n");
+    fflush(stdout);
+
+    if (g == NULL || in == NULL) {
+        return false;
+    }
+
+    MidPeerRecord tmp = *in;
+
+    if (mid_key_is_zero(tmp.identity_key)) {
+        printf("[MID] upsert_record: rejected, zero identity key\n");
+        fflush(stdout);
+        return false;
+    }
+
+    if (tmp.status != MID_STATUS_ACTIVE && tmp.status != MID_STATUS_LEFT) {
+        printf("[MID] upsert_record: rejected, invalid status\n");
+        fflush(stdout);
+        return false;
+    }
+
+    if (tmp.nickname_len > MID_MAX_NICK_SIZE) {
+        printf("[MID] upsert_record: rejected, nickname too long\n");
+        fflush(stdout);
+        return false;
+    }
+
+    /*
+     * Unsigned records do not carry a valid persistent signature.
+     * Zero the signature field so it cannot accidentally influence later logic.
+     */
+    if (!tmp.has_signature) {
+        memset(tmp.signature, 0, sizeof(tmp.signature));
+    }
+
+    /*
+     * Verify signed records before touching any state.
+     */
+    if (tmp.has_signature && !mid_verify_record(&tmp)) {
+        printf("[MID] upsert_record: rejected, signature verification failed\n");
+        fflush(stdout);
+        return false;
+    }
+
+    /**************************************************************************
+     * SIGNED LEFT TOMBSTONE PATH
+     *
+     * Signed LEFT tombstones are authoritative departure records.
+     * They must be stored and forwarded so offline peers can later learn
+     * cryptographically that this identity left.
+     *************************************************************************/
+    if (tmp.has_signature && tmp.status == MID_STATUS_LEFT) {
+        int idx = mid_find_identity(g, tmp.identity_key);
+
+        if (idx >= 0) {
+            MidPeerRecord *ex = &g->records[idx];
+
+            /*
+             * If we already have a signed record for this identity, the
+             * signing key may not change.
+             */
+            if (ex->has_signature &&
+                tmp.has_signature &&
+                !mid_same_signing_key(ex->signing_key, tmp.signing_key)) {
+                printf("[MID] upsert_record: rejected LEFT tombstone, signing key changed\n");
+                fflush(stdout);
+                return false;
+            }
+
+            /*
+             * For tombstones we use >= so that a LEFT tombstone with the
+             * same timestamp as the last ACTIVE record still wins.
+             */
+            if (tmp.timestamp >= ex->timestamp) {
+                bool same_signature =
+                    ex->has_signature &&
+                    tmp.has_signature &&
+                    memcmp(ex->signature, tmp.signature, MID_SIG_SIZE) == 0;
+
+                /*
+                 * If we already have this exact tombstone and it is already
+                 * marked offline, there is nothing to do.
+                 */
+                if (same_signature && ex->connection_status == TOX_CONNECTION_NONE) {
+                    printf("[MID] upsert_record: identical LEFT tombstone already stored\n");
+                    fflush(stdout);
+                    return false;
+                }
+
+                /* 
+                 * Track if this peer is transitioning from unsigned to signed.
+                 * If they were already signed, they are already in the fingerprint set.
+                 */
+                bool gained_signature = !ex->has_signature && tmp.has_signature;
+
+                *ex = tmp;
+                ex->connection_status = TOX_CONNECTION_NONE;
+
+                if (gained_signature) {
+                    printf("[MID] upsert_record: XOR IN tombstone transition. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                    mid_xor_fingerprint(g->roster_fingerprint, ex->identity_key);
+                    printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                }
+
+                printf("[MID] upsert_record: stored signed LEFT tombstone\n");
+                fflush(stdout);
+
+                return true; /* CHANGED */
+            }
+
+            /*
+             * Older tombstone than our current record. Ignore.
+             */
+            return false;
+        }
+
+        /* Insert new tombstone for unknown peer */
+        if (!mid_ensure_capacity(g)) {
+            printf("[MID] upsert_record: failed to ensure capacity for tombstone\n");
+            fflush(stdout);
+            return false;
+        }
+
+        g->records[g->count] = tmp;
+        g->records[g->count].connection_status = TOX_CONNECTION_NONE;
+
+        if (g->records[g->count].has_signature) {
+            printf("[MID] upsert_record: XOR IN new tombstone. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, g->records[g->count].identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        }
+
+        g->count++;
+
+        printf("[MID] upsert_record: inserted new signed LEFT tombstone\n");
+        fflush(stdout);
+
+        return true; /* CHANGED */
+    }
+
+    /**************************************************************************
+     * NORMAL ACTIVE / UNSIGNED / SIGNED PATH
+     *************************************************************************/
+
+    int idx = mid_find_identity(g, tmp.identity_key);
+
+    if (idx < 0) {
+        if (!mid_ensure_capacity(g)) {
+            printf("[MID] upsert_record: failed to ensure capacity\n");
+            fflush(stdout);
+            return false;
+        }
+
+        g->records[g->count] = tmp;
+
+        if (g->records[g->count].status == MID_STATUS_LEFT) {
+            g->records[g->count].connection_status = TOX_CONNECTION_NONE;
+        }
+
+        if (g->records[g->count].has_signature) {
+            printf("[MID] upsert_record: XOR IN new peer. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, g->records[g->count].identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        }
+
+        g->count++;
+
+        printf("[MID] upsert_record: inserted new peer (count=%zu)\n", g->count);
+        fflush(stdout);
+
+        return true; /* CHANGED */
+    }
+
+    MidPeerRecord *existing = &g->records[idx];
+
+    /*
+     * If we already have a signed record for this identity, the signing key
+     * is immutable. Reject records signed by a different key.
+     */
+    if (existing->has_signature &&
+        tmp.has_signature &&
+        !mid_same_signing_key(existing->signing_key, tmp.signing_key)) {
+        printf("[MID] upsert_record: rejected, signing key changed for same identity\n");
+        fflush(stdout);
+        return false;
+    }
+
+    bool replace = false;
+
+    if (tmp.has_signature) {
+        /*
+         * Signed records always replace unsigned records.
+         * Signed records replace older signed records only if the timestamp
+         * is strictly newer.
+         */
+        if (!existing->has_signature || tmp.timestamp > existing->timestamp) {
+            replace = true;
+        }
+    } else {
+        /*
+         * Unsigned records only replace other unsigned records.
+         * They never replace signed records.
+         */
+        if (!existing->has_signature && tmp.timestamp >= existing->timestamp) {
+            replace = true;
+        }
+    }
+
+    bool changed = false;
+
+    if (replace) {
+        printf("[MID] upsert_record: replacing existing record\n");
+        fflush(stdout);
+
+        bool old_had_signature = existing->has_signature;
+        bool new_has_signature = tmp.has_signature;
+
+        Tox_Connection old_conn = existing->connection_status;
+        Tox_Group_Role old_role = existing->role;
+        uint64_t old_last_seen = existing->last_seen;
+
+        /*
+         * If the incoming record does not know the signing key but we already
+         * have it, preserve it. This only matters for unsigned records.
+         */
+        if (mid_key_is_zero(tmp.signing_key) &&
+            !mid_key_is_zero(existing->signing_key)) {
+            memcpy(tmp.signing_key, existing->signing_key, MID_SIGNING_KEY_SIZE);
+        }
+
+        /*
+         * If the incoming signed ACTIVE record has no local connection state,
+         * preserve our previous observation.
+         */
+        if (tmp.status == MID_STATUS_ACTIVE &&
+            tmp.connection_status == TOX_CONNECTION_NONE &&
+            old_conn != TOX_CONNECTION_NONE) {
+            tmp.connection_status = old_conn;
+        }
+
+        /*
+         * LEFT records are never online.
+         */
+        if (tmp.status == MID_STATUS_LEFT) {
+            tmp.connection_status = TOX_CONNECTION_NONE;
+        }
+
+        /*
+         * Role is a local observation. Preserve it unless the caller updates
+         * it through moderation / sync logic.
+         */
+        tmp.role = old_role;
+
+        /*
+         * Preserve the newest last_seen value.
+         */
+        if (old_last_seen > tmp.last_seen) {
+            tmp.last_seen = old_last_seen;
+        }
+
+        *existing = tmp;
+
+        /*
+         * Update fingerprint ONLY if the peer's signature status changed.
+         * If they were signed before, and are signed now, they are already 
+         * in the XOR set, so we do nothing.
+         */
+        if (!old_had_signature && new_has_signature) {
+            printf("[MID] upsert_record: XOR IN peer transition to signed. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, existing->identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        } else if (old_had_signature && !new_has_signature) {
+            printf("[MID] upsert_record: XOR OUT peer transition to unsigned. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, existing->identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        }
+
+        changed = true;
+    } else {
+        printf("[MID] upsert_record: keeping existing record\n");
+        fflush(stdout);
+    }
+
+    /**************************************************************************
+     * LOCAL ONLINE STATE UPDATE
+     *
+     * This updates connection_status / last_seen only.
+     * It never modifies signed fields.
+     *
+     * Important:
+     * Do not allow connection updates to resurrect a LEFT tombstone.
+     *************************************************************************/
+    if (in->connection_status != TOX_CONNECTION_NONE &&
+        in->status == MID_STATUS_ACTIVE &&
+        existing->status == MID_STATUS_ACTIVE) {
+
+        if (existing->connection_status != in->connection_status) {
+            existing->connection_status = in->connection_status;
+            changed = true;
+        }
+
+        if (in->last_seen >= existing->last_seen) {
+            if (in->last_seen > existing->last_seen) {
+                existing->last_seen = in->last_seen;
+
+                /*
+                 * If you do not want last_seen-only changes to trigger the
+                 * peer-list-changed callback, remove the next line.
+                 */
+                changed = true;
+            }
+        }
+    }
+
+    return changed;
+}
+
+/******************************************************************************
+Packet sending
+******************************************************************************/
+
+static bool mid_send_custom(MidState *s,
+                            const Tox *tox,
+                            const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                            bool lossless,
+                            const uint8_t *data,
+                            size_t length)
+{
+    printf("[MID] send_custom: sending %zu bytes (lossless=%d)\n", length, lossless); fflush(stdout);
+
+    if (tox == NULL || data == NULL || length == 0) {
+        return false;
+    }
+
+    if (length > MID_MAX_PACKET_SIZE) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) {
+        printf("[MID] send_custom: failed to resolve chat_id to group_number\n"); fflush(stdout);
+        return false;
+    }
+
+    Tox_Err_Group_Send_Custom_Packet err;
+    bool ok = tox_group_send_custom_packet(tox,
+                                           group_number,
+                                           lossless,
+                                           data,
+                                           length,
+                                           &err);
+
+    printf("[MID] send_custom:err=%d ok=%d group_number=%d\n", (int)err, (int)ok, (int)group_number); fflush(stdout);
+
+    if (!ok) {
+        printf("[MID] send_custom: tox_group_send_custom_packet failed (err=%d)\n", err); fflush(stdout);
+    } else {
+        if (s != NULL) {
+            s->sent_bytes += length;
+        }
+    }
+    return ok;
+}
+
+static bool mid_send_presence_record(MidState *s,
+                                     MidGroupState *g,
+                                     const Tox *tox,
+                                     const MidPeerRecord *r)
+{
+    if (g == NULL || tox == NULL || r == NULL) {
+        return false;
+    }
+
+    if (!r->has_signature) {
+        return false;
+    }
+
+    uint8_t body[MID_MAX_BODY_SIZE];
+    size_t body_len = 0;
+    if (!mid_pack_record_body(body, sizeof(body), r, &body_len)) {
+        return false;
+    }
+
+    size_t packet_len = MID_HEADER_SIZE + MID_SIG_SIZE + body_len;
+    if (packet_len > MID_MAX_PACKET_SIZE) {
+        return false;
+    }
+
+    uint8_t packet[MID_MAX_PACKET_SIZE];
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_PRESENCE;
+
+    size_t o = MID_HEADER_SIZE;
+    memcpy(packet + o, r->signature, MID_SIG_SIZE);
+    o += MID_SIG_SIZE;
+    memcpy(packet + o, body, body_len);
+    o += body_len;
+
+    return mid_send_custom(s, tox, g->chat_id, true, packet, o);
+}
+
+/* FIX 3: Lightweight Heartbeat Sending */
+static bool mid_send_heartbeat_record(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    if (!g || !tox || !g->have_keys) return false;
+
+    uint8_t body[MID_HEARTBEAT_BODY_SIZE];
+    size_t o = 0;
+    body[o++] = MID_STATUS_ACTIVE;
+    mid_put_u64_be(body + o, mid_now_or_time(0));
+    o += 8;
+    memcpy(body + o, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+    o += MID_IDENTITY_KEY_SIZE;
+
+    uint8_t sig[MID_SIG_SIZE];
+    unsigned long long sig_len = 0;
+    if (crypto_sign_detached(sig, &sig_len, body, o, g->self_secret_signing_key) != 0) return false;
+
+    uint8_t packet[128];
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_HEARTBEAT;
+
+    memcpy(packet + MID_HEADER_SIZE, sig, MID_SIG_SIZE);
+    memcpy(packet + MID_HEADER_SIZE + MID_SIG_SIZE, body, o);
+
+    return mid_send_custom(s, tox, g->chat_id, true, packet, MID_HEADER_SIZE + MID_SIG_SIZE + o);
+}
+
+static bool mid_send_roster_request_group(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    printf("[MID] send_roster_request: sending request\n"); fflush(stdout);
+
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    uint8_t packet[MID_HEADER_SIZE];
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_ROSTER_REQUEST;
+
+    return mid_send_custom(s, tox, g->chat_id, true, packet, sizeof(packet));
+}
+
+static bool mid_send_roster_group(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    printf("[MID] send_roster: syncing %zu records\n", g->count); fflush(stdout);
+    if (g == NULL || tox == NULL) return false;
+
+    printf("[MID] send_roster: Injecting FP[0..3]=%02X%02X%02X%02X into batch header\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+
+    uint8_t packet[MID_MAX_PACKET_SIZE];
+    size_t p_idx = 0;
+    
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_ROSTER_BATCH;
+    p_idx = MID_HEADER_SIZE;
+    
+    // Define sizes dynamically based on actual types/arrays
+    const size_t fp_size = sizeof(g->roster_fingerprint);
+    const size_t count_size = sizeof(uint16_t);
+    
+    // Inject Set Fingerprint
+    memcpy(packet + p_idx, g->roster_fingerprint, fp_size);
+    p_idx += fp_size;
+    
+    size_t count_idx = p_idx;
+    p_idx += count_size;
+    uint16_t count = 0;
+    bool ok = true;
+    
+    // Header + Fingerprint + Count
+    size_t batch_header_size = MID_HEADER_SIZE + fp_size + count_size;
+
+    for (size_t i = 0; i < g->count; i++) {
+        if (!g->records[i].has_signature) continue;
+        
+        uint8_t body[MID_MAX_BODY_SIZE];
+        size_t body_len = 0;
+        if (!mid_pack_record_body(body, sizeof(body), &g->records[i], &body_len)) continue;
+        
+        // Signature + body_len prefix + body
+        size_t needed = MID_SIG_SIZE + count_size + body_len;
+
+        if (p_idx + needed > MID_MAX_PACKET_SIZE) {
+            mid_put_u16_be(packet + count_idx, count);
+            if (!mid_send_custom(s, tox, g->chat_id, true, packet, p_idx)) ok = false;
+            
+            p_idx = batch_header_size; 
+            printf("[MID] send_roster: Re-injecting FP[0..3]=%02X%02X%02X%02X into next batch packet\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            
+            // Re-inject full header for next packet
+            memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+            packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+            packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_ROSTER_BATCH;
+            memcpy(packet + MID_HEADER_SIZE, g->roster_fingerprint, fp_size);
+            
+            count_idx = MID_HEADER_SIZE + fp_size;
+            count = 0;
+        }
+        
+        memcpy(packet + p_idx, g->records[i].signature, MID_SIG_SIZE);
+        p_idx += MID_SIG_SIZE;
+        mid_put_u16_be(packet + p_idx, (uint16_t)body_len);
+        p_idx += count_size;
+        memcpy(packet + p_idx, body, body_len);
+        p_idx += body_len;
+        count++;
+    }
+    
+    if (count > 0) {
+        mid_put_u16_be(packet + count_idx, count);
+        if (!mid_send_custom(s, tox, g->chat_id, true, packet, p_idx)) ok = false;
+    }
+    
+    return ok;
+}
+
+/******************************************************************************
+Online state sync
+Returns true if any peer's online status changed.
+******************************************************************************/
+
+/*
+Stamps the FOUNDER role on the roster entry whose identity_key matches
+the group founder's public key obtained from Toxcore's shared state.
+
+This works regardless of whether the founder is currently online, because
+the founder key is part of the group's cryptographic shared state, not
+the live peer list.
+*/
+static void mid_apply_founder_role(MidGroupState *g, const Tox *tox)
+{
+    if (g == NULL || tox == NULL) {
+        return;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) {
+        return;
+    }
+
+    uint8_t founder_identity[MID_IDENTITY_KEY_SIZE];
+    Tox_Err_Group_State_Queries err;
+
+    if (!tox_group_get_founder_public_key(tox, group_number, founder_identity, &err)) {
+        return;
+    }
+
+    if (mid_key_is_zero(founder_identity)) {
+        return;
+    }
+
+    int idx = mid_find_identity(g, founder_identity);
+    if (idx < 0) {
+        return;
+    }
+
+    if (g->records[idx].role != TOX_GROUP_ROLE_FOUNDER) {
+        printf("[MID] apply_founder_role: stamping FOUNDER role on peer %zu\n", (size_t)idx);
+        fflush(stdout);
+        g->records[idx].role = TOX_GROUP_ROLE_FOUNDER;
+    }
+}
+
+static bool mid_sync_online_state_group(MidGroupState *g, const Tox *tox, uint64_t now)
+{
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    now = mid_now_or_time(now);
+    bool changed = false;
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    /* Ensure the founder role is always correctly stamped */
+    Tox_Group_Role old_founder_role = TOX_GROUP_ROLE_USER;
+    int founder_idx = -1;
+    uint8_t founder_identity[MID_IDENTITY_KEY_SIZE];
+    Tox_Err_Group_State_Queries founder_err;
+
+    if (tox_group_get_founder_public_key(tox, group_number, founder_identity, &founder_err)) {
+        founder_idx = mid_find_identity(g, founder_identity);
+        if (founder_idx >= 0) {
+            old_founder_role = g->records[founder_idx].role;
+        }
+    }
+
+    mid_apply_founder_role(g, tox);
+
+    if (founder_idx >= 0 && g->records[founder_idx].role != old_founder_role) {
+        changed = true;
+    }
+
+    for (size_t i = 0; i < g->count; i++) {
+        MidPeerRecord *e = &g->records[i];
+        if (e->connection_status == TOX_CONNECTION_NONE) {
+            continue;
+        }
+
+        Tox_Err_Group_Peer_Query err;
+        uint32_t peer_id = tox_group_peer_by_public_key(tox, group_number, e->identity_key, &err);
+
+        if (err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+            printf("[MID] sync_online_state: peer %zu is no longer in Toxcore, marking offline\n", i); fflush(stdout);
+            if (e->connection_status != TOX_CONNECTION_NONE) {
+                e->connection_status = TOX_CONNECTION_NONE;
+                changed = true;
+            }
+            if (now >= e->last_seen) {
+                e->last_seen = now;
+            }
+        } else {
+            Tox_Err_Group_Peer_Query conn_err;
+            Tox_Connection conn = tox_group_peer_get_connection_status(tox, group_number, peer_id, &conn_err);
+            if (conn_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                if (e->connection_status != conn) {
+                    e->connection_status = conn;
+                    changed = true;
+                }
+                if (conn != TOX_CONNECTION_NONE && now >= e->last_seen) {
+                    e->last_seen = now;
+                }
+            }
+
+            Tox_Err_Group_Peer_Query role_err;
+            Tox_Group_Role role = tox_group_peer_get_role(tox, group_number, peer_id, &role_err);
+            if (role_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                if (e->role != role) {
+                    e->role = role;
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    return changed;
+}
+
+/******************************************************************************
+Key setup
+******************************************************************************/
+
+static bool mid_set_self_keys(MidGroupState *g,
+                              const uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                              const uint8_t signing_key[MID_SIGNING_KEY_SIZE],
+                              const uint8_t secret_key[MID_SIGNING_SECRET_KEY_SIZE])
+{
+    printf("[MID] set_self_keys: setting keys\n"); fflush(stdout);
+
+    if (g == NULL ||
+        identity_key == NULL ||
+        signing_key == NULL ||
+        secret_key == NULL) {
+        return false;
+    }
+
+    if (mid_key_is_zero(identity_key) || mid_key_is_zero(signing_key)) {
+        return false;
+    }
+
+    uint8_t derived_signing_key[MID_SIGNING_KEY_SIZE];
+    if (crypto_sign_ed25519_sk_to_pk(derived_signing_key, secret_key) != 0) {
+        printf("[MID] set_self_keys: sk_to_pk failed\n"); fflush(stdout);
+        return false;
+    }
+
+    if (!mid_same_signing_key(derived_signing_key, signing_key)) {
+        printf("[MID] set_self_keys: derived signing key mismatch\n"); fflush(stdout);
+        return false;
+    }
+
+    if (!mid_valid_key_binding(identity_key, signing_key)) {
+        printf("[MID] set_self_keys: invalid key binding\n"); fflush(stdout);
+        return false;
+    }
+
+    memcpy(g->self_identity_key, identity_key, MID_IDENTITY_KEY_SIZE);
+    memcpy(g->self_signing_key, signing_key, MID_SIGNING_KEY_SIZE);
+    memcpy(g->self_secret_signing_key, secret_key, MID_SIGNING_SECRET_KEY_SIZE);
+    g->have_keys = true;
+
+    printf("[MID] set_self_keys: keys set successfully\n"); fflush(stdout);
+    return true;
+}
+
+static bool mid_init_self_from_tox(MidGroupState *g, const Tox *tox)
+{
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    if (g->have_keys) {
+        return true;
+    }
+
+    printf("[MID] init_self_from_tox: fetching keys from Toxcore\n"); fflush(stdout);
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) {
+        return false;
+    }
+
+    uint8_t identity[MID_IDENTITY_KEY_SIZE];
+    uint8_t signing[MID_SIGNING_KEY_SIZE];
+    uint8_t sk[MID_SIGNING_SECRET_KEY_SIZE];
+
+    Tox_Err_Group_Self_Query err;
+
+    if (!tox_group_self_get_public_key(tox, group_number, identity, &err)) {
+        printf("[MID] init_self_from_tox: get_public_key failed\n"); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] init_self_from_tox: got identity key\n");
+    fflush(stdout);
+
+    /*
+     * We now have the current Toxcore identity in the local variable
+     * "identity".
+     *
+     * g->self_identity_key may contain the public identity that was loaded
+     * from the middleware save file.
+     *
+     * This comparison must happen BEFORE mid_set_self_keys(), because
+     * mid_set_self_keys() will overwrite g->self_identity_key.
+     */
+    if (!mid_key_is_zero(g->self_identity_key) &&
+        !mid_same_identity(identity, g->self_identity_key)) {
+
+        printf("[MID] init_self_from_tox: Toxcore identity differs from saved middleware identity\n"); fflush(stdout);
+
+        /*
+         * Choose your policy here.
+         *
+         * Option 1: Strict mode.
+         *
+         * If the saved middleware state must belong to exactly the same
+         * identity that Toxcore currently has, fail here.
+         *
+         * return false;
+         *
+         *
+         * Option 2: Adopt the current Toxcore identity.
+         *
+         * Toxcore is the authority for the current group identity.
+         * Continue and let mid_set_self_keys() install the keys reported
+         * by Toxcore.
+         *
+         * This is usually the more robust choice.
+         */
+    }
+
+    if (!tox_group_self_get_signing_public_key(tox, group_number, signing, &err)) {
+        printf("[MID] init_self_from_tox: get_signing_public_key failed\n"); fflush(stdout);
+        return false;
+    }
+    printf("[MID] init_self_from_tox: got signing public key\n"); fflush(stdout);
+
+    if (!tox_group_self_get_signing_secret_key(tox, group_number, sk, &err)) {
+        printf("[MID] init_self_from_tox: get_signing_secret_key failed\n"); fflush(stdout);
+        return false;
+    }
+    printf("[MID] init_self_from_tox: got signing secret key\n"); fflush(stdout);
+
+    bool ok = mid_set_self_keys(g, identity, signing, sk);
+    sodium_memzero(sk, sizeof(sk));
+    return ok;
+}
+
+/******************************************************************************
+Tox peer key helpers
+******************************************************************************/
+
+static bool mid_get_peer_keys(const Tox *tox,
+                              const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                              uint32_t peer_id,
+                              uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                              uint8_t signing_key[MID_SIGNING_KEY_SIZE])
+{
+    printf("[MID] get_peer_keys: fetching keys for peer %u\n", peer_id); fflush(stdout);
+
+    if (tox == NULL || identity_key == NULL || signing_key == NULL) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    Tox_Err_Group_Peer_Query err;
+
+    if (!tox_group_peer_get_public_key(tox, group_number, peer_id,
+                                       identity_key, &err)) {
+        printf("[MID] get_peer_keys: get_public_key failed for peer %u\n", peer_id); fflush(stdout);
+        return false;
+    }
+
+    if (!tox_group_peer_get_signing_public_key(tox, group_number, peer_id,
+                                               signing_key, &err)) {
+        printf("[MID] get_peer_keys: get_signing_public_key failed for peer %u\n", peer_id); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] get_peer_keys: got both keys for peer %u\n", peer_id); fflush(stdout);
+    return mid_valid_key_binding(identity_key, signing_key);
+}
+
+/******************************************************************************
+Internal group operations
+******************************************************************************/
+
+static bool mid_announce_self_group(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    printf("[MID] announce_self: announcing ACTIVE\n"); fflush(stdout);
+
+    if (g == NULL) {
+        return false;
+    }
+
+    if (!g->have_keys) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    MidPeerRecord r;
+    memset(&r, 0, sizeof(r));
+    memcpy(r.identity_key, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+    memcpy(r.signing_key, g->self_signing_key, MID_SIGNING_KEY_SIZE);
+    r.status = MID_STATUS_ACTIVE;
+    r.timestamp = mid_now_or_time(0);
+
+    Tox_Err_Group_Peer_Query conn_err;
+    Tox_Connection conn = tox_group_peer_get_connection_status(tox, group_number, 0, &conn_err);
+    if (conn_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+        r.connection_status = conn;
+    } else {
+        r.connection_status = TOX_CONNECTION_NONE;
+    }
+
+    Tox_Err_Group_Self_Query self_role_err;
+    r.role = tox_group_self_get_role(tox, group_number, &self_role_err);
+    if (self_role_err != TOX_ERR_GROUP_SELF_QUERY_OK) {
+        r.role = TOX_GROUP_ROLE_USER;
+    }
+
+    /*
+     * Copy self nickname into the record.
+     *
+     * self_nickname_len was already bounded to MID_MAX_NICK_SIZE when it was
+     * stored in mid_on_group_self_join, but we add a defensive bounds check
+     * here as well to guard against any corruption.
+     */
+    if (g->self_nickname_len > 0) {
+        uint16_t nick_copy = g->self_nickname_len;
+        if (nick_copy > MID_MAX_NICK_SIZE) {
+            nick_copy = MID_MAX_NICK_SIZE;
+        }
+        memcpy(r.nickname, g->self_nickname, nick_copy);
+        r.nickname_len = nick_copy;
+    }
+
+    if (!mid_sign_record(g, &r)) {
+        return false;
+    }
+
+    r.last_seen = r.timestamp;
+
+    bool changed = mid_upsert_record(g, &r);
+    g->self_active = true;
+    g->last_announce = r.timestamp;
+
+    mid_send_presence_record(s, g, tox, &r);
+    return changed;
+}
+
+static bool mid_on_peer_online_keys(MidGroupState *g,
+                                    const uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                                    const uint8_t signing_key[MID_SIGNING_KEY_SIZE],
+                                    Tox_Connection conn,
+                                    Tox_Group_Role role,
+                                    uint64_t now)
+{
+    printf("[MID] on_peer_online_keys: peer observed online\n"); fflush(stdout);
+
+    if (g == NULL || identity_key == NULL || mid_key_is_zero(identity_key)) {
+        return false;
+    }
+
+    now = mid_now_or_time(now);
+
+    bool have_signing = (signing_key != NULL &&
+                         !mid_key_is_zero(signing_key) &&
+                         mid_valid_key_binding(identity_key, signing_key));
+
+    int idx = mid_find_identity(g, identity_key);
+
+    if (idx < 0) {
+        if (!mid_ensure_capacity(g)) {
+            return false;
+        }
+        MidPeerRecord r;
+        memset(&r, 0, sizeof(r));
+        memcpy(r.identity_key, identity_key, MID_IDENTITY_KEY_SIZE);
+        if (have_signing) {
+            memcpy(r.signing_key, signing_key, MID_SIGNING_KEY_SIZE);
+        }
+        r.status = MID_STATUS_ACTIVE;
+        r.timestamp = now;
+        r.connection_status = conn;
+        r.role = role;
+        r.last_seen = now;
+        g->records[g->count] = r;
+        g->count++;
+        return true; /* CHANGED */
+    }
+
+    MidPeerRecord *e = &g->records[idx];
+    bool changed = false;
+
+    if (e->connection_status != conn) {
+        e->connection_status = conn;
+        changed = true;
+    }
+
+    if (e->role != role) {
+        e->role = role;
+        changed = true;
+    }
+
+    if (conn != TOX_CONNECTION_NONE && now >= e->last_seen) {
+        e->last_seen = now;
+        changed = true;
+    }
+
+    if (!e->has_signature) {
+        e->status = MID_STATUS_ACTIVE;
+        if (now >= e->timestamp) {
+            e->timestamp = now;
+            changed = true;
+        }
+        if (have_signing) {
+            memcpy(e->signing_key, signing_key, MID_SIGNING_KEY_SIZE);
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
+static bool mid_refresh_peer_name_group(MidGroupState *g, const Tox *tox, uint32_t peer_id)
+{
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    uint8_t identity[MID_IDENTITY_KEY_SIZE];
+    Tox_Err_Group_Peer_Query err;
+
+    if (!tox_group_peer_get_public_key(tox, group_number, peer_id, identity, &err)) {
+        return false;
+    }
+
+    int idx = mid_find_identity(g, identity);
+    if (idx < 0) {
+        return false;
+    }
+
+    size_t name_size = tox_group_peer_get_name_size(tox, group_number, peer_id, &err);
+    if (err != TOX_ERR_GROUP_PEER_QUERY_OK || name_size == 0) {
+        return false;
+    }
+
+    /*
+     * SAFETY: tox_group_peer_get_name() writes exactly name_size bytes into
+     * the output buffer. We must NOT truncate name_size before calling it,
+     * because the buffer must be large enough for the full write.
+     *
+     * We heap-allocate a buffer of exactly name_size bytes to guarantee no
+     * overflow even if Toxcore returns a name larger than MID_MAX_NICK_SIZE
+     * (e.g. from a patched or broken Toxcore).
+     */
+    uint8_t *name = (uint8_t *)malloc(name_size);
+    if (name == NULL) {
+        return false;
+    }
+
+    if (!tox_group_peer_get_name(tox, group_number, peer_id, name, &err)) {
+        free(name);
+        return false;
+    }
+
+    MidPeerRecord *e = &g->records[idx];
+    bool changed = false;
+
+    if (!e->has_signature) {
+        size_t copy_len = name_size;
+        if (copy_len > MID_MAX_NICK_SIZE) {
+            copy_len = MID_MAX_NICK_SIZE;
+        }
+
+        /* Only update if the name actually changed */
+        if (e->nickname_len != copy_len || memcmp(e->nickname, name, copy_len) != 0) {
+            /*
+             * Zero-fill the destination first so no stale bytes remain past
+             * the end of the (possibly truncated) nickname.
+             *
+             * The nickname is treated as opaque binary. We do NOT assume
+             * valid UTF-8, printable ASCII, or NUL termination.
+             */
+            memset(e->nickname, 0, MID_MAX_NICK_SIZE);
+            if (copy_len > 0) {
+                memcpy(e->nickname, name, copy_len);
+            }
+            e->nickname_len = (uint16_t)copy_len;
+            changed = true;
+        }
+    }
+
+    free(name);
+    return changed;
+}
+
+static bool mid_on_custom_packet_group(MidState *s,
+                                       MidGroupState *g,
+                                       const Tox *tox,
+                                       uint32_t peer_id,
+                                       const uint8_t *data,
+                                       size_t length,
+                                       uint64_t now)
+{
+    printf("[MID] on_custom_packet: received %zu bytes from peer %u\n",
+           length, peer_id);
+    fflush(stdout);
+
+    if (g == NULL || data == NULL || length < MID_HEADER_SIZE) {
+        return false;
+    }
+
+    if (memcmp(data, MID_MAGIC, MID_MAGIC_BYTES_TOTAL) != 0 ||
+        data[MID_MAGIC_BYTES_TOTAL] != MID_PROTOCOL_VERSION) {
+        return false;
+    }
+
+    uint8_t type = data[MID_MAGIC_BYTES_TOTAL + 1];
+    const uint8_t *payload = data + MID_HEADER_SIZE;
+    size_t payload_len = length - MID_HEADER_SIZE;
+
+    now = mid_now_or_time(now);
+
+    uint8_t sender_identity[MID_IDENTITY_KEY_SIZE];
+    uint8_t sender_signing[MID_SIGNING_KEY_SIZE];
+    bool sender_has_keys = false;
+
+    if (tox != NULL && peer_id != UINT32_MAX) {
+        sender_has_keys = mid_get_peer_keys(tox,
+                                            g->chat_id,
+                                            peer_id,
+                                            sender_identity,
+                                            sender_signing);
+    }
+
+    bool changed = false;
+
+    /**************************************************************************
+     * FULL SIGNED PRESENCE RECORD
+     *
+     * This is a full signed record containing status, timestamp, nickname,
+     * identity key, and signing key.
+     *
+     * It does NOT suppress pending roster responses, because one presence
+     * record does not prove that the sender has the full roster.
+     *************************************************************************/
+    if (type == MID_MSG_PRESENCE) {
+        printf("[MID] on_custom_packet: processing PRESENCE message\n");
+        fflush(stdout);
+
+        if (payload_len < MID_SIG_SIZE) {
+            return false;
+        }
+
+        size_t body_len = payload_len - MID_SIG_SIZE;
+
+        if (body_len > MID_MAX_BODY_SIZE) {
+            return false;
+        }
+
+        MidPeerRecord r;
+        memset(&r, 0, sizeof(r));
+
+        if (!mid_unpack_record_body(&r, payload + MID_SIG_SIZE, body_len)) {
+            return false;
+        }
+
+        memcpy(r.signature, payload, MID_SIG_SIZE);
+        r.has_signature = true;
+
+        if (!mid_verify_record(&r)) {
+            printf("[MID] on_custom_packet: PRESENCE verification failed\n");
+            fflush(stdout);
+            return false;
+        }
+
+        printf("[MID] on_custom_packet: PRESENCE verified, upserting\n");
+        fflush(stdout);
+
+        /* Never process our own signed presence echoed back to us. */
+        if (g->have_keys && mid_same_identity(r.identity_key, g->self_identity_key)) {
+            return false;
+        }
+
+        bool sender_is_subject = false;
+
+        if (sender_has_keys && mid_same_identity(sender_identity, r.identity_key)) {
+            sender_is_subject = true;
+
+            /*
+             * If the packet came directly from the subject, the signing key
+             * observed from Toxcore must match the signing key in the record.
+             */
+            if (!mid_same_signing_key(sender_signing, r.signing_key)) {
+                return false;
+            }
+        }
+
+        if (sender_is_subject && r.status == MID_STATUS_ACTIVE) {
+            Tox_Err_Group_Peer_Query conn_err;
+            Tox_Connection conn = TOX_CONNECTION_NONE;
+
+            uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+            if (group_number != UINT32_MAX && tox != NULL && peer_id != UINT32_MAX) {
+                conn = tox_group_peer_get_connection_status(tox,
+                                                            group_number,
+                                                            peer_id,
+                                                            &conn_err);
+                if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                    conn = TOX_CONNECTION_NONE;
+                }
+            }
+
+            /*
+             * They just sent a packet, so they are online from our point of
+             * view even if Toxcore has not updated the connection state yet.
+             */
+            if (conn == TOX_CONNECTION_NONE) {
+                conn = TOX_CONNECTION_TCP;
+            }
+
+            r.connection_status = conn;
+            r.last_seen = now;
+        } else {
+            /*
+             * Forwarded / relayed presence, or LEFT tombstone.
+             * Do not mark the peer online.
+             */
+            r.connection_status = TOX_CONNECTION_NONE;
+            /* Anchor last_seen so we can purge them if they never come online */
+            if (r.last_seen == 0) r.last_seen = now;
+        }
+
+        if (mid_upsert_record(g, &r)) {
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    /**************************************************************************
+     * LIGHTWEIGHT HEARTBEAT
+     *
+     * Body:
+     *   status       1 byte
+     *   timestamp    8 bytes
+     *   identity_key 32 bytes
+     *
+     * Signature:
+     *   detached Ed25519 signature over the 41-byte body.
+     *
+     * Heartbeats are used only for liveness / connection state.
+     *
+     * IMPORTANT:
+     * A heartbeat must NOT modify fields belonging to a stored full signed
+     * record, otherwise the stored signature would become invalid.
+     * Therefore, if we already have a signed full record, the heartbeat only
+     * updates connection_status, role, and last_seen.
+     *
+     * Heartbeats do NOT suppress roster responses.
+     *************************************************************************/
+    if (type == MID_MSG_HEARTBEAT) {
+        printf("[MID] on_custom_packet: processing HEARTBEAT message\n");
+        fflush(stdout);
+
+        const size_t hb_body_len = MID_HEARTBEAT_BODY_SIZE;
+
+        if (payload_len < MID_SIG_SIZE + hb_body_len) {
+            return false;
+        }
+
+        const uint8_t *sig = payload;
+        const uint8_t *body = payload + MID_SIG_SIZE;
+
+        uint8_t status = body[0];
+
+        if (status != MID_STATUS_ACTIVE && status != MID_STATUS_LEFT) {
+            return false;
+        }
+
+        uint64_t ts = mid_get_u64_be(body + 1);
+
+        uint8_t hb_identity[MID_IDENTITY_KEY_SIZE];
+        memcpy(hb_identity, body + 9, MID_IDENTITY_KEY_SIZE);
+
+        /* Ignore our own heartbeat if it is echoed back. */
+        if (g->have_keys && mid_same_identity(hb_identity, g->self_identity_key)) {
+            return false;
+        }
+
+        int idx = mid_find_identity(g, hb_identity);
+        if (idx < 0) {
+            /*
+             * We do not know this peer yet.
+             * A heartbeat alone is not enough to create a persistent roster
+             * entry; wait for a full signed PRESENCE record.
+             */
+            return false;
+        }
+
+        MidPeerRecord *e = &g->records[idx];
+
+        bool sender_is_subject = false;
+        if (sender_has_keys && mid_same_identity(sender_identity, hb_identity)) {
+            sender_is_subject = true;
+        }
+
+        uint8_t verify_key[MID_SIGNING_KEY_SIZE];
+        bool have_verify_key = false;
+
+        /*
+         * Prefer the signing key already stored in the roster record.
+         */
+        if (!mid_key_is_zero(e->signing_key) &&
+            mid_valid_key_binding(e->identity_key, e->signing_key)) {
+            memcpy(verify_key, e->signing_key, MID_SIGNING_KEY_SIZE);
+            have_verify_key = true;
+        }
+        /*
+         * If we do not have a stored signing key yet, but the packet comes
+         * directly from the subject, use the signing key observed from
+         * Toxcore.
+         */
+        else if (sender_is_subject &&
+                 mid_valid_key_binding(sender_identity, sender_signing)) {
+            memcpy(verify_key, sender_signing, MID_SIGNING_KEY_SIZE);
+            have_verify_key = true;
+        }
+
+        if (!have_verify_key) {
+            return false;
+        }
+
+        if (crypto_sign_verify_detached(sig,
+                                        body,
+                                        hb_body_len,
+                                        verify_key) != 0) {
+            printf("[MID] on_custom_packet: HEARTBEAT signature invalid\n");
+            fflush(stdout);
+            return false;
+        }
+
+        printf("[MID] on_custom_packet: HEARTBEAT signature valid\n");
+        fflush(stdout);
+
+        /*
+         * Heartbeats are intended as ACTIVE keep-alives.
+         * A LEFT state should be propagated by a full signed LEFT tombstone,
+         * not by a lightweight heartbeat.
+         */
+        if (status != MID_STATUS_ACTIVE) {
+            return changed;
+        }
+
+        /*
+         * If we only have an unsigned local observation, it is safe to update
+         * the unsigned logical fields.
+         */
+        if (!e->has_signature) {
+            if (mid_key_is_zero(e->signing_key)) {
+                memcpy(e->signing_key, verify_key, MID_SIGNING_KEY_SIZE);
+                changed = true;
+            }
+
+            if (e->status != MID_STATUS_ACTIVE) {
+                e->status = MID_STATUS_ACTIVE;
+                changed = true;
+            }
+
+            if (ts > e->timestamp) {
+                e->timestamp = ts;
+                changed = true;
+            }
+        } else {
+            /*
+             * If we have a signed LEFT tombstone, do not resurrect the peer
+             * from a heartbeat alone. Require a full signed ACTIVE presence.
+             */
+            if (e->status == MID_STATUS_LEFT) {
+                return changed;
+            }
+        }
+
+        /*
+         * Only the direct sender can be considered online because of this
+         * heartbeat. A relayed heartbeat does not prove current connectivity.
+         */
+        if (sender_is_subject) {
+            uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+            if (group_number == UINT32_MAX) return changed;
+
+            Tox_Err_Group_Peer_Query conn_err;
+            Tox_Connection conn = tox_group_peer_get_connection_status(tox,
+                                                                       group_number,
+                                                                       peer_id,
+                                                                       &conn_err);
+
+            if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                conn = TOX_CONNECTION_NONE;
+            }
+
+            if (conn == TOX_CONNECTION_NONE) {
+                conn = TOX_CONNECTION_TCP;
+            }
+
+            if (e->connection_status != conn) {
+                e->connection_status = conn;
+                changed = true;
+            }
+
+            Tox_Err_Group_Peer_Query role_err;
+            Tox_Group_Role role = tox_group_peer_get_role(tox,
+                                                          group_number,
+                                                          peer_id,
+                                                          &role_err);
+
+            if (role_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                if (e->role != role) {
+                    e->role = role;
+                    changed = true;
+                }
+            }
+
+            if (now >= e->last_seen) {
+                e->last_seen = now;
+                /*
+                 * Intentionally not setting changed=true only for last_seen.
+                 * This avoids excessive peer-list-changed callbacks when only
+                 * the last-seen timestamp moves forward.
+                 */
+            }
+        }
+
+        return changed;
+    }
+
+    /**************************************************************************
+     * BATCHED ROSTER RESPONSE
+     *
+     * Payload layout:
+     *   fingerprint  32 bytes
+     *   count         2 bytes
+     *   records...
+     *
+     * Each record:
+     *   signature    64 bytes
+     *   body_len      2 bytes
+     *   body          body_len bytes
+     *
+     * Suppression rule:
+     *
+     * We cancel our own pending roster response ONLY if the batch is complete
+     * and the sender's roster fingerprint exactly matches ours.
+     *
+     * This prevents:
+     *   - a partial peer list from suppressing a fuller list
+     *   - a different set of the same size from suppressing another set
+     *   - stale state from suppressing newer state if the fingerprint includes
+     *     record signatures / versions
+     *************************************************************************/
+    if (type == MID_MSG_ROSTER_BATCH) {
+        printf("[MID] on_custom_packet: processing ROSTER_BATCH message\n");
+        fflush(stdout);
+
+        /* Minimum: MID_IDENTITY_KEY_SIZE fingerprint + 2-byte record count */
+        if (payload_len < MID_IDENTITY_KEY_SIZE + sizeof(uint16_t)) {
+            return false;
+        }
+
+        uint8_t sender_fp[MID_IDENTITY_KEY_SIZE];
+        memcpy(sender_fp, payload, MID_IDENTITY_KEY_SIZE);
+
+        uint16_t record_count = mid_get_u16_be(payload + MID_IDENTITY_KEY_SIZE);
+        size_t p_idx = MID_IDENTITY_KEY_SIZE + sizeof(uint16_t);
+
+        bool batch_complete = true;
+
+        for (uint16_t i = 0; i < record_count; i++) {
+            if (p_idx + MID_SIG_SIZE + sizeof(uint16_t) > payload_len) {
+                batch_complete = false;
+                break;
+            }
+
+            const uint8_t *sig = payload + p_idx;
+            p_idx += MID_SIG_SIZE;
+
+            uint16_t body_len = mid_get_u16_be(payload + p_idx);
+            p_idx += sizeof(uint16_t);
+
+            if (p_idx + body_len > payload_len) {
+                batch_complete = false;
+                break;
+            }
+
+            /*
+             * Defensive limit. The current protocol body cannot exceed
+             * MID_MAX_BODY_SIZE.
+             */
+            if (body_len > MID_MAX_BODY_SIZE) {
+                p_idx += body_len;
+                continue;
+            }
+
+            MidPeerRecord r;
+            memset(&r, 0, sizeof(r));
+
+            if (mid_unpack_record_body(&r, payload + p_idx, body_len)) {
+                memcpy(r.signature, sig, MID_SIG_SIZE);
+                r.has_signature = true;
+
+                if (mid_verify_record(&r)) {
+                    /* Ignore our own record if it is echoed back. */
+                    if (!(g->have_keys &&
+                          mid_same_identity(r.identity_key, g->self_identity_key))) {
+
+                        bool sender_is_subject = false;
+
+                        if (sender_has_keys &&
+                            mid_same_identity(sender_identity, r.identity_key)) {
+                            sender_is_subject = true;
+                        }
+
+                        /*
+                         * If the packet sender claims to be the subject, their
+                         * Toxcore-observed signing key must match the record.
+                         */
+                        if (sender_is_subject &&
+                            !mid_same_signing_key(sender_signing, r.signing_key)) {
+                            sender_is_subject = false;
+                        }
+
+                        if (sender_is_subject && r.status == MID_STATUS_ACTIVE) {
+                            uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+                            Tox_Connection conn = TOX_CONNECTION_NONE;
+                            Tox_Group_Role role = TOX_GROUP_ROLE_USER;
+
+                            if (group_number != UINT32_MAX && tox != NULL && peer_id != UINT32_MAX) {
+                                Tox_Err_Group_Peer_Query conn_err;
+                                conn = tox_group_peer_get_connection_status(tox,
+                                                                            group_number,
+                                                                            peer_id,
+                                                                            &conn_err);
+
+                                if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                                    conn = TOX_CONNECTION_NONE;
+                                }
+
+                                if (conn == TOX_CONNECTION_NONE) {
+                                    conn = TOX_CONNECTION_TCP;
+                                }
+
+                                Tox_Err_Group_Peer_Query role_err;
+                                role = tox_group_peer_get_role(tox,
+                                                               group_number,
+                                                               peer_id,
+                                                               &role_err);
+
+                                if (role_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                                    role = TOX_GROUP_ROLE_USER;
+                                }
+                            }
+
+                            r.connection_status = conn;
+                            r.last_seen = now;
+                            r.role = role;
+                        } else {
+                            r.connection_status = TOX_CONNECTION_NONE;
+                            /* Anchor last_seen so we can purge them if they never come online */
+                            if (r.last_seen == 0) r.last_seen = now;
+                        }
+
+                        if (mid_upsert_record(g, &r)) {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+
+            p_idx += body_len;
+        }
+
+        /*
+         * SAFE MULTICAST SUPPRESSION
+         *
+         * Only suppress if the batch was structurally complete and the
+         * fingerprint matches exactly.
+         */
+        if (batch_complete) {
+            printf("[MID] ROSTER_BATCH: Sender FP[0..3]=%02X%02X%02X%02X, Our FP[0..3]=%02X%02X%02X%02X\n",
+                   sender_fp[0], sender_fp[1], sender_fp[2], sender_fp[3],
+                   g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]);
+            fflush(stdout);
+            if (memcmp(sender_fp, g->roster_fingerprint, MID_IDENTITY_KEY_SIZE) == 0) {
+                if (g->roster_reply_deadline != 0) {
+                    printf("[MID] ROSTER_BATCH: MATCH! Suppressing our pending roster reply because another peer already sent the exact same set.\n");
+                    fflush(stdout);
+                    g->roster_reply_deadline = 0;
+                } else {
+                    printf("[MID] ROSTER_BATCH: MATCH! But we had no pending reply to suppress.\n");
+                    fflush(stdout);
+                }
+            } else {
+                printf("[MID] ROSTER_BATCH: MISMATCH. Sender has a different peer set. Keeping our pending roster reply scheduled.\n");
+                fflush(stdout);
+            }
+        } else {
+            printf("[MID] ROSTER_BATCH: batch incomplete/truncated. "
+                   "Not suppressing roster reply.\n");
+            fflush(stdout);
+        }
+
+        return changed;
+    }
+
+    /**************************************************************************
+     * ROSTER REQUEST
+     *
+     * We do not answer immediately. We schedule a delayed response.
+     *
+     * If another peer responds first with a roster whose fingerprint matches
+     * ours, our pending response will be cancelled by the ROSTER_BATCH
+     * suppression logic above.
+     *************************************************************************/
+    if (type == MID_MSG_ROSTER_REQUEST) {
+        printf("[MID] on_custom_packet: processing ROSTER_REQUEST message\n");
+        fflush(stdout);
+
+        if (tox == NULL) {
+            return false;
+        }
+
+        /*
+         * Ignore our own request if it is ever echoed back.
+         */
+        if (sender_has_keys &&
+            g->have_keys &&
+            mid_same_identity(sender_identity, g->self_identity_key)) {
+            return false;
+        }
+
+        /*
+         * Only respond if we have joined/announced ourselves and have keys.
+         */
+        if (g->have_keys && g->announced) {
+            if (g->roster_reply_deadline == 0) {
+                /*
+                 * Randomized delay for multicast suppression.
+                 *
+                 * 1 to 5 seconds is enough for the first responder to be heard
+                 * by the other peers before their timers fire.
+                 */
+                uint64_t delay = 1 + (uint64_t)(rand() % 5);
+                g->roster_reply_deadline = now + delay;
+
+                printf("[MID] ROSTER_REQUEST: scheduled roster reply in %llu seconds. Our FP[0..3]=%02X%02X%02X%02X\n",
+                       (unsigned long long)delay,
+                       g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]);
+                fflush(stdout);
+            }
+        }
+
+        return changed;
+    }
+
+    /* Unknown message type. */
+    return false;
+}
+
+/******************************************************************************
+Forward declaration for internal use.
+mid_delete_peer_by_identity_internal is defined later in this file but is
+needed by mid_on_group_moderation_internal. We must NOT call the public
+mid_delete_peer_by_identity() from within a locked section because it would
+attempt to re-acquire the non-recursive mutex → deadlock.
+******************************************************************************/
+static bool mid_delete_peer_by_identity_internal(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                                                 const uint8_t identity_key[MID_IDENTITY_KEY_SIZE]);
+
+/******************************************************************************
+Internal state management (Assumes lock is held, does NOT fire callbacks)
+
+THREAD-SAFETY CONTRACT:
+Every function in this section expects the caller to already hold s->mutex.
+These functions must ONLY call other "_internal" or static helpers.
+They must NEVER call the public (locking) API wrappers.
+******************************************************************************/
+
+static bool mid_on_group_self_join_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t *nickname, size_t nickname_len)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    bool is_new = false;
+
+    if (!g) {
+        g = mid_add_group(s, chat_id);
+        is_new = true;
+    }
+
+    if (!g || !mid_init_self_from_tox(g, tox)) return is_new;
+
+    /* Stamp the founder role as soon as we join */
+    mid_apply_founder_role(g, tox);
+
+    bool nick_changed = false;
+
+    /*
+     * Store the self nickname as raw bytes.
+     */
+    if (nickname != NULL && nickname_len > 0) {
+        if (nickname_len > MID_MAX_NICK_SIZE) {
+            nickname_len = MID_MAX_NICK_SIZE;
+        }
+        if (g->self_nickname_len != nickname_len || memcmp(g->self_nickname, nickname, nickname_len) != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            memcpy(g->self_nickname, nickname, nickname_len);
+            g->self_nickname_len = (uint16_t)nickname_len;
+            nick_changed = true;
+        }
+    } else {
+        if (g->self_nickname_len != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            g->self_nickname_len = 0;
+            nick_changed = true;
+        }
+    }
+
+    g->announced = true;
+
+    bool announce_changed = mid_announce_self_group(s, g, tox);
+    mid_send_roster_request_group(s, g, tox);
+
+    return is_new || nick_changed || announce_changed;
+}
+
+static bool mid_on_group_delete_internal(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return false;
+
+    for (size_t i = 0; i < s->group_count; i++) {
+        if (memcmp(s->groups[i].chat_id, chat_id, TOX_GROUP_CHAT_ID_SIZE) == 0) {
+            sodium_memzero(s->groups[i].self_secret_signing_key, sizeof(s->groups[i].self_secret_signing_key));
+            free(s->groups[i].records);
+            for (size_t j = i; j < s->group_count - 1; j++) {
+                s->groups[j] = s->groups[j+1];
+            }
+            s->group_count--;
+            return true; /* CHANGED */
+        }
+    }
+    return false;
+}
+
+static bool mid_on_group_peer_join_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t peer_id)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    bool changed = false;
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    uint8_t id[MID_IDENTITY_KEY_SIZE];
+    uint8_t sig[MID_SIGNING_KEY_SIZE];
+
+    Tox_Err_Group_Peer_Query conn_err;
+    Tox_Connection conn = tox_group_peer_get_connection_status(tox, group_number, peer_id, &conn_err);
+    if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) conn = TOX_CONNECTION_NONE;
+
+    Tox_Err_Group_Peer_Query role_err;
+    Tox_Group_Role role = tox_group_peer_get_role(tox, group_number, peer_id, &role_err);
+    if (role_err != TOX_ERR_GROUP_PEER_QUERY_OK) role = TOX_GROUP_ROLE_USER;
+
+    if (mid_get_peer_keys(tox, chat_id, peer_id, id, sig)) {
+        if (mid_on_peer_online_keys(g, id, sig, conn, role, mid_now_or_time(0))) {
+            changed = true;
+        }
+    }
+
+    if (mid_refresh_peer_name_group(g, tox, peer_id)) {
+        changed = true;
+    }
+
+    if (g->announced) {
+        if (mid_announce_self_group(s, g, tox)) {
+            changed = true;
+        }
+        
+        /* 
+         * RELIABILITY FIX:
+         * Toxcore often drops custom packets sent immediately during the join handshake.
+         * The new peer's ROSTER_REQUEST might be lost (as seen in the logs).
+         * Instead, when existing peers see a new peer join, they schedule a delayed 
+         * ROSTER_BATCH broadcast. The fingerprint suppression ensures only ONE existing 
+         * peer actually sends it, preventing a broadcast storm while guaranteeing delivery.
+         */
+        if (g->roster_reply_deadline == 0) {
+            uint64_t delay = 1 + (uint64_t)(rand() % 5);
+            g->roster_reply_deadline = mid_now_or_time(0) + delay;
+            printf("[MID] peer_join: scheduled roster sync in %llu seconds because a new peer joined.\n", (unsigned long long)delay);
+            fflush(stdout);
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
+static bool mid_on_group_peer_exit_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], Tox_Group_Exit_Type exit_type)
+{
+    (void)exit_type; /* Unused currently */
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    return mid_sync_online_state_group(g, tox, mid_now_or_time(0));
+}
+
+static bool mid_on_group_moderation_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t source_peer_id, uint32_t target_peer_id, Tox_Group_Mod_Event mod_type, bool *out_changed)
+{
+    *out_changed = false;
+
+    if (s == NULL || tox == NULL || chat_id == NULL) return false;
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (g == NULL) return false;
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    printf("[MID] on_group_moderation: event group=%u source_peer=%u target_peer=%u type=%d\n",
+           group_number, source_peer_id, target_peer_id, (int)mod_type);
+    fflush(stdout);
+
+    if (mod_type == TOX_GROUP_MOD_EVENT_KICK) {
+        Tox_Err_Group_Self_Query self_err;
+        uint32_t self_peer_id = tox_group_self_get_peer_id(tox, group_number, &self_err);
+
+        if (self_err == TOX_ERR_GROUP_SELF_QUERY_OK && target_peer_id == self_peer_id) {
+            printf("[MID] on_group_moderation: we were kicked; deleting group state\n");
+            fflush(stdout);
+            mid_on_group_delete_internal(s, chat_id);
+            *out_changed = true;
+            return true;
+        }
+
+        Tox_Err_Group_Peer_Query peer_err;
+        uint8_t kicked_identity[MID_IDENTITY_KEY_SIZE];
+
+        if (tox_group_peer_get_public_key(tox, group_number, target_peer_id, kicked_identity, &peer_err) &&
+            peer_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+            printf("[MID] on_group_moderation: deleting kicked peer from roster\n");
+            fflush(stdout);
+            /*
+             * THREAD-SAFETY FIX:
+             * We are already holding s->mutex (acquired by the public caller).
+             * We must call the _internal variant which does NOT lock.
+             * Calling the public mid_delete_peer_by_identity() here would
+             * deadlock on the non-recursive mutex.
+             */
+            if (mid_delete_peer_by_identity_internal(s, chat_id, kicked_identity)) {
+                *out_changed = true;
+            }
+        } else {
+            printf("[MID] on_group_moderation: kicked peer %u identity no longer queryable\n", target_peer_id);
+            fflush(stdout);
+        }
+    } else if (mod_type == TOX_GROUP_MOD_EVENT_OBSERVER ||
+               mod_type == TOX_GROUP_MOD_EVENT_USER ||
+               mod_type == TOX_GROUP_MOD_EVENT_MODERATOR) {
+        
+        Tox_Err_Group_Peer_Query peer_err;
+        uint8_t target_identity[MID_IDENTITY_KEY_SIZE];
+
+        if (tox_group_peer_get_public_key(tox, group_number, target_peer_id, target_identity, &peer_err) &&
+            peer_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+            
+            int idx = mid_find_identity(g, target_identity);
+            if (idx >= 0) {
+                Tox_Group_Role new_role = TOX_GROUP_ROLE_USER;
+                if (mod_type == TOX_GROUP_MOD_EVENT_OBSERVER) new_role = TOX_GROUP_ROLE_OBSERVER;
+                else if (mod_type == TOX_GROUP_MOD_EVENT_MODERATOR) new_role = TOX_GROUP_ROLE_MODERATOR;
+                
+                if (g->records[idx].role != new_role) {
+                    g->records[idx].role = new_role;
+                    *out_changed = true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+static bool mid_on_group_peer_name_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t peer_id)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    return mid_refresh_peer_name_group(g, tox, peer_id);
+}
+
+static bool mid_self_set_name_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t *nickname, size_t nickname_len)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g || !g->have_keys) return false;
+
+    bool nick_changed = false;
+
+    /* Update the persistent self nickname buffer */
+    if (nickname != NULL && nickname_len > 0) {
+        if (nickname_len > MID_MAX_NICK_SIZE) {
+            nickname_len = MID_MAX_NICK_SIZE;
+        }
+        if (g->self_nickname_len != nickname_len || memcmp(g->self_nickname, nickname, nickname_len) != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            memcpy(g->self_nickname, nickname, nickname_len);
+            g->self_nickname_len = (uint16_t)nickname_len;
+            nick_changed = true;
+        }
+    } else {
+        if (g->self_nickname_len != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            g->self_nickname_len = 0;
+            nick_changed = true;
+        }
+    }
+
+    if (nick_changed) {
+        /* Immediately update the local roster record so it reflects the change
+           even if the timestamp doesn't bump within the same second */
+        int idx = mid_find_identity(g, g->self_identity_key);
+        if (idx >= 0) {
+            MidPeerRecord *e = &g->records[idx];
+            memset(e->nickname, 0, MID_MAX_NICK_SIZE);
+            if (g->self_nickname_len > 0) {
+                memcpy(e->nickname, g->self_nickname, g->self_nickname_len);
+            }
+            e->nickname_len = g->self_nickname_len;
+        }
+
+        /* Re-announce ourselves to broadcast the new signed presence record */
+        if (g->announced) {
+            mid_announce_self_group(s, g, tox);
+        }
+    }
+
+    return nick_changed;
+}
+
+static bool mid_on_group_custom_packet_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t peer_id, const uint8_t *data, size_t length)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    s->recv_bytes += length;
+
+    return mid_on_custom_packet_group(s, g, tox, peer_id, data, length, mid_now_or_time(0));
+}
+
+static bool mid_announce_leave_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], bool *out_changed)
+{
+    *out_changed = false;
+
+    if (!chat_id) return false;
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g || !g->have_keys) return false;
+
+    MidPeerRecord r;
+    memset(&r, 0, sizeof(r));
+    memcpy(r.identity_key, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+    memcpy(r.signing_key, g->self_signing_key, MID_SIGNING_KEY_SIZE);
+    r.status = MID_STATUS_LEFT;
+    r.timestamp = mid_now_or_time(0);
+    r.connection_status = TOX_CONNECTION_NONE;
+
+    if (g->self_nickname_len > 0) {
+        uint16_t nick_copy = g->self_nickname_len;
+        if (nick_copy > MID_MAX_NICK_SIZE) {
+            nick_copy = MID_MAX_NICK_SIZE;
+        }
+        memcpy(r.nickname, g->self_nickname, nick_copy);
+        r.nickname_len = nick_copy;
+    }
+
+    if (!mid_sign_record(g, &r)) return false;
+
+    printf("[MID] announce_leave: broadcasting signed LEFT tombstone\n"); fflush(stdout);
+
+    bool sent = mid_send_presence_record(s, g, tox, &r);
+
+    int idx = mid_find_identity(g, g->self_identity_key);
+    if (idx >= 0) {
+        /* Replacing self with tombstone */
+        g->records[idx] = r;
+        g->records[idx].connection_status = TOX_CONNECTION_NONE;
+        *out_changed = true;
+    }
+
+    g->self_active = false;
+    return sent;
+}
+
+/*
+Internal delete: assumes lock is already held. Does NOT fire callbacks.
+This is the non-locking counterpart of the public mid_delete_peer_by_identity().
+*/
+static bool mid_delete_peer_by_identity_internal(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                                                 const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (s == NULL || identity_key == NULL || chat_id == NULL) return false;
+    if (mid_key_is_zero(identity_key)) return false;
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (g == NULL) return false;
+
+    int idx = mid_find_identity(g, identity_key);
+    if (idx < 0) return false;
+
+    printf("[MID] delete_peer_by_identity: deleting peer from roster\n");
+    fflush(stdout);
+
+    if (g->records[idx].has_signature) {
+        printf("[MID] delete_peer: XOR OUT deleted peer. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        mid_xor_fingerprint(g->roster_fingerprint, g->records[idx].identity_key);
+        printf("[MID] delete_peer: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+    }
+
+    for (size_t k = (size_t)idx; k + 1 < g->count; k++) {
+        g->records[k] = g->records[k+1];
+    }
+    g->count--;
+    return true; /* CHANGED */
+}
+
+/******************************************************************************
+Public state management (Handles Locking and Callbacks)
+
+THREAD-SAFETY:
+Every public entry point follows the same pattern:
+  1. mid_lock(s)
+  2. Call the corresponding _internal function (which assumes lock is held)
+  3. Snapshot the callback pointer under the lock
+  4. mid_unlock(s)
+  5. Fire the callback OUTSIDE the lock (prevents deadlock if the
+     callback calls back into any mid_* public function)
+******************************************************************************/
+
+static bool mid_load_from_disk(MidState *s, const char *path, const uint8_t *passphrase, size_t passphrase_len) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return false;
+
+    fseek(f, 0, SEEK_END);
+    long file_size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (file_size <= 0) { fclose(f); return false; }
+
+    uint8_t *file_data = (uint8_t *)malloc(file_size);
+    if (!file_data || fread(file_data, 1, file_size, f) != (size_t)file_size) {
+        free(file_data); fclose(f); return false;
+    }
+    fclose(f);
+
+    uint8_t *data_to_parse = file_data;
+    size_t data_len = file_size;
+    uint8_t *decrypted_data = NULL;
+
+    // Check if the file was encrypted by TOXENCRYPTSAVE
+    if (file_size >= TOX_PASS_ENCRYPTION_EXTRA_LENGTH && tox_is_data_encrypted(file_data)) {
+        if (!passphrase || passphrase_len == 0) {
+            printf("[MID] load: file is encrypted but no passphrase provided, ignoring\n");
+            free(file_data);
+            return false;
+        }
+        decrypted_data = (uint8_t *)malloc(file_size);
+        if (!decrypted_data) {
+            free(file_data);
+            return false;
+        }
+        Tox_Err_Decryption err;
+        if (!tox_pass_decrypt(file_data, file_size, passphrase, passphrase_len, decrypted_data, &err)) {
+            printf("[MID] load: decryption failed (err=%d)\n", err);
+            free(decrypted_data);
+            free(file_data);
+            return false;
+        }
+        data_to_parse = decrypted_data;
+        data_len = file_size - TOX_PASS_ENCRYPTION_EXTRA_LENGTH;
+    }
+
+    // Parse Header
+    MidReader r = { data_to_parse, data_len, 0 };
+    uint8_t magic[MID_SAVE_MAGIC_SIZE];
+    if (!mid_reader_read(&r, magic, MID_SAVE_MAGIC_SIZE) || memcmp(magic, MID_SAVE_MAGIC, MID_SAVE_MAGIC_SIZE) != 0) {
+        goto parse_fail;
+    }
+
+    uint32_t ver;
+    if (!mid_reader_read_u32(&r, &ver) || ver != MID_SAVE_VERSION) {
+        printf("[MID] load: unsupported or missing version %u\n", ver);
+        goto parse_fail;
+    }
+
+    uint64_t load_time = (uint64_t)time(NULL);
+
+    // Parse Body
+    uint32_t group_count;
+    if (!mid_reader_read_u32(&r, &group_count) || group_count > MID_MAX_GROUPS) goto parse_fail;
+
+    for (uint32_t i = 0; i < group_count; i++) {
+        uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+        if (!mid_reader_read(&r, chat_id, TOX_GROUP_CHAT_ID_SIZE)) goto parse_fail;
+
+        MidGroupState *g = mid_add_group(s, chat_id);
+        if (!g) goto parse_fail;
+
+        if (!mid_reader_read(&r, g->self_identity_key, MID_IDENTITY_KEY_SIZE)) goto parse_fail;
+        if (!mid_reader_read(&r, g->self_signing_key, MID_SIGNING_KEY_SIZE)) goto parse_fail;
+        /*
+         * NEVER load self_secret_signing_key from disk.
+         *
+         * The secret key is fetched from Toxcore once the group becomes
+         * active again via mid_init_self_from_tox().
+         */
+        sodium_memzero(g->self_secret_signing_key, sizeof(g->self_secret_signing_key));
+
+        /*
+         * We only have public keys at this point.
+         * We cannot sign anything until Toxcore gives us the secret signing key.
+         */
+        g->have_keys = false;
+        g->self_active = false;
+        g->announced = false;
+
+        uint16_t nick_len;
+        if (!mid_reader_read_u16(&r, &nick_len) || nick_len > MID_MAX_NICK_SIZE) goto parse_fail;
+        g->self_nickname_len = nick_len;
+        if (!mid_reader_read(&r, g->self_nickname, nick_len)) goto parse_fail;
+
+        uint32_t peer_count;
+        if (!mid_reader_read_u32(&r, &peer_count) || peer_count > MID_MAX_PEERS_PER_GROUP) goto parse_fail;
+
+        for (uint32_t j = 0; j < peer_count; j++) {
+            MidPeerRecord tmp_rec;
+            memset(&tmp_rec, 0, sizeof(tmp_rec));
+
+            if (!mid_reader_read(&r, tmp_rec.identity_key, MID_IDENTITY_KEY_SIZE)) goto parse_fail;
+            if (!mid_reader_read(&r, tmp_rec.signing_key, MID_SIGNING_KEY_SIZE)) goto parse_fail;
+
+            uint8_t status;
+            if (!mid_reader_read_u8(&r, &status)) goto parse_fail;
+            tmp_rec.status = status;
+            if (tmp_rec.status != MID_STATUS_ACTIVE && tmp_rec.status != MID_STATUS_LEFT) goto parse_fail;
+
+            if (!mid_reader_read_u64(&r, &tmp_rec.timestamp)) goto parse_fail;
+
+            uint16_t p_nick_len;
+            if (!mid_reader_read_u16(&r, &p_nick_len) || p_nick_len > MID_MAX_NICK_SIZE) goto parse_fail;
+            tmp_rec.nickname_len = p_nick_len;
+            if (!mid_reader_read(&r, tmp_rec.nickname, p_nick_len)) goto parse_fail;
+
+            if (!mid_reader_read(&r, tmp_rec.signature, MID_SIG_SIZE)) goto parse_fail;
+            uint8_t has_sig;
+            if (!mid_reader_read_u8(&r, &has_sig)) goto parse_fail;
+            tmp_rec.has_signature = has_sig ? true : false;
+
+            uint32_t conn, role;
+            if (!mid_reader_read_u32(&r, &conn)) goto parse_fail;
+            /* HINT: Force all loaded peers to offline.
+                     Leaves status (ACTIVE/LEFT) exactly as it was saved. */
+            // tmp_rec.connection_status = (Tox_Connection)conn;
+            tmp_rec.connection_status = TOX_CONNECTION_NONE;
+
+            if (!mid_reader_read_u32(&r, &role)) goto parse_fail;
+            tmp_rec.role = (Tox_Group_Role)role;
+
+
+            if (!mid_reader_read_u64(&r, &tmp_rec.last_seen)) goto parse_fail;
+            // Only anchor if the saved value was 0 (e.g. corrupted or legacy save).
+            // If you use this, and the app was closed for 31 days, offline peers
+            // WILL be purged immediately upon the first mid_iterate() call.
+            //
+            if (tmp_rec.last_seen == 0) {
+                tmp_rec.last_seen = load_time;
+            }
+
+            if (mid_find_identity(g, tmp_rec.identity_key) >= 0) continue;
+
+            if (!mid_ensure_capacity(g)) goto parse_fail;
+            MidPeerRecord *p = &g->records[g->count];
+            *p = tmp_rec;
+
+            if (p->has_signature) {
+                mid_xor_fingerprint(g->roster_fingerprint, p->identity_key);
+            }
+            g->count++;
+        }
+    }
+
+    if (decrypted_data) free(decrypted_data);
+    free(file_data);
+    return true;
+
+parse_fail:
+    printf("[MID] load: parse error, discarding loaded state\n");
+    if (decrypted_data) free(decrypted_data);
+    free(file_data);
+    for (size_t i = 0; i < s->group_count; i++) free(s->groups[i].records);
+    free(s->groups);
+    s->groups = NULL; s->group_count = 0; s->group_capacity = 0;
+    return false;
+}
+
+bool mid_save(MidState *s, const uint8_t *passphrase, size_t passphrase_len) {
+    if (!s || !s->save_path) return false;
+
+    mid_lock(s);
+    MidBuf buf;
+    mid_buf_init(&buf);
+
+    // 1. Assemble Header and Body
+    mid_buf_append(&buf, MID_SAVE_MAGIC, MID_SAVE_MAGIC_SIZE);
+    uint8_t ver[4]; 
+    mid_put_u32_be(ver, MID_SAVE_VERSION); 
+    mid_buf_append(&buf, ver, sizeof(ver));
+
+    // 2. Serialize Body
+    mid_buf_append_u32(&buf, (uint32_t)s->group_count);
+    for (size_t i = 0; i < s->group_count; i++) {
+        MidGroupState *g = &s->groups[i];
+        mid_buf_append(&buf, g->chat_id, TOX_GROUP_CHAT_ID_SIZE);
+        mid_buf_append(&buf, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+        mid_buf_append(&buf, g->self_signing_key, MID_SIGNING_KEY_SIZE);
+        /*
+         * NEVER save self_secret_signing_key.
+         *
+         * The Ed25519 signing secret key belongs to the NGC group identity
+         * and is owned by Toxcore. It must be re-obtained from Toxcore when
+         * the group is active again.
+         */
+        mid_buf_append_u16(&buf, g->self_nickname_len);
+        mid_buf_append(&buf, g->self_nickname, g->self_nickname_len);
+        mid_buf_append_u32(&buf, (uint32_t)g->count);
+
+        for (size_t j = 0; j < g->count; j++) {
+            MidPeerRecord *p = &g->records[j];
+            mid_buf_append(&buf, p->identity_key, MID_IDENTITY_KEY_SIZE);
+            mid_buf_append(&buf, p->signing_key, MID_SIGNING_KEY_SIZE);
+            mid_buf_append_u8(&buf, p->status);
+            mid_buf_append_u64(&buf, p->timestamp);
+            mid_buf_append_u16(&buf, p->nickname_len);
+            mid_buf_append(&buf, p->nickname, p->nickname_len);
+            mid_buf_append(&buf, p->signature, MID_SIG_SIZE);
+            mid_buf_append_u8(&buf, p->has_signature ? 1 : 0);
+            mid_buf_append_u32(&buf, (uint32_t)p->connection_status);
+            mid_buf_append_u32(&buf, (uint32_t)p->role);
+            mid_buf_append_u64(&buf, p->last_seen);
+        }
+    }
+
+    // 3. Encrypt payload if passphrase provided
+    uint8_t *final_payload = buf.data;
+    size_t final_payload_len = buf.len;
+    uint8_t *free_payload = NULL;
+
+    if (passphrase && passphrase_len > 0) {
+        size_t cipher_len = buf.len + TOX_PASS_ENCRYPTION_EXTRA_LENGTH;
+        free_payload = (uint8_t *)malloc(cipher_len);
+        if (!free_payload) { mid_buf_free(&buf); mid_unlock(s); return false; }
+
+        Tox_Err_Encryption err;
+        if (!tox_pass_encrypt(buf.data, buf.len, passphrase, passphrase_len, free_payload, &err)) {
+            printf("[MID] save: encryption failed (err=%d)\n", err);
+            free(free_payload); mid_buf_free(&buf); mid_unlock(s); return false;
+        }
+        final_payload = free_payload;
+        final_payload_len = cipher_len;
+    }
+
+    char *path_copy = mid_strdup(s->save_path);
+    mid_unlock(s); // <--- CRITICAL: Release lock before doing blocking Disk I/O
+
+    if (!path_copy) {
+        if (free_payload) free(free_payload);
+        mid_buf_free(&buf);
+        return false;
+    }
+
+    // 4. Write to Disk Atomically
+    size_t path_len = strlen(path_copy);
+    char *tmp_path = (char *)malloc(path_len + 6);
+    if (!tmp_path) {
+        free(path_copy);
+        if (free_payload) free(free_payload);
+        mid_buf_free(&buf);
+        return false;
+    }
+    snprintf(tmp_path, path_len + 6, "%s.tmp", path_copy);
+
+    FILE *f = fopen(tmp_path, "wb");
+    if (!f) {
+        free(tmp_path); free(path_copy);
+        if (free_payload) free(free_payload);
+        mid_buf_free(&buf);
+        return false;
+    }
+
+#ifndef _WIN32
+    /* 
+     * FIX: CodeQL TOCTOU Race Condition.
+     * Instead of closing the file and calling chmod() on the path string 
+     * (which allows an attacker to swap the path with a symlink in between),
+     * we use fchmod() on the open file descriptor. This atomically secures 
+     * the exact file we just created, completely bypassing path-based races.
+     */
+    if (fchmod(fileno(f), 0600) != 0) {
+        // Silently ignore permission errors, matching previous behavior
+    }
+#endif
+
+    fwrite(final_payload, 1, final_payload_len, f);
+    fclose(f);
+
+    if (free_payload) free(free_payload);
+    mid_buf_free(&buf);
+
+#ifdef _WIN32
+    /*
+     * Windows filesystem semantics differ from POSIX. Symlink-based TOCTOU 
+     * attacks via _chmod are not part of the standard Windows threat model 
+     * in this context, so _chmod remains the correct and standard approach here.
+     */
+    _chmod(tmp_path, _S_IREAD | _S_IWRITE);
+#endif
+
+#ifdef __MINGW32__
+    // HINT: rename() will refuse to overwrite existing files with WIN32 mingw
+    unlink(path_copy);
+#endif
+
+    bool ok = (rename(tmp_path, path_copy) == 0);
+    if (!ok) remove(tmp_path);
+
+    free(tmp_path);
+    free(path_copy);
+    return ok;
+}
+
+MidState *mid_new(const char *save_path, const uint8_t *passphrase, size_t passphrase_len) {
+    if (sodium_init() < 0) return NULL;
+
+    MidState *s = (MidState *)calloc(1, sizeof(MidState));
+    if (!s) return NULL;
+
+    s->mutex = (pthread_mutex_t *)calloc(1, sizeof(pthread_mutex_t));
+    if (!s->mutex) { free(s); return NULL; }
+    pthread_mutex_init(s->mutex, NULL);
+
+    if (save_path) s->save_path = mid_strdup(save_path);
+
+    if (s->save_path) {
+        mid_load_from_disk(s, s->save_path, passphrase, passphrase_len);
+    }
+
+    return s;
+}
+
+void mid_free(MidState *s) {
+    if (s == NULL) return;
+
+    for (size_t i = 0; i < s->group_count; i++) {
+        sodium_memzero(s->groups[i].self_secret_signing_key, sizeof(s->groups[i].self_secret_signing_key));
+        free(s->groups[i].records);
+    }
+    free(s->groups);
+
+    free(s->save_path);
+
+    if (s->mutex) {
+        pthread_mutex_destroy(s->mutex);
+        free(s->mutex);
+    }
+
+    free(s);
+}
+
+void mid_on_group_self_join(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_self_join_internal(s, tox, chat_id, nickname, nickname_len);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    /* Fire callback OUTSIDE the lock to avoid deadlock */
+    if (changed && cb) cb(chat_id, ud);
+}
+
+void mid_on_group_delete(MidState *s, Tox *tox, uint32_t group_number)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_delete_internal(s, chat_id);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+void mid_on_group_peer_join(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_peer_join_internal(s, tox, chat_id, peer_id);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+void mid_on_group_peer_exit(MidState *s, Tox *tox, uint32_t group_number, Tox_Group_Exit_Type exit_type)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_peer_exit_internal(s, tox, chat_id, exit_type);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+bool mid_on_group_moderation(MidState *s, Tox *tox, uint32_t group_number,
+                             uint32_t source_peer_id, uint32_t target_peer_id,
+                             Tox_Group_Mod_Event mod_type)
+{
+    if (!s || !tox) return false;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return false;
+
+    mid_lock(s);
+    bool changed = false;
+    bool we_were_kicked = mid_on_group_moderation_internal(s, tox, chat_id, source_peer_id, target_peer_id, mod_type, &changed);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+    return we_were_kicked;
+}
+
+void mid_on_group_peer_name(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_peer_name_internal(s, tox, chat_id, peer_id);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+bool mid_self_set_name(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len)
+{
+    if (!s || !tox) return false;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return false;
+
+    mid_lock(s);
+    bool changed = mid_self_set_name_internal(s, tox, chat_id, nickname, nickname_len);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    /* Fire callback OUTSIDE the lock to avoid deadlock */
+    if (changed && cb) cb(chat_id, ud);
+
+    return changed;
+}
+
+void mid_on_group_custom_packet(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data, size_t length)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_custom_packet_internal(s, tox, chat_id, peer_id, data, length);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+bool mid_announce_leave(MidState *s, Tox *tox, uint32_t group_number)
+{
+    if (!s || !tox) return false;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return false;
+
+    mid_lock(s);
+    bool changed = false;
+    bool sent = mid_announce_leave_internal(s, tox, chat_id, &changed);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+    return sent;
+}
+
+void mid_iterate(MidState *s, Tox *tox)
+{
+    if (!s || !tox) return;
+
+    mid_lock(s);
+
+    uint64_t now = mid_now_or_time(0);
+
+    /*
+     * PERFORMANCE THROTTLE:
+     * Do not run the heavy sync/cleanup loop on every 50ms tox_iterate() tick.
+     * Only run it every MID_SYNC_INTERVAL_SEC seconds.
+     */
+    if (now - s->last_sync_time < MID_SYNC_INTERVAL_SEC) {
+        mid_unlock(s);
+        return;
+    }
+
+    s->last_sync_time = now;
+
+    /* Collect changed groups to fire callbacks AFTER unlocking */
+    uint8_t changed_groups[MID_MAX_CHANGED_GROUPS_PER_ITERATE][TOX_GROUP_CHAT_ID_SIZE];
+    size_t num_changed = 0;
+
+    for (size_t i = 0; i < s->group_count; i++) {
+        MidGroupState *g = &s->groups[i];
+        bool changed = false;
+
+        // 1. Sync online state with Toxcore
+        if (mid_sync_online_state_group(g, tox, now)) {
+            changed = true;
+        }
+
+        // 2. Heartbeats (FIX 3: Uses lightweight heartbeat packet)
+        if (g->have_keys && g->self_active && g->announced) {
+            if (now >= g->last_announce && (now - g->last_announce >= MID_HEARTBEAT_SEC)) {
+                printf("[MID] poll: heartbeat triggered\n"); fflush(stdout);
+                if (mid_send_heartbeat_record(s, g, tox)) {
+                    g->last_announce = now;
+                    int idx = mid_find_identity(g, g->self_identity_key);
+                    if (idx >= 0) {
+                        g->records[idx].timestamp = now;
+                    }
+                    changed = true;
+                }
+            }
+        }
+
+        // 3. GRAVEYARD & STALE CLEANUP
+        uint64_t cutoff_tombstone = (now > MID_TOMBSTONE_TTL_SEC) ? (now - MID_TOMBSTONE_TTL_SEC) : 0;
+        uint64_t cutoff_stale = (now > MID_STALE_PEER_TTL_SEC) ? (now - MID_STALE_PEER_TTL_SEC) : 0;
+
+        size_t j = 0;
+        while (j < g->count) {
+            bool purge = false;
+            const MidPeerRecord *rec = &g->records[j];
+
+            // A. Purge expired LEFT tombstones (7 days)
+            if (rec->status == MID_STATUS_LEFT && rec->timestamp < cutoff_tombstone) {
+                purge = true;
+            }
+            // B. Purge stale offline ACTIVE peers (30 days)
+            // Must be ACTIVE, offline, and last_seen is older than the stale cutoff.
+            else if (rec->status == MID_STATUS_ACTIVE &&
+                     rec->connection_status == TOX_CONNECTION_NONE &&
+                     rec->last_seen > 0 &&
+                     rec->last_seen < cutoff_stale) {
+                purge = true;
+            }
+
+            if (purge) {
+                printf("[MID] iterate: purging stale/expired peer %zu\n", j); fflush(stdout);
+                if (rec->has_signature) {
+                    printf("[MID] iterate: XOR OUT purged peer. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                    mid_xor_fingerprint(g->roster_fingerprint, rec->identity_key);
+                    printf("[MID] iterate: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                }
+                // Shift array down to delete
+                for (size_t k = j; k < g->count - 1; k++) {
+                    g->records[k] = g->records[k+1];
+                }
+                g->count--;
+                changed = true;
+                continue; // Do not increment j, check the new record at this index
+            }
+            j++;
+        }
+
+        // 4. FIX 2: Multicast Roster Reply Timer execution
+        if (g->roster_reply_deadline != 0 && now >= g->roster_reply_deadline) {
+            printf("[MID] iterate: Roster reply timer fired! No one else suppressed us. Sending our roster. Our FP[0..3]=%02X%02X%02X%02X\n",
+                   g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]);
+            fflush(stdout);
+            g->roster_reply_deadline = 0;
+            mid_send_roster_group(s, g, tox);
+            changed = true;
+        }
+
+        if (changed && num_changed < MID_MAX_CHANGED_GROUPS_PER_ITERATE) {
+            memcpy(changed_groups[num_changed++], g->chat_id, TOX_GROUP_CHAT_ID_SIZE);
+        }
+    }
+
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+
+    /*
+     * IMPORTANT: Unlock BEFORE firing callbacks.
+     * This prevents deadlocks if the user's callback calls mid_peer_list_get().
+     */
+    mid_unlock(s);
+
+    if (cb) {
+        for (size_t i = 0; i < num_changed; i++) {
+            cb(changed_groups[i], ud);
+        }
+    }
+}
+
+size_t mid_group_count(MidState *s)
+{
+    if (!s) return 0;
+
+    mid_lock(s);
+    size_t count = s->group_count;
+    mid_unlock(s);
+
+    return count;
+}
+
+int mid_find_peer(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (s == NULL || identity_key == NULL || chat_id == NULL) return -1;
+    if (mid_key_is_zero(identity_key)) return -1;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    int idx = -1;
+    if (g != NULL) {
+        idx = mid_find_identity(g, identity_key);
+    }
+    mid_unlock(s);
+
+    return idx;
+}
+
+bool mid_delete_peer_by_identity(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (!s || !chat_id) return false;
+
+    mid_lock(s);
+    bool changed = mid_delete_peer_by_identity_internal(s, chat_id, identity_key);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+    return changed;
+}
+
+size_t mid_peer_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t count = g ? g->count : 0;
+    mid_unlock(s);
+
+    return count;
+}
+
+size_t mid_signed_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t c = 0;
+    if (g) {
+        for (size_t i = 0; i < g->count; i++) {
+            if (g->records[i].has_signature) c++;
+        }
+    }
+    mid_unlock(s);
+
+    return c;
+}
+
+size_t mid_online_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t c = 0;
+    if (g) {
+        for (size_t i = 0; i < g->count; i++) {
+            if (g->records[i].connection_status != TOX_CONNECTION_NONE) c++;
+        }
+    }
+    mid_unlock(s);
+
+    return c;
+}
+
+size_t mid_offline_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t c = 0;
+    if (g) {
+        for (size_t i = 0; i < g->count; i++) {
+            if (g->records[i].connection_status == TOX_CONNECTION_NONE &&
+                g->records[i].status == MID_STATUS_ACTIVE) c++;
+        }
+    }
+    mid_unlock(s);
+
+    return c;
+}
+
+bool mid_peer_is_signed_left(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (s == NULL || identity_key == NULL || chat_id == NULL) return false;
+    if (mid_key_is_zero(identity_key)) return false;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    bool res = false;
+    if (g != NULL) {
+        int idx = mid_find_identity(g, identity_key);
+        if (idx >= 0) {
+            const MidPeerRecord *rec = &g->records[idx];
+            res = rec->has_signature && rec->status == MID_STATUS_LEFT;
+        }
+    }
+    mid_unlock(s);
+
+    return res;
+}
+
+/******************************************************************************
+Network Stats
+******************************************************************************/
+
+void mid_get_network_stats(MidState *s, uint64_t *sent_bytes, uint64_t *recv_bytes)
+{
+    if (s == NULL) {
+        if (sent_bytes) *sent_bytes = 0;
+        if (recv_bytes) *recv_bytes = 0;
+        return;
+    }
+
+    /* Cast away const for locking; the mutex is logically mutable */
+    mid_lock(s);
+    if (sent_bytes) *sent_bytes = s->sent_bytes;
+    if (recv_bytes) *recv_bytes = s->recv_bytes;
+    mid_unlock(s);
+}
+
+/******************************************************************************
+Peer List Query API (for C / JNI clients)
+******************************************************************************/
+
+size_t mid_peer_list_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t count = g ? g->count : 0;
+    mid_unlock(s);
+
+    return count;
+}
+
+bool mid_peer_list_get(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], size_t index, MidPeerInfo *out)
+{
+    if (s == NULL || out == NULL || chat_id == NULL) return false;
+
+    mid_lock(s);
+
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    bool success = false;
+
+    if (g != NULL && index < g->count) {
+        const MidPeerRecord *rec = &g->records[index];
+
+        memset(out, 0, sizeof(*out));
+
+        memcpy(out->identity_key, rec->identity_key, MID_IDENTITY_KEY_SIZE);
+        memcpy(out->signing_key, rec->signing_key, MID_SIGNING_KEY_SIZE);
+
+        out->status        = rec->status;
+        out->connection_status = (uint8_t)rec->connection_status;
+        out->role          = (uint8_t)rec->role;
+        out->has_signature = rec->has_signature ? 1 : 0;
+        out->reserved      = 0;
+        out->last_seen     = rec->last_seen;
+        out->nickname_len  = rec->nickname_len;
+
+        // Safe copy bounded strictly by MID_MAX_NICK_SIZE
+        if (rec->nickname_len > 0 && rec->nickname_len <= MID_MAX_NICK_SIZE) {
+            memcpy(out->nickname, rec->nickname, rec->nickname_len);
+        }
+
+        // The NUL-termination.
+        // Because the array in MidPeerInfo is (MID_MAX_NICK_SIZE + 1),
+        // the index [nickname_len] is ALWAYS a valid memory location.
+        // (Max index written to is MID_MAX_NICK_SIZE, which is the last byte).
+        out->nickname[out->nickname_len] = '\0';
+
+        success = true;
+    }
+
+    mid_unlock(s);
+
+    return success;
+}
+
+/******************************************************************************
+Peer List Changed Callback registration
+******************************************************************************/
+
+void mid_set_peer_list_changed_cb(MidState *s, mid_peer_list_changed_cb cb, void *user_data)
+{
+    if (!s) return;
+
+    mid_lock(s);
+    s->peer_list_changed_cb = cb;
+    s->peer_list_changed_user_data = user_data;
+    mid_unlock(s);
+}
+
+/******************************************************************************
+Peer table printing
+******************************************************************************/
+
+static void mid_hex_short(char *out, size_t out_size, const uint8_t *data, size_t data_len, size_t max_bytes)
+{
+    if (out == NULL || out_size == 0) return;
+    out[0] = '\0';
+    if (data == NULL || data_len == 0 || max_bytes == 0) return;
+    if (max_bytes > data_len) max_bytes = data_len;
+    if (out_size <= (max_bytes * 2)) max_bytes = (out_size - 1) / 2;
+
+    for (size_t i = 0; i < max_bytes; i++) {
+        snprintf(out + (i * 2), 3, "%02X", data[i]);
+    }
+    out[max_bytes * 2] = '\0';
+}
+
+static void mid_make_safe_nick(char *out, size_t out_size, const uint8_t *nick, uint16_t nick_len)
+{
+    if (out == NULL || out_size == 0) return;
+
+    size_t o = 0;
+    if (nick != NULL) {
+        for (uint16_t i = 0; i < nick_len && o + 1 < out_size; i++) {
+            uint8_t c = nick[i];
+            if (c >= 0x20 && c <= 0x7E) out[o] = (char)c;
+            else out[o] = '.';
+            o++;
+        }
+    }
+    out[o] = '\0';
+}
+
+void mid_print_peer_table(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const char *title)
+{
+    if (!s || !chat_id) return;
+
+    mid_lock(s);
+
+    time_t now = time(NULL);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+
+    char chat_id_hex[9];
+    mid_hex_short(chat_id_hex, sizeof(chat_id_hex), chat_id, TOX_GROUP_CHAT_ID_SIZE, 4);
+
+    printf("\n");
+    printf("==========================================================================================\n");
+    printf("MIDDLEWARE PEER TABLE: %s (ChatID %s...)\n", title != NULL ? title : "unknown", chat_id_hex);
+
+    if (g == NULL) {
+        printf("(Group not found in middleware)\n");
+        printf("==========================================================================================\n\n");
+        fflush(stdout);
+        mid_unlock(s);
+        return;
+    }
+
+    size_t active_count = 0;
+    size_t online_count = 0;
+    size_t signed_count = 0;
+
+    for (size_t i = 0; i < g->count; i++) {
+        if (g->records[i].status == MID_STATUS_ACTIVE) active_count++;
+        if (g->records[i].connection_status != TOX_CONNECTION_NONE) online_count++;
+        if (g->records[i].has_signature) signed_count++;
+    }
+
+    printf("records=%zu active=%zu online=%zu signed=%zu sent=%llu recv=%llu\n",
+           g->count, active_count, online_count, signed_count,
+           (unsigned long long)s->sent_bytes, (unsigned long long)s->recv_bytes);
+
+    printf("+----+------+--------------+--------------+--------------+--------+------+--------+--------+----------+\n");
+    printf("| %2s | %-4s | %-12s | %-12s | %-12s | %-6s | %-4s | %-6s | %-6s | %-8s |\n",
+           "#", "Self", "Nickname", "Identity", "Signing", "Status", "Sig", "Conn", "Role", "Last seen");
+    printf("+----+------+--------------+--------------+--------------+--------+------+--------+--------+----------+\n");
+
+    for (size_t i = 0; i < g->count; i++) {
+        const MidPeerRecord *rec = &g->records[i];
+
+        char nick_buf[13];
+        char identity_buf[13];
+        char signing_buf[13];
+        char seen_buf[16];
+
+        mid_make_safe_nick(nick_buf, sizeof(nick_buf), rec->nickname, rec->nickname_len);
+        mid_hex_short(identity_buf, sizeof(identity_buf), rec->identity_key, MID_IDENTITY_KEY_SIZE, 6);
+        mid_hex_short(signing_buf, sizeof(signing_buf), rec->signing_key, MID_SIGNING_KEY_SIZE, 6);
+
+        bool is_self = false;
+        if (g->have_keys) {
+            is_self = mid_same_identity(rec->identity_key, g->self_identity_key);
+        }
+
+        const char *status_str = "?";
+        if (rec->status == MID_STATUS_ACTIVE) status_str = "ACTIVE";
+        else if (rec->status == MID_STATUS_LEFT) status_str = "LEFT";
+
+        const char *conn_str = "NONE";
+        if (rec->connection_status == TOX_CONNECTION_TCP) conn_str = "TCP";
+        else if (rec->connection_status == TOX_CONNECTION_UDP) conn_str = "UDP";
+
+        const char *role_str = "USER";
+        if (rec->role == TOX_GROUP_ROLE_FOUNDER) role_str = "FOUNDER";
+        else if (rec->role == TOX_GROUP_ROLE_MODERATOR) role_str = "MOD";
+        else if (rec->role == TOX_GROUP_ROLE_OBSERVER) role_str = "OBS";
+
+        if (rec->connection_status != TOX_CONNECTION_NONE) {
+            snprintf(seen_buf, sizeof(seen_buf), "now");
+        } else if (rec->last_seen == 0) {
+            snprintf(seen_buf, sizeof(seen_buf), "-");
+        } else if (rec->last_seen > (uint64_t)now) {
+            snprintf(seen_buf, sizeof(seen_buf), "future");
+        } else {
+            unsigned long age = (unsigned long)(now - (time_t)rec->last_seen);
+            snprintf(seen_buf, sizeof(seen_buf), "%lus", age);
+        }
+
+        printf("| %2zu | %-4s | %-12s | %-12s | %-12s | %-6s | %-4s | %-6s | %-6s | %-8s |\n",
+               i,
+               is_self ? "YES" : "no",
+               nick_buf,
+               identity_buf,
+               signing_buf,
+               status_str,
+               rec->has_signature ? "yes" : "no",
+               conn_str,
+               role_str,
+               seen_buf);
+    }
+
+    printf("+----+------+--------------+--------------+--------------+--------+------+--------+--------+----------+\n");
+    printf("\n");
+    fflush(stdout);
+
+    mid_unlock(s);
+}

--- a/amalgamation/toxcore_amalgamation_no_toxav.c
+++ b/amalgamation/toxcore_amalgamation_no_toxav.c
@@ -9545,6 +9545,19 @@ uint32_t tox_group_chat_id_size(void);
 
 uint32_t tox_group_peer_public_key_size(void);
 
+/**
+ * The size of an Ed25519 group signing public key.
+ */
+#define TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE 32
+
+/**
+ * The size of a peer's group secret signing key.
+ *
+ * This is the size of the Ed25519 secret signing key used for the client's
+ * group identity in an NGC group.
+ */
+#define TOX_GROUP_SIGNING_SECRET_KEY_SIZE 64
+
 
 /*******************************************************************************
  *
@@ -10126,6 +10139,53 @@ uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_E
 bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
                                    Tox_Err_Group_Self_Query *error);
 
+/**
+ * Write the client's group Ed25519 signing public key designated by the given
+ * group number to a byte array.
+ *
+ * This is the public signing key that corresponds to the group secret signing
+ * key returned by tox_group_self_get_signing_secret_key().
+ *
+ * `public_key` should have room for at least TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE
+ * bytes.
+ *
+ * If `public_key` is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_self_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Self_Query *error);
+
+/**
+ * Write the client's group secret signing key designated by the given group
+ * number to a byte array.
+ *
+ * This key is the Ed25519 secret signing key for the client's group identity.
+ * It is permanently tied to the client's identity for this particular group
+ * until the client explicitly leaves the group.
+ *
+ * This key can be used to sign application-level group packets, for example
+ * membership / presence events.
+ *
+ * `secret_key` should have room for at least TOX_GROUP_SIGNING_SECRET_KEY_SIZE
+ * bytes.
+ *
+ * If `secret_key` is NULL, this function call has no effect.
+ *
+ * @param secret_key A valid memory region large enough to store the secret key.
+ *   If this parameter is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_self_get_signing_secret_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *secret_key,
+                                           Tox_Err_Group_Self_Query *error);
+
+
+
 
 /*******************************************************************************
  *
@@ -10253,6 +10313,26 @@ bool tox_group_peer_get_public_key(const Tox *tox, uint32_t group_number, uint32
 
 bool tox_group_savedpeer_get_public_key(const Tox *tox, uint32_t group_number, uint32_t slot_number, uint8_t *public_key,
                                    Tox_Err_Group_Peer_Query *error);
+
+/**
+ * Write the Ed25519 signing public key of the peer designated by `peer_id`
+ * to `public_key`.
+ *
+ * This key can be used to verify signatures created by that peer's group
+ * secret signing key.
+ *
+ * `public_key` should have room for at least TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE
+ * bytes.
+ *
+ * If `public_key` is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_peer_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint32_t peer_id,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Peer_Query *error);
 
 /**
  * @brief Return the peer number associated with that NGC Peer Public Key.
@@ -10399,6 +10479,24 @@ bool tox_group_set_topic(const Tox *tox, uint32_t group_number, const uint8_t *t
  * `group_topic` callback.
  */
 size_t tox_group_get_topic_size(const Tox *tox, uint32_t group_number, Tox_Err_Group_State_Queries *error);
+
+/**
+ * Write the group founder's public key designated by the given group number to a byte array.
+ *
+ * This key is permanently tied to the group's identity and represents the peer who originally
+ * created the group. It remains valid for the entire lifetime of the group and cannot be
+ * changed or reassigned. This key allows peers to reliably identify the group founder even
+ * when the founder is offline.
+ *
+ * `public_key` should have room for at least TOX_GROUP_PEER_PUBLIC_KEY_SIZE bytes.
+ *
+ * @param public_key A valid memory region large enough to store the public key.
+ *   If this parameter is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_get_founder_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
+                                      Tox_Err_Group_State_Queries *error);
 
 /**
  * Write the topic designated by the given group number to a byte array.
@@ -13055,6 +13153,35 @@ uint32_t gc_get_self_peer_id(const GC_Chat *chat);
 non_null(1) nullable(2)
 void gc_get_self_public_key(const GC_Chat *chat, uint8_t *public_key);
 
+/**
+ * Copies the client's group Ed25519 secret signing key to `secret_key`.
+ *
+ * `secret_key` must have room for SIG_SECRET_KEY_SIZE bytes.
+ */
+non_null() nullable(2)
+void gc_get_self_signing_secret_key(const GC_Chat *chat, uint8_t *secret_key);
+
+/**
+ * Copies self Ed25519 group signing public key to `public_key`.
+ *
+ * If `public_key` is null this function has no effect.
+ */
+non_null(1) nullable(2)
+void gc_get_self_signing_public_key(const GC_Chat *chat, uint8_t *public_key);
+
+/**
+ * Copies the Ed25519 signing public key of peer `peer_id` to `public_key`.
+ *
+ * If `public_key` is null this function has no effect.
+ *
+ * Returns true on success.
+ * Returns false if the peer is not found.
+ */
+non_null(1) nullable(3)
+bool gc_get_peer_signing_public_key(const GC_Chat *chat,
+                                    uint32_t peer_id,
+                                    uint8_t *public_key);
+
 /** @brief Copies nick designated by `peer_id` to `name`.
  *
  * Call `gc_get_peer_nick_size` to determine the allocation size for the `name` parameter.
@@ -13141,6 +13268,10 @@ uint8_t gc_get_status(const GC_Chat *chat, uint32_t peer_id);
  */
 non_null()
 uint8_t gc_get_role(const GC_Chat *chat, uint32_t peer_id);
+
+
+void gc_get_founder_public_key(const GC_Chat *chat, uint8_t *public_key);
+
 
 /** @brief Sets the role of peer_id. role must be one of: GR_MODERATOR, GR_USER, GR_OBSERVER
  *
@@ -15926,6 +16057,381 @@ bool tox_utils_friend_delete(Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_DE
 //!TOKSTYLE+
 
 #endif
+/*
+mid_roster.h
+Minimal persistent group-roster middleware for Tox NGC.
+This header exposes a very simple API. All internal state, heartbeats,
+online-state synchronization, and roster requests are hidden inside
+the middleware. The client only needs to forward Toxcore events to
+the middleware hooks and call mid_iterate() in its main loop.
+*/
+
+#ifndef MID_ROSTER_H
+#define MID_ROSTER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+/*
+Opaque middleware state.
+A single MidState instance can manage multiple groups simultaneously.
+
+THREAD-SAFETY:
+All public functions in this header are thread-safe and may be called
+concurrently from any thread. Internally a single non-recursive
+pthread_mutex_t protects all mutable state (similar to tox_lock/tox_unlock
+in Toxcore). Callbacks are always fired WITHOUT the lock held, so it is
+safe to call any mid_* function from within a callback without deadlock.
+
+mid_new() and mid_free() are NOT thread-safe with respect to each other
+or to concurrent users. The caller must ensure mid_free() is only called
+after all other threads have stopped using the MidState.
+*/
+typedef struct MidState MidState;
+
+/* Hard limit for stored peers per group. */
+#define MID_MAX_PEERS_PER_GROUP 1024
+
+#define MID_PROTOCOL_VERSION    1
+
+/* NGC custom packet ID */
+#define MID_MAGIC_0  0x66      // was before: 0xA0
+#define MID_MAGIC_1  0x77      // was before: 0x91
+#define MID_MAGIC_2  0x92
+
+#define MID_MAGIC_BYTES_TOTAL 3
+/* Total header size: Magic bytes + Protocol Version (1 byte) + Message Type (1 byte) */
+#define MID_HEADER_SIZE (MID_MAGIC_BYTES_TOTAL + 2)
+
+/******************************************************************************
+Key-size constants (needed by MidPeerInfo below)
+******************************************************************************/
+
+#ifndef MID_IDENTITY_KEY_SIZE
+#define MID_IDENTITY_KEY_SIZE TOX_GROUP_PEER_PUBLIC_KEY_SIZE
+#endif
+
+#ifndef MID_SIGNING_KEY_SIZE
+#define MID_SIGNING_KEY_SIZE 32
+#endif
+
+#ifndef MID_MAX_NICK_SIZE
+#define MID_MAX_NICK_SIZE 128
+#endif
+
+/******************************************************************************
+Lifecycle
+******************************************************************************/
+
+/*
+Create a new middleware state.
+
+Parameters:
+  save_path      File path to load/save state. Pass NULL for a clean,
+                 in-memory only state.
+
+  passphrase     Optional passphrase to encrypt/decrypt the save file on disk.
+                 Pass NULL (with passphrase_len = 0) to save in plaintext
+                 (file permissions will be set to 0600).
+                 The passphrase can be any arbitrary length. It is fed
+                 directly to tox_pass_key_derive() internally.
+                 The passphrase is NOT stored in the middleware state.
+                 You must provide the same passphrase on every call to
+                 mid_save() to produce a readable encrypted file.
+
+  passphrase_len Length of the passphrase in bytes. Pass 0 if passphrase
+                 is NULL.
+
+Behavior on load:
+  If a save file exists at save_path:
+    - If the file is encrypted, the passphrase MUST be correct, otherwise
+      decryption fails and the file is ignored (clean state is started).
+    - If the file is unencrypted, it is loaded regardless of passphrase.
+    - If the file is corrupted or has an unsupported version, it is ignored.
+
+Returns:
+  A new MidState instance, or NULL on fatal error.
+*/
+MidState *mid_new(const char *save_path, const uint8_t *passphrase, size_t passphrase_len);
+
+/*
+Save the current state to disk. Thread-safe.
+
+The state is written atomically: data is written to a temporary file first,
+then renamed over the target path. This prevents corruption if the process
+is killed mid-write.
+
+Parameters:
+  s              The middleware state. Must not be NULL.
+
+  passphrase     Optional passphrase to encrypt the save file on disk.
+                 Pass NULL (with passphrase_len = 0) to save in plaintext.
+                 Must match the passphrase used when the file was originally
+                 encrypted if you intend to load it later with a passphrase.
+                 The passphrase is NOT stored. It is used only for this
+                 single save operation.
+
+  passphrase_len Length of the passphrase in bytes. Pass 0 if passphrase
+                 is NULL.
+
+Note:
+  The save_path used here is the one provided to mid_new(). There is no
+  separate configuration function. If save_path was NULL at creation,
+  this function returns false immediately.
+
+Returns:
+  true on success, false on failure.
+*/
+bool mid_save(MidState *s, const uint8_t *passphrase, size_t passphrase_len);
+
+void mid_free(MidState *s);
+
+/******************************************************************************
+Group Hooks
+******************************************************************************/
+
+/*
+Call this when the client successfully joins a group (or creates one).
+The middleware will fetch keys, announce the client, and request the roster.
+*/
+void mid_on_group_self_join(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len);
+
+/*
+Call this when the client leaves or deletes a group.
+The middleware will securely wipe keys and free the roster for this group.
+*/
+void mid_on_group_delete(MidState *s, Tox *tox, uint32_t group_number);
+
+/******************************************************************************
+Peer Event Hooks
+******************************************************************************/
+
+/*
+Call this when a new peer joins the group.
+The middleware will record them as online, refresh their name, and
+automatically re-sync the roster if we have already announced ourselves.
+*/
+void mid_on_group_peer_join(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id);
+
+/*
+ * Call this when a peer exits the group (via Toxcore's peer_exit callback).
+ * 
+ * NOTE: The `exit_type` parameter is intentionally ignored. 
+ * To maintain a stable, persistent roster that includes offline peers, 
+ * we do not delete peers simply because they disconnected or quit. 
+ * 
+ * Instead, this triggers a state-sync (`mid_sync_online_state_group`). 
+ * The middleware will query Toxcore to confirm the peer is gone and mark 
+ * them as offline (`TOX_CONNECTION_NONE`). 
+ * 
+ * If a peer actually intends to leave permanently, they should broadcast 
+ * a signed LEFT tombstone (MID_STATUS_LEFT) via custom packets before 
+ * disconnecting. The middleware will process that tombstone and keep the 
+ * peer in the roster for 7 days (MID_TOMBSTONE_TTL_SEC) to allow offline 
+ * peers to sync the departure.
+ */
+void mid_on_group_peer_exit(MidState *s, Tox *tox, uint32_t group_number, Tox_Group_Exit_Type exit_type);
+
+/*
+Call this when a peer changes their nickname.
+The middleware will update the unsigned local observation of their name.
+*/
+void mid_on_group_peer_name(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id);
+
+/******************************************************************************
+Moderation Hook
+******************************************************************************/
+
+/*
+Call this when a group moderation event is received.
+The middleware hides all kick-related roster logic internally:
+If we were the target of the kick, the middleware securely wipes the group
+state (keys and roster) and returns true. The client should then clear its
+own local group reference (group_number / group_connected).
+If another peer was kicked, the middleware deletes that peer from the
+roster and returns false.
+
+NOTE:
+The peer who INITIATES a kick does NOT receive the group_moderation event
+(see tox_group_mod_kick_peer / tox_callback_group_moderation in tox.h).
+Therefore the middleware cannot delete the kicked peer on the kicker's side
+from this hook. The kicker must explicitly call mid_delete_peer_by_identity()
+for the peer it kicked.
+
+Returns true if we ourselves were kicked.
+*/
+bool mid_on_group_moderation(MidState *s, Tox *tox, uint32_t group_number,
+                             uint32_t source_peer_id, uint32_t target_peer_id,
+                             Tox_Group_Mod_Event mod_type);
+
+/******************************************************************************
+Network Hook
+******************************************************************************/
+
+/*
+Call this when a group custom packet is received.
+The middleware will verify signatures, upsert records, and respond to
+roster requests automatically.
+*/
+void mid_on_group_custom_packet(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data, size_t length);
+
+/******************************************************************************
+Main Loop Hook
+******************************************************************************/
+
+/*
+Call this in your main loop alongside tox_iterate().
+The middleware will handle periodic heartbeats and continuously sync
+the online state of all peers across all managed groups.
+*/
+void mid_iterate(MidState *s, Tox *tox);
+
+/******************************************************************************
+Queries
+******************************************************************************/
+
+size_t mid_group_count(MidState *s);
+size_t mid_peer_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+size_t mid_signed_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+size_t mid_online_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+size_t mid_offline_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+
+/*
+Find a peer by NGC identity public key in a specific group.
+Returns:
+>= 0   peer index in the middleware roster for that group
+-1     peer not found, or group not found
+*/
+int mid_find_peer(MidState *s,
+                  const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                  const uint8_t identity_key[TOX_GROUP_PEER_PUBLIC_KEY_SIZE]);
+
+/*
+Delete a peer from the middleware roster by identity key.
+This is needed for kick handling.
+The kicker does not receive a group_peer_exit event for the peer it kicked,
+so the client must explicitly delete the kicked peer.
+*/
+bool mid_delete_peer_by_identity(MidState *s,
+                                 const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                                 const uint8_t identity_key[TOX_GROUP_PEER_PUBLIC_KEY_SIZE]);
+
+/*
+Returns true if the middleware has a signed LEFT tombstone for this
+identity key in the given group.
+*/
+bool mid_peer_is_signed_left(MidState *s,
+                             const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                             const uint8_t identity_key[MID_IDENTITY_KEY_SIZE]);
+
+/*
+Call this IMMEDIATELY BEFORE calling tox_group_leave().
+This broadcasts a signed "LEFT" tombstone to the group.
+When other peers (including those who were offline and just synced)
+receive this signed record, they will permanently delete this peer
+from their persistent rosters.
+*/
+bool mid_announce_leave(MidState *s, Tox *tox, uint32_t group_number);
+
+
+bool mid_self_set_name(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len);
+
+/******************************************************************************
+Peer List Query API (for C / JNI clients)
+Flat, fixed-size, index-based access. No dynamic allocation.
+Safe pattern:
+
+    size_t n = mid_peer_list_count(s, chat_id);
+    for (size_t i = 0; i < n; i++) {
+        MidPeerInfo info;
+        if (mid_peer_list_get(s, chat_id, i, &info)) {
+            // use info
+        }
+    }
+******************************************************************************/
+
+/*
+Flat representation of one peer in the roster.
+All fields are fixed-size. No pointers. NUL-terminated nickname.
+Suitable for direct mapping to JNI structs or flatbuffers.
+*/
+typedef struct {
+    uint8_t  identity_key[MID_IDENTITY_KEY_SIZE];   /*  NGC group identity key  */
+    uint8_t  signing_key[MID_SIGNING_KEY_SIZE];     /*  Ed25519 signing key    */
+    uint8_t  status;          /*  0 = ACTIVE, 1 = LEFT  */
+    uint8_t  connection_status; /* Tox_Connection: 0=NONE(offline), 1=TCP, 2=UDP */
+    uint8_t  role;            /* Tox_Group_Role: 0=FOUNDER, 1=MOD, 2=USER, 3=OBSERVER */
+    uint8_t  has_signature;   /*  1 if record is cryptographically signed  */
+    uint8_t  reserved;        /*  padding for alignment  */
+    uint64_t last_seen;       /*  unix timestamp, 0 if never seen  */
+    uint16_t nickname_len;    /*  length of nickname in bytes (without NUL)  */
+    /* CRUCIAL: +1 byte to safely hold the NUL terminator for JNI/C strings */
+    uint8_t nickname[MID_MAX_NICK_SIZE + 1];
+} MidPeerInfo;
+
+/*
+Return the number of peers in the middleware roster for a group.
+Returns 0 if the group is not found.
+*/
+size_t mid_peer_list_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+
+/*
+Fill `out` with the peer at `index` in the roster for the given group.
+Returns true on success.
+Returns false if s is NULL, out is NULL, group not found, or index >= count.
+The caller provides the MidPeerInfo storage. No memory is allocated.
+All fields are written; the struct is fully initialised on success.
+*/
+bool mid_peer_list_get(MidState *s,
+                       const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                       size_t index,
+                       MidPeerInfo *out);
+
+/******************************************************************************
+Peer List Changed Callback
+Register a callback to be notified whenever the peer roster for any group
+managed by this MidState has changed. The client should then call
+mid_peer_list_count() / mid_peer_list_get() to refresh its view.
+The callback receives the chat_id whose list changed, plus the
+user_data pointer.
+
+Thread-safety: the callback is invoked WITHOUT the middleware lock held.
+It is safe to call mid_peer_list_get() from within the callback.
+******************************************************************************/
+
+typedef void (*mid_peer_list_changed_cb)(const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], void *user_data);
+
+/*
+Register the peer-list-changed callback.
+Pass NULL for cb to unregister.
+*/
+void mid_set_peer_list_changed_cb(MidState *s,
+                                  mid_peer_list_changed_cb cb,
+                                  void *user_data);
+
+/******************************************************************************
+Network Stats
+******************************************************************************/
+
+/*
+Query the total bytes sent and received by the middleware custom packets.
+Pass NULL for either pointer if you only want to query one of them.
+Thread-safe.
+*/
+void mid_get_network_stats(MidState *s, uint64_t *sent_bytes, uint64_t *recv_bytes);
+
+/******************************************************************************
+Debug
+******************************************************************************/
+
+void mid_print_peer_table(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const char *title);
+
+#endif /* MID_ROSTER_H */
 /* SPDX-License-Identifier: GPL-3.0-or-later
  * Copyright © 2020-2021 The TokTok team.
  */
@@ -26944,6 +27450,33 @@ void gc_get_self_public_key(const GC_Chat *chat, uint8_t *public_key)
     }
 }
 
+void gc_get_self_signing_secret_key(const GC_Chat *chat, uint8_t *secret_key)
+{
+    if (secret_key != nullptr) {
+        memcpy(secret_key, get_sig_sk(chat->self_secret_key), SIG_SECRET_KEY_SIZE);
+    }
+}
+
+void gc_get_self_signing_public_key(const GC_Chat *chat, uint8_t *public_key)
+{
+    if (public_key == nullptr) {
+        return;
+    }
+
+    /*
+     * Peer 0 is always self.
+     */
+    const GC_Connection *gconn = get_gc_connection(chat, 0);
+
+    if (gconn == nullptr) {
+        return;
+    }
+
+    memcpy(public_key,
+           get_sig_pk(gconn->addr.public_key),
+           SIG_PUBLIC_KEY_SIZE);
+}
+
 /** @brief Sets self extended public key to `ext_public_key`.
  *
  * If `ext_public_key` is null this function has no effect.
@@ -27281,6 +27814,31 @@ static int get_peer_number_of_peer_id(const GC_Chat *chat, uint32_t peer_id)
     }
 
     return -1;
+}
+
+bool gc_get_peer_signing_public_key(const GC_Chat *chat,
+                                    uint32_t peer_id,
+                                    uint8_t *public_key)
+{
+    const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
+
+    if (peer_number == -1) {
+        return false;
+    }
+
+    const GC_Connection *gconn = get_gc_connection(chat, peer_number);
+
+    if (gconn == nullptr) {
+        return false;
+    }
+
+    if (public_key != nullptr) {
+        memcpy(public_key,
+               get_sig_pk(gconn->addr.public_key),
+               SIG_PUBLIC_KEY_SIZE);
+    }
+
+    return true;
 }
 
 /** @brief Returns a unique peer ID.
@@ -29128,6 +29686,13 @@ uint8_t gc_get_role(const GC_Chat *chat, uint32_t peer_id)
     }
 
     return peer->role;
+}
+
+void gc_get_founder_public_key(const GC_Chat *chat, uint8_t *public_key)
+{
+    if (public_key != nullptr) {
+        memcpy(public_key, get_enc_key(chat->shared_state.founder_public_key), ENC_PUBLIC_KEY_SIZE);
+    }
 }
 
 void gc_get_chat_id(const GC_Chat *chat, uint8_t *dest)
@@ -61463,6 +62028,7 @@ Tox_Group_Role tox_group_self_get_role(const Tox *tox, uint32_t group_number, To
     return (Tox_Group_Role)role;
 }
 
+
 uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_Err_Group_Self_Query *error)
 {
     assert(tox != nullptr);
@@ -61501,6 +62067,105 @@ bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_
     SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
 
     gc_get_self_public_key(chat, public_key);
+    tox_unlock(tox);
+
+    return true;
+}
+
+bool tox_group_self_get_signing_secret_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *secret_key,
+                                           Tox_Err_Group_Self_Query *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
+
+    gc_get_self_signing_secret_key(chat, secret_key);
+    tox_unlock(tox);
+
+    return true;
+}
+
+bool tox_group_self_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Self_Query *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
+
+    gc_get_self_signing_public_key(chat, public_key);
+    tox_unlock(tox);
+
+    return true;
+}
+
+bool tox_group_peer_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint32_t peer_id,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Peer_Query *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_PEER_QUERY_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    const bool ret = gc_get_peer_signing_public_key(chat, peer_id, public_key);
+    tox_unlock(tox);
+
+    if (!ret) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_PEER_QUERY_PEER_NOT_FOUND);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_PEER_QUERY_OK);
+    return true;
+}
+
+bool tox_group_get_founder_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
+                                      Tox_Err_Group_State_Queries *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_STATE_QUERIES_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_STATE_QUERIES_OK);
+
+    gc_get_founder_public_key(chat, public_key);
     tox_unlock(tox);
 
     return true;
@@ -74879,3 +75544,3817 @@ int64_t tox_util_friend_send_message_v2(Tox *tox, uint32_t friend_number, TOX_ME
 #pragma GCC diagnostic pop
 
 //!TOKSTYLE+
+/*
+mid_roster.c
+Minimal persistent group-roster middleware for Tox NGC.
+
+Goal:
+Maintain a stable peer list that can include offline peers.
+This is a best-effort, eventually consistent P2P solution.
+
+Transport:
+Uses only tox_group_send_custom_packet().
+
+Crypto:
+Uses libsodium Ed25519 signatures.
+Each peer signs their own JOIN / LEAVE / presence updates.
+
+KEY MODEL -- VERY IMPORTANT
+
+Tox NGC has multiple keys. This middleware uses three distinct keys:
+
+identity_key
+This is the normal 32-byte Tox NGC group peer public key.
+Tox NGC exposes a 32-byte group identity public key:
+tox_group_self_get_public_key()
+tox_group_peer_get_public_key()
+This key is used as the main roster lookup key.
+It is the persistent peer identity inside the group.
+In typical NGC extended-key layout, this is the Curve25519 encryption
+public key derived from the peer's Ed25519 signing key.
+
+signing_key
+This is the 32-byte Ed25519 public signing key belonging to the same
+NGC group identity.
+For signing/verification we also need Ed25519 keys:
+tox_group_self_get_signing_secret_key()      [patched]
+tox_group_self_get_signing_public_key()      [patched]
+For other peers we need:
+tox_group_peer_get_signing_public_key()      [patched]
+This key is used to verify signatures made by that peer.
+
+self_secret_signing_key
+This is the Ed25519 secret signing key for our own NGC group identity.
+It is obtained from the patched API:
+tox_group_self_get_signing_secret_key()
+This is NOT:
+the long-term Tox one-to-one secret key
+the NGC encryption secret key
+the group shared secret
+It is specifically the Ed25519 signing secret key.
+
+Signed presence records
+A presence record contains:
+status          ACTIVE / LEFT
+timestamp       sender-generated timestamp / logical version
+nickname        optional peer nickname
+identity_key    normal Tox NGC identity public key
+signing_key     Ed25519 public signing key
+The record is signed with the peer's Ed25519 signing secret key.
+The signature is verified with the Ed25519 signing public key.
+The identity_key and signing_key are both included in the signed body so
+that offline peers can be verified later as long as their signing key is
+known.
+
+Key binding:
+This middleware checks that the Ed25519 signing key belongs to the Tox
+NGC identity key.
+In normal NGC extended-key design:
+identity_key == curve25519_from_ed25519(signing_key)
+For compatibility, direct equality is also accepted:
+identity_key == signing_key
+
+Storage:
+No storage backend is implemented.
+Use:
+mid_peer_count()
+mid_signed_count()
+mid_online_count()
+to attach any storage backend later.
+
+Nickname safety:
+Toxcore nicknames are raw uint8_t buffers. They are NOT guaranteed to be
+valid UTF-8, NOT guaranteed to be printable ASCII, and NOT guaranteed to
+be NUL-terminated. They may contain embedded NUL bytes or arbitrary binary.
+This middleware treats all nicknames as opaque byte arrays with an
+explicit length. No C-string functions (strlen, strcmp, strcpy, printf %s)
+are ever used on nickname data. All copies are bounded by explicit lengths
+and destination buffers are zero-filled before use.
+
+Thread-safety model:
+All public API functions acquire a single non-recursive pthread_mutex_t
+(similar to tox_lock/tox_unlock in Toxcore) before touching any internal
+state. Internal "_internal" helper functions assume the lock is ALREADY
+held and must NEVER be called without it. Callbacks are always invoked
+AFTER the lock is released to prevent deadlocks when the client calls
+back into the middleware from within the callback.
+
+IMPORTANT: Internal functions must only call other "_internal" functions,
+never the public (locking) wrappers. This guarantees no deadlock with a
+non-recursive mutex.
+
+Requirements:
+Toxcore NGC
+tox_group_send_custom_packet()
+tox_group_self_get_public_key()
+tox_group_peer_get_public_key()
+tox_group_self_get_signing_secret_key()      [patched]
+tox_group_self_get_signing_public_key()      [patched]
+tox_group_peer_get_signing_public_key()      [patched]
+libsodium
+*/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <sodium.h>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+#ifndef MID_DEBUG_LOGGING
+#define printf(...) ((void)0)
+#define fflush(x)   ((void)0)
+#endif
+
+
+/******************************************************************************
+Tox key-size constants
+******************************************************************************/
+
+#ifndef TOX_GROUP_PEER_PUBLIC_KEY_SIZE
+#define TOX_GROUP_PEER_PUBLIC_KEY_SIZE 32
+#endif
+
+#ifndef TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE
+#define TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE 32
+#endif
+
+#ifndef TOX_GROUP_SIGNING_SECRET_KEY_SIZE
+#define TOX_GROUP_SIGNING_SECRET_KEY_SIZE 64
+#endif
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+/******************************************************************************
+Middleware key-size constants
+******************************************************************************/
+
+static const uint8_t MID_MAGIC[MID_MAGIC_BYTES_TOTAL] = {
+    MID_MAGIC_0,
+    MID_MAGIC_1,
+    MID_MAGIC_2
+};
+
+#define MID_SAVE_MAGIC       "MIDR"
+#define MID_SAVE_MAGIC_SIZE  4
+#define MID_SAVE_VERSION     3
+#define MID_MAX_GROUPS       1000
+
+#define MID_BUF_INIT_CAP 4096
+#define MID_MAX_CHANGED_GROUPS_PER_ITERATE 256
+
+#define MID_SIGNING_SECRET_KEY_SIZE TOX_GROUP_SIGNING_SECRET_KEY_SIZE
+
+#if MID_IDENTITY_KEY_SIZE != 32
+#error "mid_roster.c currently requires TOX_GROUP_PEER_PUBLIC_KEY_SIZE == 32"
+#endif
+
+#if MID_SIGNING_KEY_SIZE != 32
+#error "mid_roster.c currently requires TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE == 32"
+#endif
+
+#if MID_SIGNING_SECRET_KEY_SIZE != 64
+#error "mid_roster.c requires TOX_GROUP_SIGNING_SECRET_KEY_SIZE == 64"
+#endif
+
+#define MID_SIG_SIZE            64
+#define MID_MAX_PACKET_SIZE     1200
+#define MID_ROSTER_COOLDOWN_SEC 30
+/* FIX 4: Increased heartbeat interval from 50s to 300s (5 mins) to save traffic */
+#define MID_HEARTBEAT_SEC       300
+
+#define MID_RECORD_STATUS_SIZE    sizeof(uint8_t)
+#define MID_RECORD_TIMESTAMP_SIZE sizeof(uint64_t)
+#define MID_RECORD_NICKLEN_SIZE   sizeof(uint16_t)
+
+#define MID_RECORD_FIXED_BODY_SIZE (MID_RECORD_STATUS_SIZE + MID_RECORD_TIMESTAMP_SIZE + MID_RECORD_NICKLEN_SIZE)
+
+#define MID_HEARTBEAT_BODY_SIZE (MID_RECORD_STATUS_SIZE + MID_RECORD_TIMESTAMP_SIZE + MID_IDENTITY_KEY_SIZE)
+
+
+/*
+Throttle for the heavy sync/cleanup loop in mid_iterate().
+xx second is fast enough for responsive UI, but slow enough to avoid
+hammering Toxcore on every 50ms tox_iterate() tick.
+*/
+#define MID_SYNC_INTERVAL_SEC   5
+
+
+#define MID_MAX_BODY_SIZE (MID_RECORD_FIXED_BODY_SIZE + MID_MAX_NICK_SIZE + \
+                           MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE)
+
+/*
+Time-To-Live for LEFT tombstones.
+We keep them in the roster for 7 days so that offline peers who come
+back online can sync and receive cryptographic proof of the departure.
+*/
+#define MID_TOMBSTONE_TTL_SEC (7 * 24 * 60 * 60)
+
+/*
+Time-To-Live for "Zombie" peers (offline ACTIVE peers who never sent a LEFT tombstone).
+30 days is safe because Toxcore's network timeout is much shorter, and our 5-minute
+heartbeats guarantee last_seen stays fresh for actually active peers.
+*/
+#define MID_STALE_PEER_TTL_SEC (30 * 24 * 60 * 60)
+
+
+typedef enum {
+    MID_STATUS_ACTIVE = 0,
+    MID_STATUS_LEFT   = 1
+} MidStatus;
+
+typedef enum {
+    MID_MSG_PRESENCE       = 1,
+    MID_MSG_ROSTER_REQUEST = 2,
+    MID_MSG_HEARTBEAT      = 3, /* FIX 3: Lightweight heartbeat message */
+    MID_MSG_ROSTER_BATCH   = 4  /* FIX 5: Batched roster response message */
+} MidMsg;
+
+typedef struct {
+    uint8_t identity_key[MID_IDENTITY_KEY_SIZE];
+    uint8_t signing_key[MID_SIGNING_KEY_SIZE];
+    uint8_t  status;
+    uint64_t timestamp;
+    uint8_t  nickname[MID_MAX_NICK_SIZE];
+    uint16_t nickname_len;
+    uint8_t  signature[MID_SIG_SIZE];
+    bool     has_signature;
+    Tox_Connection connection_status;
+    Tox_Group_Role role;
+    uint64_t last_seen;
+} MidPeerRecord;
+
+typedef struct {
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    uint8_t self_identity_key[MID_IDENTITY_KEY_SIZE];
+    uint8_t self_signing_key[MID_SIGNING_KEY_SIZE];
+    uint8_t self_secret_signing_key[MID_SIGNING_SECRET_KEY_SIZE];
+    bool     have_keys;
+    uint8_t  self_nickname[MID_MAX_NICK_SIZE];
+    uint16_t self_nickname_len;
+    bool     self_active;
+    bool     announced;
+    MidPeerRecord *records;
+    size_t         count;
+    size_t         capacity;
+    uint64_t last_announce;
+    uint64_t last_roster_response;
+    uint64_t roster_reply_deadline; /* FIX 2: Multicast suppression timer */
+    uint8_t  roster_fingerprint[MID_IDENTITY_KEY_SIZE]; /* Incremental XOR sum of all signed identity keys */
+} MidGroupState;
+
+/*
+The actual definition of the opaque MidState struct.
+*/
+struct MidState {
+    MidGroupState *groups;
+    size_t         group_count;
+    size_t         group_capacity;
+
+    /*
+     * Peer-list-changed callback.
+     * Called whenever the roster for any group is mutated.
+     */
+    mid_peer_list_changed_cb peer_list_changed_cb;
+    void                    *peer_list_changed_user_data;
+
+    /*
+     * Thread-safety mutex (non-recursive).
+     * Protects all internal state. Modeled after tox->mutex in Toxcore.
+     * All public entry points call mid_lock()/mid_unlock().
+     * Internal "_internal" functions assume the lock is already held.
+     */
+    pthread_mutex_t *mutex;
+
+    /*
+     * Timestamp of the last heavy sync/cleanup pass in mid_iterate().
+     */
+    uint64_t last_sync_time;
+
+    /*
+     * Network statistics (custom packets only).
+     */
+    uint64_t sent_bytes;
+    uint64_t recv_bytes;
+
+    char *save_path;
+};
+
+/******************************************************************************
+Thread-safety helpers
+Modeled after tox_lock()/tox_unlock() in Toxcore.
+The mutex is non-recursive; internal code paths must never re-lock.
+******************************************************************************/
+
+static void mid_lock(MidState *s)
+{
+    if (s != NULL && s->mutex != NULL) {
+        pthread_mutex_lock(s->mutex);
+    }
+}
+
+static void mid_unlock(MidState *s)
+{
+    if (s != NULL && s->mutex != NULL) {
+        pthread_mutex_unlock(s->mutex);
+    }
+}
+
+/******************************************************************************
+Small helper functions
+******************************************************************************/
+
+static uint64_t mid_now_or_time(uint64_t now)
+{
+    if (now != 0) {
+        return now;
+    }
+    return (uint64_t)time(NULL);
+}
+
+static void mid_put_u16_be(uint8_t *p, uint16_t v)
+{
+    p[0] = (uint8_t)(v >> 8);
+    p[1] = (uint8_t)(v & 0xFF);
+}
+
+static void mid_put_u64_be(uint8_t *p, uint64_t v)
+{
+    p[0] = (uint8_t)(v >> 56);
+    p[1] = (uint8_t)(v >> 48);
+    p[2] = (uint8_t)(v >> 40);
+    p[3] = (uint8_t)(v >> 32);
+    p[4] = (uint8_t)(v >> 24);
+    p[5] = (uint8_t)(v >> 16);
+    p[6] = (uint8_t)(v >> 8);
+    p[7] = (uint8_t)(v & 0xFF);
+}
+
+static uint16_t mid_get_u16_be(const uint8_t *p)
+{
+    return (uint16_t)((uint16_t)p[0] << 8 | p[1]);
+}
+
+static uint64_t mid_get_u64_be(const uint8_t *p)
+{
+    uint64_t v = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); i++) {
+        v = (v << 8) | p[i];
+    }
+    return v;
+}
+
+static char *mid_strdup(const char *s) {
+    if (!s) return NULL;
+    size_t len = strlen(s) + 1;
+    char *d = (char *)malloc(len);
+    if (d) memcpy(d, s, len);
+    return d;
+}
+
+static void mid_put_u32_be(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v >> 24); p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);  p[3] = (uint8_t)(v & 0xFF);
+}
+
+static uint32_t mid_get_u32_be(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8)  | ((uint32_t)p[3]);
+}
+
+/* Dynamic Buffer for Serialization */
+typedef struct { uint8_t *data; size_t len; size_t cap; } MidBuf;
+
+static void mid_buf_init(MidBuf *b) { b->data = NULL; b->len = 0; b->cap = 0; }
+
+static void mid_buf_free(MidBuf *b) { free(b->data); b->data = NULL; b->len = 0; b->cap = 0; }
+
+static bool mid_buf_ensure(MidBuf *b, size_t extra) {
+    if (b->len + extra <= b->cap) return true;
+
+    // Prevent overflow in b->len + extra
+    if (extra > SIZE_MAX - b->len) return false;
+    size_t required = b->len + extra;
+
+    size_t new_cap = (b->cap == 0) ? MID_BUF_INIT_CAP : b->cap;
+    while (new_cap < required) {
+        if (new_cap > SIZE_MAX / 2) return false; // Prevent overflow
+        new_cap *= 2;
+    }
+
+    uint8_t *tmp = realloc(b->data, new_cap);
+    if (!tmp) return false;
+    b->data = tmp; b->cap = new_cap; return true;
+}
+
+static void mid_buf_append(MidBuf *b, const void *data, size_t len) {
+    if (len == 0) return;
+    if (mid_buf_ensure(b, len)) { memcpy(b->data + b->len, data, len); b->len += len; }
+}
+
+static void mid_buf_append_u8(MidBuf *b, uint8_t v) { mid_buf_append(b, &v, 1); }
+static void mid_buf_append_u16(MidBuf *b, uint16_t v) { uint8_t tmp[2]; mid_put_u16_be(tmp, v); mid_buf_append(b, tmp, 2); }
+static void mid_buf_append_u32(MidBuf *b, uint32_t v) { uint8_t tmp[4]; mid_put_u32_be(tmp, v); mid_buf_append(b, tmp, 4); }
+static void mid_buf_append_u64(MidBuf *b, uint64_t v) { uint8_t tmp[8]; mid_put_u64_be(tmp, v); mid_buf_append(b, tmp, 8); }
+
+/* Binary Reader for Deserialization */
+typedef struct { const uint8_t *data; size_t len; size_t pos; } MidReader;
+
+static bool mid_reader_has(MidReader *r, size_t need) { return r->pos + need <= r->len; }
+
+static bool mid_reader_read(MidReader *r, void *out, size_t len) {
+    if (!mid_reader_has(r, len)) return false;
+    memcpy(out, r->data + r->pos, len); r->pos += len; return true;
+}
+
+static bool mid_reader_read_u8(MidReader *r, uint8_t *out) { return mid_reader_read(r, out, 1); }
+
+static bool mid_reader_read_u16(MidReader *r, uint16_t *out) {
+    uint8_t tmp[2]; if (!mid_reader_read(r, tmp, 2)) return false;
+    *out = mid_get_u16_be(tmp); return true;
+}
+
+static bool mid_reader_read_u32(MidReader *r, uint32_t *out) {
+    uint8_t tmp[4]; if (!mid_reader_read(r, tmp, 4)) return false;
+    *out = mid_get_u32_be(tmp); return true;
+}
+
+static bool mid_reader_read_u64(MidReader *r, uint64_t *out) {
+    uint8_t tmp[8]; if (!mid_reader_read(r, tmp, 8)) return false;
+    *out = mid_get_u64_be(tmp); return true;
+}
+
+static bool mid_key_is_zero(const uint8_t key[32])
+{
+    for (int i = 0; i < 32; i++) {
+        if (key[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void mid_xor_fingerprint(uint8_t fp[MID_IDENTITY_KEY_SIZE], const uint8_t key[MID_IDENTITY_KEY_SIZE])
+{
+    for (size_t i = 0; i < MID_IDENTITY_KEY_SIZE; i++) {
+        fp[i] ^= key[i];
+    }
+}
+
+static bool mid_same_identity(const uint8_t a[MID_IDENTITY_KEY_SIZE],
+                              const uint8_t b[MID_IDENTITY_KEY_SIZE])
+{
+    return memcmp(a, b, MID_IDENTITY_KEY_SIZE) == 0;
+}
+
+static bool mid_same_signing_key(const uint8_t a[MID_SIGNING_KEY_SIZE],
+                                 const uint8_t b[MID_SIGNING_KEY_SIZE])
+{
+    return memcmp(a, b, MID_SIGNING_KEY_SIZE) == 0;
+}
+
+static bool mid_valid_key_binding(const uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                                  const uint8_t signing_key[MID_SIGNING_KEY_SIZE])
+{
+    if (mid_key_is_zero(identity_key) || mid_key_is_zero(signing_key)) {
+        printf("[MID] valid_key_binding: rejected, zero key\n"); fflush(stdout);
+        return false;
+    }
+
+    uint8_t derived_curve_pk[32];
+    if (crypto_sign_ed25519_pk_to_curve25519(derived_curve_pk, signing_key) != 0) {
+        printf("[MID] valid_key_binding: rejected, curve25519 derivation failed\n"); fflush(stdout);
+        return false;
+    }
+
+    if (mid_same_identity(identity_key, derived_curve_pk)) {
+        printf("[MID] valid_key_binding: accepted, curve25519 derived match\n"); fflush(stdout);
+        return true;
+    }
+
+    printf("[MID] valid_key_binding: rejected, no match\n"); fflush(stdout);
+    return false;
+}
+
+static uint32_t mid_chat_id_to_group_number(const Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (tox == NULL || chat_id == NULL) return UINT32_MAX;
+    Tox_Err_Group_State_Queries err;
+    uint32_t gnum = tox_group_by_chat_id(tox, chat_id, &err);
+    if (err != TOX_ERR_GROUP_STATE_QUERIES_OK) {
+        return UINT32_MAX;
+    }
+    return gnum;
+}
+
+static MidGroupState *mid_find_group(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (s == NULL || chat_id == NULL) return NULL;
+    for (size_t i = 0; i < s->group_count; i++) {
+        if (memcmp(s->groups[i].chat_id, chat_id, TOX_GROUP_CHAT_ID_SIZE) == 0) {
+            return &s->groups[i];
+        }
+    }
+    return NULL;
+}
+
+static const MidGroupState *mid_find_group_const(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    return mid_find_group((MidState *)s, chat_id);
+}
+
+static MidGroupState *mid_add_group(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (s == NULL || chat_id == NULL) return NULL;
+
+    if (s->group_count >= s->group_capacity) {
+        size_t new_cap = (s->group_capacity == 0) ? 4 : s->group_capacity * 2;
+        MidGroupState *tmp = realloc(s->groups, new_cap * sizeof(MidGroupState));
+        if (tmp == NULL) return NULL;
+        s->groups = tmp;
+        s->group_capacity = new_cap;
+    }
+
+    MidGroupState *g = &s->groups[s->group_count++];
+    memset(g, 0, sizeof(*g));
+    memcpy(g->chat_id, chat_id, TOX_GROUP_CHAT_ID_SIZE);
+    return g;
+}
+
+static bool mid_evict_oldest_offline_active(MidGroupState *g)
+{
+    if (g == NULL || g->count == 0) {
+        return false;
+    }
+
+    size_t oldest = g->count;
+    uint64_t oldest_seen = 0;
+
+    for (size_t i = 0; i < g->count; i++) {
+        const MidPeerRecord *r = &g->records[i];
+
+        /* Only ACTIVE peers that are currently offline are evictable. */
+        if (r->status != MID_STATUS_ACTIVE ||
+            r->connection_status != TOX_CONNECTION_NONE) {
+            continue;
+        }
+
+        /* Never evict our own record. */
+        if (!mid_key_is_zero(g->self_identity_key) &&
+            mid_same_identity(r->identity_key, g->self_identity_key)) {
+            continue;
+        }
+
+        /* last_seen == 0 is treated as the oldest possible value. */
+        if (oldest == g->count || r->last_seen < oldest_seen) {
+            oldest = i;
+            oldest_seen = r->last_seen;
+        }
+    }
+
+    if (oldest == g->count) {
+        return false;
+    }
+
+    printf("[MID] evict_peer: evicting oldest offline ACTIVE peer %zu\n", oldest); fflush(stdout);
+
+    if (g->records[oldest].has_signature) {
+        printf("[MID] evict_peer: XOR OUT evicted peer. Old FP[0..3]=%02X%02X%02X%02X\n",
+               g->roster_fingerprint[0],
+               g->roster_fingerprint[1],
+               g->roster_fingerprint[2],
+               g->roster_fingerprint[3]);
+        fflush(stdout);
+
+        mid_xor_fingerprint(g->roster_fingerprint, g->records[oldest].identity_key);
+
+        printf("[MID] evict_peer: New FP[0..3]=%02X%02X%02X%02X\n",
+               g->roster_fingerprint[0],
+               g->roster_fingerprint[1],
+               g->roster_fingerprint[2],
+               g->roster_fingerprint[3]);
+        fflush(stdout);
+    }
+
+    for (size_t k = oldest; k + 1 < g->count; k++) {
+        g->records[k] = g->records[k + 1];
+    }
+
+    g->count--;
+
+    return true;
+}
+
+static bool mid_ensure_capacity(MidGroupState *g)
+{
+    if (g == NULL) {
+        return false;
+    }
+
+    if (g->count >= MID_MAX_PEERS_PER_GROUP) {
+        printf("[MID] ensure_capacity: peer limit %d reached, trying eviction\n", MID_MAX_PEERS_PER_GROUP); fflush(stdout);
+
+        if (!mid_evict_oldest_offline_active(g)) {
+            printf("[MID] ensure_capacity: rejected, peer limit %d reached and no offline ACTIVE peer to evict\n", MID_MAX_PEERS_PER_GROUP); fflush(stdout);
+            return false;
+        }
+
+        if (g->count >= MID_MAX_PEERS_PER_GROUP) {
+            printf("[MID] ensure_capacity: still at peer limit after eviction\n"); fflush(stdout);
+            return false;
+        }
+    }
+
+    if (g->count < g->capacity) {
+        return true;
+    }
+
+    size_t new_capacity = (g->capacity == 0) ? 16 : g->capacity * 2;
+
+    if (new_capacity > MID_MAX_PEERS_PER_GROUP) {
+        new_capacity = MID_MAX_PEERS_PER_GROUP;
+        printf("[MID] ensure_capacity: new_capacity cut to limit\n"); fflush(stdout);
+    }
+
+    printf("[MID] ensure_capacity: reallocating from %zu to %zu\n", g->capacity, new_capacity); fflush(stdout);
+
+    MidPeerRecord *tmp = realloc(g->records, new_capacity * sizeof(MidPeerRecord));
+    if (tmp == NULL) {
+        printf("[MID] ensure_capacity: realloc failed\n"); fflush(stdout);
+        return false;
+    }
+
+    g->records = tmp;
+    g->capacity = new_capacity;
+    return true;
+}
+
+static int mid_find_identity(const MidGroupState *g,
+                             const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    for (size_t i = 0; i < g->count; i++) {
+        if (mid_same_identity(g->records[i].identity_key, identity_key)) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+/******************************************************************************
+Record serialization and crypto
+******************************************************************************/
+
+static bool mid_pack_record_body(uint8_t *buf,
+                                 size_t cap,
+                                 const MidPeerRecord *r,
+                                 size_t *out_len)
+{
+    if (r->nickname_len > MID_MAX_NICK_SIZE) {
+        return false;
+    }
+
+    if (mid_key_is_zero(r->identity_key)) {
+        return false;
+    }
+
+    size_t need = MID_RECORD_FIXED_BODY_SIZE + r->nickname_len + MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE;
+
+    if (need > cap) {
+        printf("[MID] pack_record_body: rejected, need %zu > cap %zu\n", need, cap); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] pack_record_body: packing %zu bytes\n", need); fflush(stdout);
+
+    size_t o = 0;
+    buf[o++] = r->status;
+    mid_put_u64_be(buf + o, r->timestamp);
+    o += 8;
+    mid_put_u16_be(buf + o, r->nickname_len);
+    o += 2;
+    if (r->nickname_len > 0) {
+        memcpy(buf + o, r->nickname, r->nickname_len);
+        o += r->nickname_len;
+    }
+    memcpy(buf + o, r->identity_key, MID_IDENTITY_KEY_SIZE);
+    o += MID_IDENTITY_KEY_SIZE;
+    memcpy(buf + o, r->signing_key, MID_SIGNING_KEY_SIZE);
+    o += MID_SIGNING_KEY_SIZE;
+
+    if (out_len != NULL) {
+        *out_len = o;
+    }
+    return true;
+}
+
+static bool mid_unpack_record_body(MidPeerRecord *r,
+                                   const uint8_t *buf,
+                                   size_t len)
+{
+    memset(r, 0, sizeof(*r));
+
+    size_t o = 0;
+    size_t min_len = MID_RECORD_FIXED_BODY_SIZE + MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE;
+
+    if (len < min_len) {
+        printf("[MID] unpack_record_body: rejected, len %zu < min_len %zu\n", len, min_len); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] unpack_record_body: unpacking %zu bytes\n", len); fflush(stdout);
+
+    r->status = buf[o++];
+    if (r->status != MID_STATUS_ACTIVE && r->status != MID_STATUS_LEFT) {
+        return false;
+    }
+
+    r->timestamp = mid_get_u64_be(buf + o);
+    o += 8;
+
+    r->nickname_len = mid_get_u16_be(buf + o);
+    o += 2;
+
+    if (r->nickname_len > MID_MAX_NICK_SIZE) {
+        return false;
+    }
+
+    if (o + r->nickname_len + MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE > len) {
+        return false;
+    }
+
+    if (r->nickname_len > 0) {
+        memcpy(r->nickname, buf + o, r->nickname_len);
+        o += r->nickname_len;
+    }
+
+    memcpy(r->identity_key, buf + o, MID_IDENTITY_KEY_SIZE);
+    o += MID_IDENTITY_KEY_SIZE;
+
+    memcpy(r->signing_key, buf + o, MID_SIGNING_KEY_SIZE);
+    o += MID_SIGNING_KEY_SIZE;
+
+    if (mid_key_is_zero(r->identity_key)) {
+        return false;
+    }
+
+    r->has_signature = false;
+    r->connection_status = TOX_CONNECTION_NONE;
+    r->role = TOX_GROUP_ROLE_USER;
+    r->last_seen = 0;
+    return true;
+}
+
+static bool mid_verify_record(const MidPeerRecord *r)
+{
+    if (!r->has_signature) {
+        printf("[MID] verify_record: rejected, no signature\n"); fflush(stdout);
+        return false;
+    }
+
+    if (!mid_valid_key_binding(r->identity_key, r->signing_key)) {
+        printf("[MID] verify_record: rejected, invalid key binding\n"); fflush(stdout);
+        return false;
+    }
+
+    uint8_t body[MID_MAX_BODY_SIZE];
+    size_t body_len = 0;
+    if (!mid_pack_record_body(body, sizeof(body), r, &body_len)) {
+        return false;
+    }
+
+    int res = crypto_sign_verify_detached(r->signature,
+                                          body,
+                                          body_len,
+                                          r->signing_key);
+
+    if (res == 0) {
+        printf("[MID] verify_record: signature VALID\n"); fflush(stdout);
+        return true;
+    } else {
+        printf("[MID] verify_record: signature INVALID\n"); fflush(stdout);
+        return false;
+    }
+}
+
+static bool mid_sign_record(MidGroupState *g, MidPeerRecord *r)
+{
+    if (!g->have_keys) {
+        printf("[MID] sign_record: failed, no keys\n"); fflush(stdout);
+        return false;
+    }
+
+    uint8_t body[MID_MAX_BODY_SIZE];
+    size_t body_len = 0;
+    if (!mid_pack_record_body(body, sizeof(body), r, &body_len)) {
+        return false;
+    }
+
+    unsigned long long sig_len = 0;
+    if (crypto_sign_detached(r->signature,
+                             &sig_len,
+                             body,
+                             body_len,
+                             g->self_secret_signing_key) != 0) {
+        printf("[MID] sign_record: crypto_sign_detached failed\n"); fflush(stdout);
+        return false;
+    }
+
+    if (sig_len != MID_SIG_SIZE) {
+        printf("[MID] sign_record: unexpected sig_len %llu\n", sig_len); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] sign_record: successfully signed %zu bytes\n", body_len); fflush(stdout);
+    r->has_signature = true;
+    return true;
+}
+
+/******************************************************************************
+Roster record upsert
+Returns true if the roster was actually modified (inserted or updated).
+
+This version maintains g->roster_fingerprint by XORing the 32-byte 
+identity_key of every peer that has a valid signature. 
+
+This means the fingerprint tracks the SET of signed peers. It changes when:
+  - a signed peer is added
+  - a signed peer is removed
+  - an unsigned peer becomes signed
+  
+It does NOT change when a signed peer updates their nickname or timestamp.
+******************************************************************************/
+
+static bool mid_upsert_record(MidGroupState *g, const MidPeerRecord *in)
+{
+    printf("[MID] upsert_record: processing record\n");
+    fflush(stdout);
+
+    if (g == NULL || in == NULL) {
+        return false;
+    }
+
+    MidPeerRecord tmp = *in;
+
+    if (mid_key_is_zero(tmp.identity_key)) {
+        printf("[MID] upsert_record: rejected, zero identity key\n");
+        fflush(stdout);
+        return false;
+    }
+
+    if (tmp.status != MID_STATUS_ACTIVE && tmp.status != MID_STATUS_LEFT) {
+        printf("[MID] upsert_record: rejected, invalid status\n");
+        fflush(stdout);
+        return false;
+    }
+
+    if (tmp.nickname_len > MID_MAX_NICK_SIZE) {
+        printf("[MID] upsert_record: rejected, nickname too long\n");
+        fflush(stdout);
+        return false;
+    }
+
+    /*
+     * Unsigned records do not carry a valid persistent signature.
+     * Zero the signature field so it cannot accidentally influence later logic.
+     */
+    if (!tmp.has_signature) {
+        memset(tmp.signature, 0, sizeof(tmp.signature));
+    }
+
+    /*
+     * Verify signed records before touching any state.
+     */
+    if (tmp.has_signature && !mid_verify_record(&tmp)) {
+        printf("[MID] upsert_record: rejected, signature verification failed\n");
+        fflush(stdout);
+        return false;
+    }
+
+    /**************************************************************************
+     * SIGNED LEFT TOMBSTONE PATH
+     *
+     * Signed LEFT tombstones are authoritative departure records.
+     * They must be stored and forwarded so offline peers can later learn
+     * cryptographically that this identity left.
+     *************************************************************************/
+    if (tmp.has_signature && tmp.status == MID_STATUS_LEFT) {
+        int idx = mid_find_identity(g, tmp.identity_key);
+
+        if (idx >= 0) {
+            MidPeerRecord *ex = &g->records[idx];
+
+            /*
+             * If we already have a signed record for this identity, the
+             * signing key may not change.
+             */
+            if (ex->has_signature &&
+                tmp.has_signature &&
+                !mid_same_signing_key(ex->signing_key, tmp.signing_key)) {
+                printf("[MID] upsert_record: rejected LEFT tombstone, signing key changed\n");
+                fflush(stdout);
+                return false;
+            }
+
+            /*
+             * For tombstones we use >= so that a LEFT tombstone with the
+             * same timestamp as the last ACTIVE record still wins.
+             */
+            if (tmp.timestamp >= ex->timestamp) {
+                bool same_signature =
+                    ex->has_signature &&
+                    tmp.has_signature &&
+                    memcmp(ex->signature, tmp.signature, MID_SIG_SIZE) == 0;
+
+                /*
+                 * If we already have this exact tombstone and it is already
+                 * marked offline, there is nothing to do.
+                 */
+                if (same_signature && ex->connection_status == TOX_CONNECTION_NONE) {
+                    printf("[MID] upsert_record: identical LEFT tombstone already stored\n");
+                    fflush(stdout);
+                    return false;
+                }
+
+                /* 
+                 * Track if this peer is transitioning from unsigned to signed.
+                 * If they were already signed, they are already in the fingerprint set.
+                 */
+                bool gained_signature = !ex->has_signature && tmp.has_signature;
+
+                *ex = tmp;
+                ex->connection_status = TOX_CONNECTION_NONE;
+
+                if (gained_signature) {
+                    printf("[MID] upsert_record: XOR IN tombstone transition. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                    mid_xor_fingerprint(g->roster_fingerprint, ex->identity_key);
+                    printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                }
+
+                printf("[MID] upsert_record: stored signed LEFT tombstone\n");
+                fflush(stdout);
+
+                return true; /* CHANGED */
+            }
+
+            /*
+             * Older tombstone than our current record. Ignore.
+             */
+            return false;
+        }
+
+        /* Insert new tombstone for unknown peer */
+        if (!mid_ensure_capacity(g)) {
+            printf("[MID] upsert_record: failed to ensure capacity for tombstone\n");
+            fflush(stdout);
+            return false;
+        }
+
+        g->records[g->count] = tmp;
+        g->records[g->count].connection_status = TOX_CONNECTION_NONE;
+
+        if (g->records[g->count].has_signature) {
+            printf("[MID] upsert_record: XOR IN new tombstone. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, g->records[g->count].identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        }
+
+        g->count++;
+
+        printf("[MID] upsert_record: inserted new signed LEFT tombstone\n");
+        fflush(stdout);
+
+        return true; /* CHANGED */
+    }
+
+    /**************************************************************************
+     * NORMAL ACTIVE / UNSIGNED / SIGNED PATH
+     *************************************************************************/
+
+    int idx = mid_find_identity(g, tmp.identity_key);
+
+    if (idx < 0) {
+        if (!mid_ensure_capacity(g)) {
+            printf("[MID] upsert_record: failed to ensure capacity\n");
+            fflush(stdout);
+            return false;
+        }
+
+        g->records[g->count] = tmp;
+
+        if (g->records[g->count].status == MID_STATUS_LEFT) {
+            g->records[g->count].connection_status = TOX_CONNECTION_NONE;
+        }
+
+        if (g->records[g->count].has_signature) {
+            printf("[MID] upsert_record: XOR IN new peer. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, g->records[g->count].identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        }
+
+        g->count++;
+
+        printf("[MID] upsert_record: inserted new peer (count=%zu)\n", g->count);
+        fflush(stdout);
+
+        return true; /* CHANGED */
+    }
+
+    MidPeerRecord *existing = &g->records[idx];
+
+    /*
+     * If we already have a signed record for this identity, the signing key
+     * is immutable. Reject records signed by a different key.
+     */
+    if (existing->has_signature &&
+        tmp.has_signature &&
+        !mid_same_signing_key(existing->signing_key, tmp.signing_key)) {
+        printf("[MID] upsert_record: rejected, signing key changed for same identity\n");
+        fflush(stdout);
+        return false;
+    }
+
+    bool replace = false;
+
+    if (tmp.has_signature) {
+        /*
+         * Signed records always replace unsigned records.
+         * Signed records replace older signed records only if the timestamp
+         * is strictly newer.
+         */
+        if (!existing->has_signature || tmp.timestamp > existing->timestamp) {
+            replace = true;
+        }
+    } else {
+        /*
+         * Unsigned records only replace other unsigned records.
+         * They never replace signed records.
+         */
+        if (!existing->has_signature && tmp.timestamp >= existing->timestamp) {
+            replace = true;
+        }
+    }
+
+    bool changed = false;
+
+    if (replace) {
+        printf("[MID] upsert_record: replacing existing record\n");
+        fflush(stdout);
+
+        bool old_had_signature = existing->has_signature;
+        bool new_has_signature = tmp.has_signature;
+
+        Tox_Connection old_conn = existing->connection_status;
+        Tox_Group_Role old_role = existing->role;
+        uint64_t old_last_seen = existing->last_seen;
+
+        /*
+         * If the incoming record does not know the signing key but we already
+         * have it, preserve it. This only matters for unsigned records.
+         */
+        if (mid_key_is_zero(tmp.signing_key) &&
+            !mid_key_is_zero(existing->signing_key)) {
+            memcpy(tmp.signing_key, existing->signing_key, MID_SIGNING_KEY_SIZE);
+        }
+
+        /*
+         * If the incoming signed ACTIVE record has no local connection state,
+         * preserve our previous observation.
+         */
+        if (tmp.status == MID_STATUS_ACTIVE &&
+            tmp.connection_status == TOX_CONNECTION_NONE &&
+            old_conn != TOX_CONNECTION_NONE) {
+            tmp.connection_status = old_conn;
+        }
+
+        /*
+         * LEFT records are never online.
+         */
+        if (tmp.status == MID_STATUS_LEFT) {
+            tmp.connection_status = TOX_CONNECTION_NONE;
+        }
+
+        /*
+         * Role is a local observation. Preserve it unless the caller updates
+         * it through moderation / sync logic.
+         */
+        tmp.role = old_role;
+
+        /*
+         * Preserve the newest last_seen value.
+         */
+        if (old_last_seen > tmp.last_seen) {
+            tmp.last_seen = old_last_seen;
+        }
+
+        *existing = tmp;
+
+        /*
+         * Update fingerprint ONLY if the peer's signature status changed.
+         * If they were signed before, and are signed now, they are already 
+         * in the XOR set, so we do nothing.
+         */
+        if (!old_had_signature && new_has_signature) {
+            printf("[MID] upsert_record: XOR IN peer transition to signed. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, existing->identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        } else if (old_had_signature && !new_has_signature) {
+            printf("[MID] upsert_record: XOR OUT peer transition to unsigned. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, existing->identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        }
+
+        changed = true;
+    } else {
+        printf("[MID] upsert_record: keeping existing record\n");
+        fflush(stdout);
+    }
+
+    /**************************************************************************
+     * LOCAL ONLINE STATE UPDATE
+     *
+     * This updates connection_status / last_seen only.
+     * It never modifies signed fields.
+     *
+     * Important:
+     * Do not allow connection updates to resurrect a LEFT tombstone.
+     *************************************************************************/
+    if (in->connection_status != TOX_CONNECTION_NONE &&
+        in->status == MID_STATUS_ACTIVE &&
+        existing->status == MID_STATUS_ACTIVE) {
+
+        if (existing->connection_status != in->connection_status) {
+            existing->connection_status = in->connection_status;
+            changed = true;
+        }
+
+        if (in->last_seen >= existing->last_seen) {
+            if (in->last_seen > existing->last_seen) {
+                existing->last_seen = in->last_seen;
+
+                /*
+                 * If you do not want last_seen-only changes to trigger the
+                 * peer-list-changed callback, remove the next line.
+                 */
+                changed = true;
+            }
+        }
+    }
+
+    return changed;
+}
+
+/******************************************************************************
+Packet sending
+******************************************************************************/
+
+static bool mid_send_custom(MidState *s,
+                            const Tox *tox,
+                            const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                            bool lossless,
+                            const uint8_t *data,
+                            size_t length)
+{
+    printf("[MID] send_custom: sending %zu bytes (lossless=%d)\n", length, lossless); fflush(stdout);
+
+    if (tox == NULL || data == NULL || length == 0) {
+        return false;
+    }
+
+    if (length > MID_MAX_PACKET_SIZE) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) {
+        printf("[MID] send_custom: failed to resolve chat_id to group_number\n"); fflush(stdout);
+        return false;
+    }
+
+    Tox_Err_Group_Send_Custom_Packet err;
+    bool ok = tox_group_send_custom_packet(tox,
+                                           group_number,
+                                           lossless,
+                                           data,
+                                           length,
+                                           &err);
+
+    printf("[MID] send_custom:err=%d ok=%d group_number=%d\n", (int)err, (int)ok, (int)group_number); fflush(stdout);
+
+    if (!ok) {
+        printf("[MID] send_custom: tox_group_send_custom_packet failed (err=%d)\n", err); fflush(stdout);
+    } else {
+        if (s != NULL) {
+            s->sent_bytes += length;
+        }
+    }
+    return ok;
+}
+
+static bool mid_send_presence_record(MidState *s,
+                                     MidGroupState *g,
+                                     const Tox *tox,
+                                     const MidPeerRecord *r)
+{
+    if (g == NULL || tox == NULL || r == NULL) {
+        return false;
+    }
+
+    if (!r->has_signature) {
+        return false;
+    }
+
+    uint8_t body[MID_MAX_BODY_SIZE];
+    size_t body_len = 0;
+    if (!mid_pack_record_body(body, sizeof(body), r, &body_len)) {
+        return false;
+    }
+
+    size_t packet_len = MID_HEADER_SIZE + MID_SIG_SIZE + body_len;
+    if (packet_len > MID_MAX_PACKET_SIZE) {
+        return false;
+    }
+
+    uint8_t packet[MID_MAX_PACKET_SIZE];
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_PRESENCE;
+
+    size_t o = MID_HEADER_SIZE;
+    memcpy(packet + o, r->signature, MID_SIG_SIZE);
+    o += MID_SIG_SIZE;
+    memcpy(packet + o, body, body_len);
+    o += body_len;
+
+    return mid_send_custom(s, tox, g->chat_id, true, packet, o);
+}
+
+/* FIX 3: Lightweight Heartbeat Sending */
+static bool mid_send_heartbeat_record(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    if (!g || !tox || !g->have_keys) return false;
+
+    uint8_t body[MID_HEARTBEAT_BODY_SIZE];
+    size_t o = 0;
+    body[o++] = MID_STATUS_ACTIVE;
+    mid_put_u64_be(body + o, mid_now_or_time(0));
+    o += 8;
+    memcpy(body + o, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+    o += MID_IDENTITY_KEY_SIZE;
+
+    uint8_t sig[MID_SIG_SIZE];
+    unsigned long long sig_len = 0;
+    if (crypto_sign_detached(sig, &sig_len, body, o, g->self_secret_signing_key) != 0) return false;
+
+    uint8_t packet[128];
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_HEARTBEAT;
+
+    memcpy(packet + MID_HEADER_SIZE, sig, MID_SIG_SIZE);
+    memcpy(packet + MID_HEADER_SIZE + MID_SIG_SIZE, body, o);
+
+    return mid_send_custom(s, tox, g->chat_id, true, packet, MID_HEADER_SIZE + MID_SIG_SIZE + o);
+}
+
+static bool mid_send_roster_request_group(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    printf("[MID] send_roster_request: sending request\n"); fflush(stdout);
+
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    uint8_t packet[MID_HEADER_SIZE];
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_ROSTER_REQUEST;
+
+    return mid_send_custom(s, tox, g->chat_id, true, packet, sizeof(packet));
+}
+
+static bool mid_send_roster_group(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    printf("[MID] send_roster: syncing %zu records\n", g->count); fflush(stdout);
+    if (g == NULL || tox == NULL) return false;
+
+    printf("[MID] send_roster: Injecting FP[0..3]=%02X%02X%02X%02X into batch header\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+
+    uint8_t packet[MID_MAX_PACKET_SIZE];
+    size_t p_idx = 0;
+    
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_ROSTER_BATCH;
+    p_idx = MID_HEADER_SIZE;
+    
+    // Define sizes dynamically based on actual types/arrays
+    const size_t fp_size = sizeof(g->roster_fingerprint);
+    const size_t count_size = sizeof(uint16_t);
+    
+    // Inject Set Fingerprint
+    memcpy(packet + p_idx, g->roster_fingerprint, fp_size);
+    p_idx += fp_size;
+    
+    size_t count_idx = p_idx;
+    p_idx += count_size;
+    uint16_t count = 0;
+    bool ok = true;
+    
+    // Header + Fingerprint + Count
+    size_t batch_header_size = MID_HEADER_SIZE + fp_size + count_size;
+
+    for (size_t i = 0; i < g->count; i++) {
+        if (!g->records[i].has_signature) continue;
+        
+        uint8_t body[MID_MAX_BODY_SIZE];
+        size_t body_len = 0;
+        if (!mid_pack_record_body(body, sizeof(body), &g->records[i], &body_len)) continue;
+        
+        // Signature + body_len prefix + body
+        size_t needed = MID_SIG_SIZE + count_size + body_len;
+
+        if (p_idx + needed > MID_MAX_PACKET_SIZE) {
+            mid_put_u16_be(packet + count_idx, count);
+            if (!mid_send_custom(s, tox, g->chat_id, true, packet, p_idx)) ok = false;
+            
+            p_idx = batch_header_size; 
+            printf("[MID] send_roster: Re-injecting FP[0..3]=%02X%02X%02X%02X into next batch packet\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            
+            // Re-inject full header for next packet
+            memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+            packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+            packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_ROSTER_BATCH;
+            memcpy(packet + MID_HEADER_SIZE, g->roster_fingerprint, fp_size);
+            
+            count_idx = MID_HEADER_SIZE + fp_size;
+            count = 0;
+        }
+        
+        memcpy(packet + p_idx, g->records[i].signature, MID_SIG_SIZE);
+        p_idx += MID_SIG_SIZE;
+        mid_put_u16_be(packet + p_idx, (uint16_t)body_len);
+        p_idx += count_size;
+        memcpy(packet + p_idx, body, body_len);
+        p_idx += body_len;
+        count++;
+    }
+    
+    if (count > 0) {
+        mid_put_u16_be(packet + count_idx, count);
+        if (!mid_send_custom(s, tox, g->chat_id, true, packet, p_idx)) ok = false;
+    }
+    
+    return ok;
+}
+
+/******************************************************************************
+Online state sync
+Returns true if any peer's online status changed.
+******************************************************************************/
+
+/*
+Stamps the FOUNDER role on the roster entry whose identity_key matches
+the group founder's public key obtained from Toxcore's shared state.
+
+This works regardless of whether the founder is currently online, because
+the founder key is part of the group's cryptographic shared state, not
+the live peer list.
+*/
+static void mid_apply_founder_role(MidGroupState *g, const Tox *tox)
+{
+    if (g == NULL || tox == NULL) {
+        return;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) {
+        return;
+    }
+
+    uint8_t founder_identity[MID_IDENTITY_KEY_SIZE];
+    Tox_Err_Group_State_Queries err;
+
+    if (!tox_group_get_founder_public_key(tox, group_number, founder_identity, &err)) {
+        return;
+    }
+
+    if (mid_key_is_zero(founder_identity)) {
+        return;
+    }
+
+    int idx = mid_find_identity(g, founder_identity);
+    if (idx < 0) {
+        return;
+    }
+
+    if (g->records[idx].role != TOX_GROUP_ROLE_FOUNDER) {
+        printf("[MID] apply_founder_role: stamping FOUNDER role on peer %zu\n", (size_t)idx);
+        fflush(stdout);
+        g->records[idx].role = TOX_GROUP_ROLE_FOUNDER;
+    }
+}
+
+static bool mid_sync_online_state_group(MidGroupState *g, const Tox *tox, uint64_t now)
+{
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    now = mid_now_or_time(now);
+    bool changed = false;
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    /* Ensure the founder role is always correctly stamped */
+    Tox_Group_Role old_founder_role = TOX_GROUP_ROLE_USER;
+    int founder_idx = -1;
+    uint8_t founder_identity[MID_IDENTITY_KEY_SIZE];
+    Tox_Err_Group_State_Queries founder_err;
+
+    if (tox_group_get_founder_public_key(tox, group_number, founder_identity, &founder_err)) {
+        founder_idx = mid_find_identity(g, founder_identity);
+        if (founder_idx >= 0) {
+            old_founder_role = g->records[founder_idx].role;
+        }
+    }
+
+    mid_apply_founder_role(g, tox);
+
+    if (founder_idx >= 0 && g->records[founder_idx].role != old_founder_role) {
+        changed = true;
+    }
+
+    for (size_t i = 0; i < g->count; i++) {
+        MidPeerRecord *e = &g->records[i];
+        if (e->connection_status == TOX_CONNECTION_NONE) {
+            continue;
+        }
+
+        Tox_Err_Group_Peer_Query err;
+        uint32_t peer_id = tox_group_peer_by_public_key(tox, group_number, e->identity_key, &err);
+
+        if (err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+            printf("[MID] sync_online_state: peer %zu is no longer in Toxcore, marking offline\n", i); fflush(stdout);
+            if (e->connection_status != TOX_CONNECTION_NONE) {
+                e->connection_status = TOX_CONNECTION_NONE;
+                changed = true;
+            }
+            if (now >= e->last_seen) {
+                e->last_seen = now;
+            }
+        } else {
+            Tox_Err_Group_Peer_Query conn_err;
+            Tox_Connection conn = tox_group_peer_get_connection_status(tox, group_number, peer_id, &conn_err);
+            if (conn_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                if (e->connection_status != conn) {
+                    e->connection_status = conn;
+                    changed = true;
+                }
+                if (conn != TOX_CONNECTION_NONE && now >= e->last_seen) {
+                    e->last_seen = now;
+                }
+            }
+
+            Tox_Err_Group_Peer_Query role_err;
+            Tox_Group_Role role = tox_group_peer_get_role(tox, group_number, peer_id, &role_err);
+            if (role_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                if (e->role != role) {
+                    e->role = role;
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    return changed;
+}
+
+/******************************************************************************
+Key setup
+******************************************************************************/
+
+static bool mid_set_self_keys(MidGroupState *g,
+                              const uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                              const uint8_t signing_key[MID_SIGNING_KEY_SIZE],
+                              const uint8_t secret_key[MID_SIGNING_SECRET_KEY_SIZE])
+{
+    printf("[MID] set_self_keys: setting keys\n"); fflush(stdout);
+
+    if (g == NULL ||
+        identity_key == NULL ||
+        signing_key == NULL ||
+        secret_key == NULL) {
+        return false;
+    }
+
+    if (mid_key_is_zero(identity_key) || mid_key_is_zero(signing_key)) {
+        return false;
+    }
+
+    uint8_t derived_signing_key[MID_SIGNING_KEY_SIZE];
+    if (crypto_sign_ed25519_sk_to_pk(derived_signing_key, secret_key) != 0) {
+        printf("[MID] set_self_keys: sk_to_pk failed\n"); fflush(stdout);
+        return false;
+    }
+
+    if (!mid_same_signing_key(derived_signing_key, signing_key)) {
+        printf("[MID] set_self_keys: derived signing key mismatch\n"); fflush(stdout);
+        return false;
+    }
+
+    if (!mid_valid_key_binding(identity_key, signing_key)) {
+        printf("[MID] set_self_keys: invalid key binding\n"); fflush(stdout);
+        return false;
+    }
+
+    memcpy(g->self_identity_key, identity_key, MID_IDENTITY_KEY_SIZE);
+    memcpy(g->self_signing_key, signing_key, MID_SIGNING_KEY_SIZE);
+    memcpy(g->self_secret_signing_key, secret_key, MID_SIGNING_SECRET_KEY_SIZE);
+    g->have_keys = true;
+
+    printf("[MID] set_self_keys: keys set successfully\n"); fflush(stdout);
+    return true;
+}
+
+static bool mid_init_self_from_tox(MidGroupState *g, const Tox *tox)
+{
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    if (g->have_keys) {
+        return true;
+    }
+
+    printf("[MID] init_self_from_tox: fetching keys from Toxcore\n"); fflush(stdout);
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) {
+        return false;
+    }
+
+    uint8_t identity[MID_IDENTITY_KEY_SIZE];
+    uint8_t signing[MID_SIGNING_KEY_SIZE];
+    uint8_t sk[MID_SIGNING_SECRET_KEY_SIZE];
+
+    Tox_Err_Group_Self_Query err;
+
+    if (!tox_group_self_get_public_key(tox, group_number, identity, &err)) {
+        printf("[MID] init_self_from_tox: get_public_key failed\n"); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] init_self_from_tox: got identity key\n");
+    fflush(stdout);
+
+    /*
+     * We now have the current Toxcore identity in the local variable
+     * "identity".
+     *
+     * g->self_identity_key may contain the public identity that was loaded
+     * from the middleware save file.
+     *
+     * This comparison must happen BEFORE mid_set_self_keys(), because
+     * mid_set_self_keys() will overwrite g->self_identity_key.
+     */
+    if (!mid_key_is_zero(g->self_identity_key) &&
+        !mid_same_identity(identity, g->self_identity_key)) {
+
+        printf("[MID] init_self_from_tox: Toxcore identity differs from saved middleware identity\n"); fflush(stdout);
+
+        /*
+         * Choose your policy here.
+         *
+         * Option 1: Strict mode.
+         *
+         * If the saved middleware state must belong to exactly the same
+         * identity that Toxcore currently has, fail here.
+         *
+         * return false;
+         *
+         *
+         * Option 2: Adopt the current Toxcore identity.
+         *
+         * Toxcore is the authority for the current group identity.
+         * Continue and let mid_set_self_keys() install the keys reported
+         * by Toxcore.
+         *
+         * This is usually the more robust choice.
+         */
+    }
+
+    if (!tox_group_self_get_signing_public_key(tox, group_number, signing, &err)) {
+        printf("[MID] init_self_from_tox: get_signing_public_key failed\n"); fflush(stdout);
+        return false;
+    }
+    printf("[MID] init_self_from_tox: got signing public key\n"); fflush(stdout);
+
+    if (!tox_group_self_get_signing_secret_key(tox, group_number, sk, &err)) {
+        printf("[MID] init_self_from_tox: get_signing_secret_key failed\n"); fflush(stdout);
+        return false;
+    }
+    printf("[MID] init_self_from_tox: got signing secret key\n"); fflush(stdout);
+
+    bool ok = mid_set_self_keys(g, identity, signing, sk);
+    sodium_memzero(sk, sizeof(sk));
+    return ok;
+}
+
+/******************************************************************************
+Tox peer key helpers
+******************************************************************************/
+
+static bool mid_get_peer_keys(const Tox *tox,
+                              const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                              uint32_t peer_id,
+                              uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                              uint8_t signing_key[MID_SIGNING_KEY_SIZE])
+{
+    printf("[MID] get_peer_keys: fetching keys for peer %u\n", peer_id); fflush(stdout);
+
+    if (tox == NULL || identity_key == NULL || signing_key == NULL) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    Tox_Err_Group_Peer_Query err;
+
+    if (!tox_group_peer_get_public_key(tox, group_number, peer_id,
+                                       identity_key, &err)) {
+        printf("[MID] get_peer_keys: get_public_key failed for peer %u\n", peer_id); fflush(stdout);
+        return false;
+    }
+
+    if (!tox_group_peer_get_signing_public_key(tox, group_number, peer_id,
+                                               signing_key, &err)) {
+        printf("[MID] get_peer_keys: get_signing_public_key failed for peer %u\n", peer_id); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] get_peer_keys: got both keys for peer %u\n", peer_id); fflush(stdout);
+    return mid_valid_key_binding(identity_key, signing_key);
+}
+
+/******************************************************************************
+Internal group operations
+******************************************************************************/
+
+static bool mid_announce_self_group(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    printf("[MID] announce_self: announcing ACTIVE\n"); fflush(stdout);
+
+    if (g == NULL) {
+        return false;
+    }
+
+    if (!g->have_keys) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    MidPeerRecord r;
+    memset(&r, 0, sizeof(r));
+    memcpy(r.identity_key, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+    memcpy(r.signing_key, g->self_signing_key, MID_SIGNING_KEY_SIZE);
+    r.status = MID_STATUS_ACTIVE;
+    r.timestamp = mid_now_or_time(0);
+
+    Tox_Err_Group_Peer_Query conn_err;
+    Tox_Connection conn = tox_group_peer_get_connection_status(tox, group_number, 0, &conn_err);
+    if (conn_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+        r.connection_status = conn;
+    } else {
+        r.connection_status = TOX_CONNECTION_NONE;
+    }
+
+    Tox_Err_Group_Self_Query self_role_err;
+    r.role = tox_group_self_get_role(tox, group_number, &self_role_err);
+    if (self_role_err != TOX_ERR_GROUP_SELF_QUERY_OK) {
+        r.role = TOX_GROUP_ROLE_USER;
+    }
+
+    /*
+     * Copy self nickname into the record.
+     *
+     * self_nickname_len was already bounded to MID_MAX_NICK_SIZE when it was
+     * stored in mid_on_group_self_join, but we add a defensive bounds check
+     * here as well to guard against any corruption.
+     */
+    if (g->self_nickname_len > 0) {
+        uint16_t nick_copy = g->self_nickname_len;
+        if (nick_copy > MID_MAX_NICK_SIZE) {
+            nick_copy = MID_MAX_NICK_SIZE;
+        }
+        memcpy(r.nickname, g->self_nickname, nick_copy);
+        r.nickname_len = nick_copy;
+    }
+
+    if (!mid_sign_record(g, &r)) {
+        return false;
+    }
+
+    r.last_seen = r.timestamp;
+
+    bool changed = mid_upsert_record(g, &r);
+    g->self_active = true;
+    g->last_announce = r.timestamp;
+
+    mid_send_presence_record(s, g, tox, &r);
+    return changed;
+}
+
+static bool mid_on_peer_online_keys(MidGroupState *g,
+                                    const uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                                    const uint8_t signing_key[MID_SIGNING_KEY_SIZE],
+                                    Tox_Connection conn,
+                                    Tox_Group_Role role,
+                                    uint64_t now)
+{
+    printf("[MID] on_peer_online_keys: peer observed online\n"); fflush(stdout);
+
+    if (g == NULL || identity_key == NULL || mid_key_is_zero(identity_key)) {
+        return false;
+    }
+
+    now = mid_now_or_time(now);
+
+    bool have_signing = (signing_key != NULL &&
+                         !mid_key_is_zero(signing_key) &&
+                         mid_valid_key_binding(identity_key, signing_key));
+
+    int idx = mid_find_identity(g, identity_key);
+
+    if (idx < 0) {
+        if (!mid_ensure_capacity(g)) {
+            return false;
+        }
+        MidPeerRecord r;
+        memset(&r, 0, sizeof(r));
+        memcpy(r.identity_key, identity_key, MID_IDENTITY_KEY_SIZE);
+        if (have_signing) {
+            memcpy(r.signing_key, signing_key, MID_SIGNING_KEY_SIZE);
+        }
+        r.status = MID_STATUS_ACTIVE;
+        r.timestamp = now;
+        r.connection_status = conn;
+        r.role = role;
+        r.last_seen = now;
+        g->records[g->count] = r;
+        g->count++;
+        return true; /* CHANGED */
+    }
+
+    MidPeerRecord *e = &g->records[idx];
+    bool changed = false;
+
+    if (e->connection_status != conn) {
+        e->connection_status = conn;
+        changed = true;
+    }
+
+    if (e->role != role) {
+        e->role = role;
+        changed = true;
+    }
+
+    if (conn != TOX_CONNECTION_NONE && now >= e->last_seen) {
+        e->last_seen = now;
+        changed = true;
+    }
+
+    if (!e->has_signature) {
+        e->status = MID_STATUS_ACTIVE;
+        if (now >= e->timestamp) {
+            e->timestamp = now;
+            changed = true;
+        }
+        if (have_signing) {
+            memcpy(e->signing_key, signing_key, MID_SIGNING_KEY_SIZE);
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
+static bool mid_refresh_peer_name_group(MidGroupState *g, const Tox *tox, uint32_t peer_id)
+{
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    uint8_t identity[MID_IDENTITY_KEY_SIZE];
+    Tox_Err_Group_Peer_Query err;
+
+    if (!tox_group_peer_get_public_key(tox, group_number, peer_id, identity, &err)) {
+        return false;
+    }
+
+    int idx = mid_find_identity(g, identity);
+    if (idx < 0) {
+        return false;
+    }
+
+    size_t name_size = tox_group_peer_get_name_size(tox, group_number, peer_id, &err);
+    if (err != TOX_ERR_GROUP_PEER_QUERY_OK || name_size == 0) {
+        return false;
+    }
+
+    /*
+     * SAFETY: tox_group_peer_get_name() writes exactly name_size bytes into
+     * the output buffer. We must NOT truncate name_size before calling it,
+     * because the buffer must be large enough for the full write.
+     *
+     * We heap-allocate a buffer of exactly name_size bytes to guarantee no
+     * overflow even if Toxcore returns a name larger than MID_MAX_NICK_SIZE
+     * (e.g. from a patched or broken Toxcore).
+     */
+    uint8_t *name = (uint8_t *)malloc(name_size);
+    if (name == NULL) {
+        return false;
+    }
+
+    if (!tox_group_peer_get_name(tox, group_number, peer_id, name, &err)) {
+        free(name);
+        return false;
+    }
+
+    MidPeerRecord *e = &g->records[idx];
+    bool changed = false;
+
+    if (!e->has_signature) {
+        size_t copy_len = name_size;
+        if (copy_len > MID_MAX_NICK_SIZE) {
+            copy_len = MID_MAX_NICK_SIZE;
+        }
+
+        /* Only update if the name actually changed */
+        if (e->nickname_len != copy_len || memcmp(e->nickname, name, copy_len) != 0) {
+            /*
+             * Zero-fill the destination first so no stale bytes remain past
+             * the end of the (possibly truncated) nickname.
+             *
+             * The nickname is treated as opaque binary. We do NOT assume
+             * valid UTF-8, printable ASCII, or NUL termination.
+             */
+            memset(e->nickname, 0, MID_MAX_NICK_SIZE);
+            if (copy_len > 0) {
+                memcpy(e->nickname, name, copy_len);
+            }
+            e->nickname_len = (uint16_t)copy_len;
+            changed = true;
+        }
+    }
+
+    free(name);
+    return changed;
+}
+
+static bool mid_on_custom_packet_group(MidState *s,
+                                       MidGroupState *g,
+                                       const Tox *tox,
+                                       uint32_t peer_id,
+                                       const uint8_t *data,
+                                       size_t length,
+                                       uint64_t now)
+{
+    printf("[MID] on_custom_packet: received %zu bytes from peer %u\n",
+           length, peer_id);
+    fflush(stdout);
+
+    if (g == NULL || data == NULL || length < MID_HEADER_SIZE) {
+        return false;
+    }
+
+    if (memcmp(data, MID_MAGIC, MID_MAGIC_BYTES_TOTAL) != 0 ||
+        data[MID_MAGIC_BYTES_TOTAL] != MID_PROTOCOL_VERSION) {
+        return false;
+    }
+
+    uint8_t type = data[MID_MAGIC_BYTES_TOTAL + 1];
+    const uint8_t *payload = data + MID_HEADER_SIZE;
+    size_t payload_len = length - MID_HEADER_SIZE;
+
+    now = mid_now_or_time(now);
+
+    uint8_t sender_identity[MID_IDENTITY_KEY_SIZE];
+    uint8_t sender_signing[MID_SIGNING_KEY_SIZE];
+    bool sender_has_keys = false;
+
+    if (tox != NULL && peer_id != UINT32_MAX) {
+        sender_has_keys = mid_get_peer_keys(tox,
+                                            g->chat_id,
+                                            peer_id,
+                                            sender_identity,
+                                            sender_signing);
+    }
+
+    bool changed = false;
+
+    /**************************************************************************
+     * FULL SIGNED PRESENCE RECORD
+     *
+     * This is a full signed record containing status, timestamp, nickname,
+     * identity key, and signing key.
+     *
+     * It does NOT suppress pending roster responses, because one presence
+     * record does not prove that the sender has the full roster.
+     *************************************************************************/
+    if (type == MID_MSG_PRESENCE) {
+        printf("[MID] on_custom_packet: processing PRESENCE message\n");
+        fflush(stdout);
+
+        if (payload_len < MID_SIG_SIZE) {
+            return false;
+        }
+
+        size_t body_len = payload_len - MID_SIG_SIZE;
+
+        if (body_len > MID_MAX_BODY_SIZE) {
+            return false;
+        }
+
+        MidPeerRecord r;
+        memset(&r, 0, sizeof(r));
+
+        if (!mid_unpack_record_body(&r, payload + MID_SIG_SIZE, body_len)) {
+            return false;
+        }
+
+        memcpy(r.signature, payload, MID_SIG_SIZE);
+        r.has_signature = true;
+
+        if (!mid_verify_record(&r)) {
+            printf("[MID] on_custom_packet: PRESENCE verification failed\n");
+            fflush(stdout);
+            return false;
+        }
+
+        printf("[MID] on_custom_packet: PRESENCE verified, upserting\n");
+        fflush(stdout);
+
+        /* Never process our own signed presence echoed back to us. */
+        if (g->have_keys && mid_same_identity(r.identity_key, g->self_identity_key)) {
+            return false;
+        }
+
+        bool sender_is_subject = false;
+
+        if (sender_has_keys && mid_same_identity(sender_identity, r.identity_key)) {
+            sender_is_subject = true;
+
+            /*
+             * If the packet came directly from the subject, the signing key
+             * observed from Toxcore must match the signing key in the record.
+             */
+            if (!mid_same_signing_key(sender_signing, r.signing_key)) {
+                return false;
+            }
+        }
+
+        if (sender_is_subject && r.status == MID_STATUS_ACTIVE) {
+            Tox_Err_Group_Peer_Query conn_err;
+            Tox_Connection conn = TOX_CONNECTION_NONE;
+
+            uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+            if (group_number != UINT32_MAX && tox != NULL && peer_id != UINT32_MAX) {
+                conn = tox_group_peer_get_connection_status(tox,
+                                                            group_number,
+                                                            peer_id,
+                                                            &conn_err);
+                if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                    conn = TOX_CONNECTION_NONE;
+                }
+            }
+
+            /*
+             * They just sent a packet, so they are online from our point of
+             * view even if Toxcore has not updated the connection state yet.
+             */
+            if (conn == TOX_CONNECTION_NONE) {
+                conn = TOX_CONNECTION_TCP;
+            }
+
+            r.connection_status = conn;
+            r.last_seen = now;
+        } else {
+            /*
+             * Forwarded / relayed presence, or LEFT tombstone.
+             * Do not mark the peer online.
+             */
+            r.connection_status = TOX_CONNECTION_NONE;
+            /* Anchor last_seen so we can purge them if they never come online */
+            if (r.last_seen == 0) r.last_seen = now;
+        }
+
+        if (mid_upsert_record(g, &r)) {
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    /**************************************************************************
+     * LIGHTWEIGHT HEARTBEAT
+     *
+     * Body:
+     *   status       1 byte
+     *   timestamp    8 bytes
+     *   identity_key 32 bytes
+     *
+     * Signature:
+     *   detached Ed25519 signature over the 41-byte body.
+     *
+     * Heartbeats are used only for liveness / connection state.
+     *
+     * IMPORTANT:
+     * A heartbeat must NOT modify fields belonging to a stored full signed
+     * record, otherwise the stored signature would become invalid.
+     * Therefore, if we already have a signed full record, the heartbeat only
+     * updates connection_status, role, and last_seen.
+     *
+     * Heartbeats do NOT suppress roster responses.
+     *************************************************************************/
+    if (type == MID_MSG_HEARTBEAT) {
+        printf("[MID] on_custom_packet: processing HEARTBEAT message\n");
+        fflush(stdout);
+
+        const size_t hb_body_len = MID_HEARTBEAT_BODY_SIZE;
+
+        if (payload_len < MID_SIG_SIZE + hb_body_len) {
+            return false;
+        }
+
+        const uint8_t *sig = payload;
+        const uint8_t *body = payload + MID_SIG_SIZE;
+
+        uint8_t status = body[0];
+
+        if (status != MID_STATUS_ACTIVE && status != MID_STATUS_LEFT) {
+            return false;
+        }
+
+        uint64_t ts = mid_get_u64_be(body + 1);
+
+        uint8_t hb_identity[MID_IDENTITY_KEY_SIZE];
+        memcpy(hb_identity, body + 9, MID_IDENTITY_KEY_SIZE);
+
+        /* Ignore our own heartbeat if it is echoed back. */
+        if (g->have_keys && mid_same_identity(hb_identity, g->self_identity_key)) {
+            return false;
+        }
+
+        int idx = mid_find_identity(g, hb_identity);
+        if (idx < 0) {
+            /*
+             * We do not know this peer yet.
+             * A heartbeat alone is not enough to create a persistent roster
+             * entry; wait for a full signed PRESENCE record.
+             */
+            return false;
+        }
+
+        MidPeerRecord *e = &g->records[idx];
+
+        bool sender_is_subject = false;
+        if (sender_has_keys && mid_same_identity(sender_identity, hb_identity)) {
+            sender_is_subject = true;
+        }
+
+        uint8_t verify_key[MID_SIGNING_KEY_SIZE];
+        bool have_verify_key = false;
+
+        /*
+         * Prefer the signing key already stored in the roster record.
+         */
+        if (!mid_key_is_zero(e->signing_key) &&
+            mid_valid_key_binding(e->identity_key, e->signing_key)) {
+            memcpy(verify_key, e->signing_key, MID_SIGNING_KEY_SIZE);
+            have_verify_key = true;
+        }
+        /*
+         * If we do not have a stored signing key yet, but the packet comes
+         * directly from the subject, use the signing key observed from
+         * Toxcore.
+         */
+        else if (sender_is_subject &&
+                 mid_valid_key_binding(sender_identity, sender_signing)) {
+            memcpy(verify_key, sender_signing, MID_SIGNING_KEY_SIZE);
+            have_verify_key = true;
+        }
+
+        if (!have_verify_key) {
+            return false;
+        }
+
+        if (crypto_sign_verify_detached(sig,
+                                        body,
+                                        hb_body_len,
+                                        verify_key) != 0) {
+            printf("[MID] on_custom_packet: HEARTBEAT signature invalid\n");
+            fflush(stdout);
+            return false;
+        }
+
+        printf("[MID] on_custom_packet: HEARTBEAT signature valid\n");
+        fflush(stdout);
+
+        /*
+         * Heartbeats are intended as ACTIVE keep-alives.
+         * A LEFT state should be propagated by a full signed LEFT tombstone,
+         * not by a lightweight heartbeat.
+         */
+        if (status != MID_STATUS_ACTIVE) {
+            return changed;
+        }
+
+        /*
+         * If we only have an unsigned local observation, it is safe to update
+         * the unsigned logical fields.
+         */
+        if (!e->has_signature) {
+            if (mid_key_is_zero(e->signing_key)) {
+                memcpy(e->signing_key, verify_key, MID_SIGNING_KEY_SIZE);
+                changed = true;
+            }
+
+            if (e->status != MID_STATUS_ACTIVE) {
+                e->status = MID_STATUS_ACTIVE;
+                changed = true;
+            }
+
+            if (ts > e->timestamp) {
+                e->timestamp = ts;
+                changed = true;
+            }
+        } else {
+            /*
+             * If we have a signed LEFT tombstone, do not resurrect the peer
+             * from a heartbeat alone. Require a full signed ACTIVE presence.
+             */
+            if (e->status == MID_STATUS_LEFT) {
+                return changed;
+            }
+        }
+
+        /*
+         * Only the direct sender can be considered online because of this
+         * heartbeat. A relayed heartbeat does not prove current connectivity.
+         */
+        if (sender_is_subject) {
+            uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+            if (group_number == UINT32_MAX) return changed;
+
+            Tox_Err_Group_Peer_Query conn_err;
+            Tox_Connection conn = tox_group_peer_get_connection_status(tox,
+                                                                       group_number,
+                                                                       peer_id,
+                                                                       &conn_err);
+
+            if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                conn = TOX_CONNECTION_NONE;
+            }
+
+            if (conn == TOX_CONNECTION_NONE) {
+                conn = TOX_CONNECTION_TCP;
+            }
+
+            if (e->connection_status != conn) {
+                e->connection_status = conn;
+                changed = true;
+            }
+
+            Tox_Err_Group_Peer_Query role_err;
+            Tox_Group_Role role = tox_group_peer_get_role(tox,
+                                                          group_number,
+                                                          peer_id,
+                                                          &role_err);
+
+            if (role_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                if (e->role != role) {
+                    e->role = role;
+                    changed = true;
+                }
+            }
+
+            if (now >= e->last_seen) {
+                e->last_seen = now;
+                /*
+                 * Intentionally not setting changed=true only for last_seen.
+                 * This avoids excessive peer-list-changed callbacks when only
+                 * the last-seen timestamp moves forward.
+                 */
+            }
+        }
+
+        return changed;
+    }
+
+    /**************************************************************************
+     * BATCHED ROSTER RESPONSE
+     *
+     * Payload layout:
+     *   fingerprint  32 bytes
+     *   count         2 bytes
+     *   records...
+     *
+     * Each record:
+     *   signature    64 bytes
+     *   body_len      2 bytes
+     *   body          body_len bytes
+     *
+     * Suppression rule:
+     *
+     * We cancel our own pending roster response ONLY if the batch is complete
+     * and the sender's roster fingerprint exactly matches ours.
+     *
+     * This prevents:
+     *   - a partial peer list from suppressing a fuller list
+     *   - a different set of the same size from suppressing another set
+     *   - stale state from suppressing newer state if the fingerprint includes
+     *     record signatures / versions
+     *************************************************************************/
+    if (type == MID_MSG_ROSTER_BATCH) {
+        printf("[MID] on_custom_packet: processing ROSTER_BATCH message\n");
+        fflush(stdout);
+
+        /* Minimum: MID_IDENTITY_KEY_SIZE fingerprint + 2-byte record count */
+        if (payload_len < MID_IDENTITY_KEY_SIZE + sizeof(uint16_t)) {
+            return false;
+        }
+
+        uint8_t sender_fp[MID_IDENTITY_KEY_SIZE];
+        memcpy(sender_fp, payload, MID_IDENTITY_KEY_SIZE);
+
+        uint16_t record_count = mid_get_u16_be(payload + MID_IDENTITY_KEY_SIZE);
+        size_t p_idx = MID_IDENTITY_KEY_SIZE + sizeof(uint16_t);
+
+        bool batch_complete = true;
+
+        for (uint16_t i = 0; i < record_count; i++) {
+            if (p_idx + MID_SIG_SIZE + sizeof(uint16_t) > payload_len) {
+                batch_complete = false;
+                break;
+            }
+
+            const uint8_t *sig = payload + p_idx;
+            p_idx += MID_SIG_SIZE;
+
+            uint16_t body_len = mid_get_u16_be(payload + p_idx);
+            p_idx += sizeof(uint16_t);
+
+            if (p_idx + body_len > payload_len) {
+                batch_complete = false;
+                break;
+            }
+
+            /*
+             * Defensive limit. The current protocol body cannot exceed
+             * MID_MAX_BODY_SIZE.
+             */
+            if (body_len > MID_MAX_BODY_SIZE) {
+                p_idx += body_len;
+                continue;
+            }
+
+            MidPeerRecord r;
+            memset(&r, 0, sizeof(r));
+
+            if (mid_unpack_record_body(&r, payload + p_idx, body_len)) {
+                memcpy(r.signature, sig, MID_SIG_SIZE);
+                r.has_signature = true;
+
+                if (mid_verify_record(&r)) {
+                    /* Ignore our own record if it is echoed back. */
+                    if (!(g->have_keys &&
+                          mid_same_identity(r.identity_key, g->self_identity_key))) {
+
+                        bool sender_is_subject = false;
+
+                        if (sender_has_keys &&
+                            mid_same_identity(sender_identity, r.identity_key)) {
+                            sender_is_subject = true;
+                        }
+
+                        /*
+                         * If the packet sender claims to be the subject, their
+                         * Toxcore-observed signing key must match the record.
+                         */
+                        if (sender_is_subject &&
+                            !mid_same_signing_key(sender_signing, r.signing_key)) {
+                            sender_is_subject = false;
+                        }
+
+                        if (sender_is_subject && r.status == MID_STATUS_ACTIVE) {
+                            uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+                            Tox_Connection conn = TOX_CONNECTION_NONE;
+                            Tox_Group_Role role = TOX_GROUP_ROLE_USER;
+
+                            if (group_number != UINT32_MAX && tox != NULL && peer_id != UINT32_MAX) {
+                                Tox_Err_Group_Peer_Query conn_err;
+                                conn = tox_group_peer_get_connection_status(tox,
+                                                                            group_number,
+                                                                            peer_id,
+                                                                            &conn_err);
+
+                                if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                                    conn = TOX_CONNECTION_NONE;
+                                }
+
+                                if (conn == TOX_CONNECTION_NONE) {
+                                    conn = TOX_CONNECTION_TCP;
+                                }
+
+                                Tox_Err_Group_Peer_Query role_err;
+                                role = tox_group_peer_get_role(tox,
+                                                               group_number,
+                                                               peer_id,
+                                                               &role_err);
+
+                                if (role_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                                    role = TOX_GROUP_ROLE_USER;
+                                }
+                            }
+
+                            r.connection_status = conn;
+                            r.last_seen = now;
+                            r.role = role;
+                        } else {
+                            r.connection_status = TOX_CONNECTION_NONE;
+                            /* Anchor last_seen so we can purge them if they never come online */
+                            if (r.last_seen == 0) r.last_seen = now;
+                        }
+
+                        if (mid_upsert_record(g, &r)) {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+
+            p_idx += body_len;
+        }
+
+        /*
+         * SAFE MULTICAST SUPPRESSION
+         *
+         * Only suppress if the batch was structurally complete and the
+         * fingerprint matches exactly.
+         */
+        if (batch_complete) {
+            printf("[MID] ROSTER_BATCH: Sender FP[0..3]=%02X%02X%02X%02X, Our FP[0..3]=%02X%02X%02X%02X\n",
+                   sender_fp[0], sender_fp[1], sender_fp[2], sender_fp[3],
+                   g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]);
+            fflush(stdout);
+            if (memcmp(sender_fp, g->roster_fingerprint, MID_IDENTITY_KEY_SIZE) == 0) {
+                if (g->roster_reply_deadline != 0) {
+                    printf("[MID] ROSTER_BATCH: MATCH! Suppressing our pending roster reply because another peer already sent the exact same set.\n");
+                    fflush(stdout);
+                    g->roster_reply_deadline = 0;
+                } else {
+                    printf("[MID] ROSTER_BATCH: MATCH! But we had no pending reply to suppress.\n");
+                    fflush(stdout);
+                }
+            } else {
+                printf("[MID] ROSTER_BATCH: MISMATCH. Sender has a different peer set. Keeping our pending roster reply scheduled.\n");
+                fflush(stdout);
+            }
+        } else {
+            printf("[MID] ROSTER_BATCH: batch incomplete/truncated. "
+                   "Not suppressing roster reply.\n");
+            fflush(stdout);
+        }
+
+        return changed;
+    }
+
+    /**************************************************************************
+     * ROSTER REQUEST
+     *
+     * We do not answer immediately. We schedule a delayed response.
+     *
+     * If another peer responds first with a roster whose fingerprint matches
+     * ours, our pending response will be cancelled by the ROSTER_BATCH
+     * suppression logic above.
+     *************************************************************************/
+    if (type == MID_MSG_ROSTER_REQUEST) {
+        printf("[MID] on_custom_packet: processing ROSTER_REQUEST message\n");
+        fflush(stdout);
+
+        if (tox == NULL) {
+            return false;
+        }
+
+        /*
+         * Ignore our own request if it is ever echoed back.
+         */
+        if (sender_has_keys &&
+            g->have_keys &&
+            mid_same_identity(sender_identity, g->self_identity_key)) {
+            return false;
+        }
+
+        /*
+         * Only respond if we have joined/announced ourselves and have keys.
+         */
+        if (g->have_keys && g->announced) {
+            if (g->roster_reply_deadline == 0) {
+                /*
+                 * Randomized delay for multicast suppression.
+                 *
+                 * 1 to 5 seconds is enough for the first responder to be heard
+                 * by the other peers before their timers fire.
+                 */
+                uint64_t delay = 1 + (uint64_t)(rand() % 5);
+                g->roster_reply_deadline = now + delay;
+
+                printf("[MID] ROSTER_REQUEST: scheduled roster reply in %llu seconds. Our FP[0..3]=%02X%02X%02X%02X\n",
+                       (unsigned long long)delay,
+                       g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]);
+                fflush(stdout);
+            }
+        }
+
+        return changed;
+    }
+
+    /* Unknown message type. */
+    return false;
+}
+
+/******************************************************************************
+Forward declaration for internal use.
+mid_delete_peer_by_identity_internal is defined later in this file but is
+needed by mid_on_group_moderation_internal. We must NOT call the public
+mid_delete_peer_by_identity() from within a locked section because it would
+attempt to re-acquire the non-recursive mutex → deadlock.
+******************************************************************************/
+static bool mid_delete_peer_by_identity_internal(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                                                 const uint8_t identity_key[MID_IDENTITY_KEY_SIZE]);
+
+/******************************************************************************
+Internal state management (Assumes lock is held, does NOT fire callbacks)
+
+THREAD-SAFETY CONTRACT:
+Every function in this section expects the caller to already hold s->mutex.
+These functions must ONLY call other "_internal" or static helpers.
+They must NEVER call the public (locking) API wrappers.
+******************************************************************************/
+
+static bool mid_on_group_self_join_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t *nickname, size_t nickname_len)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    bool is_new = false;
+
+    if (!g) {
+        g = mid_add_group(s, chat_id);
+        is_new = true;
+    }
+
+    if (!g || !mid_init_self_from_tox(g, tox)) return is_new;
+
+    /* Stamp the founder role as soon as we join */
+    mid_apply_founder_role(g, tox);
+
+    bool nick_changed = false;
+
+    /*
+     * Store the self nickname as raw bytes.
+     */
+    if (nickname != NULL && nickname_len > 0) {
+        if (nickname_len > MID_MAX_NICK_SIZE) {
+            nickname_len = MID_MAX_NICK_SIZE;
+        }
+        if (g->self_nickname_len != nickname_len || memcmp(g->self_nickname, nickname, nickname_len) != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            memcpy(g->self_nickname, nickname, nickname_len);
+            g->self_nickname_len = (uint16_t)nickname_len;
+            nick_changed = true;
+        }
+    } else {
+        if (g->self_nickname_len != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            g->self_nickname_len = 0;
+            nick_changed = true;
+        }
+    }
+
+    g->announced = true;
+
+    bool announce_changed = mid_announce_self_group(s, g, tox);
+    mid_send_roster_request_group(s, g, tox);
+
+    return is_new || nick_changed || announce_changed;
+}
+
+static bool mid_on_group_delete_internal(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return false;
+
+    for (size_t i = 0; i < s->group_count; i++) {
+        if (memcmp(s->groups[i].chat_id, chat_id, TOX_GROUP_CHAT_ID_SIZE) == 0) {
+            sodium_memzero(s->groups[i].self_secret_signing_key, sizeof(s->groups[i].self_secret_signing_key));
+            free(s->groups[i].records);
+            for (size_t j = i; j < s->group_count - 1; j++) {
+                s->groups[j] = s->groups[j+1];
+            }
+            s->group_count--;
+            return true; /* CHANGED */
+        }
+    }
+    return false;
+}
+
+static bool mid_on_group_peer_join_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t peer_id)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    bool changed = false;
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    uint8_t id[MID_IDENTITY_KEY_SIZE];
+    uint8_t sig[MID_SIGNING_KEY_SIZE];
+
+    Tox_Err_Group_Peer_Query conn_err;
+    Tox_Connection conn = tox_group_peer_get_connection_status(tox, group_number, peer_id, &conn_err);
+    if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) conn = TOX_CONNECTION_NONE;
+
+    Tox_Err_Group_Peer_Query role_err;
+    Tox_Group_Role role = tox_group_peer_get_role(tox, group_number, peer_id, &role_err);
+    if (role_err != TOX_ERR_GROUP_PEER_QUERY_OK) role = TOX_GROUP_ROLE_USER;
+
+    if (mid_get_peer_keys(tox, chat_id, peer_id, id, sig)) {
+        if (mid_on_peer_online_keys(g, id, sig, conn, role, mid_now_or_time(0))) {
+            changed = true;
+        }
+    }
+
+    if (mid_refresh_peer_name_group(g, tox, peer_id)) {
+        changed = true;
+    }
+
+    if (g->announced) {
+        if (mid_announce_self_group(s, g, tox)) {
+            changed = true;
+        }
+        
+        /* 
+         * RELIABILITY FIX:
+         * Toxcore often drops custom packets sent immediately during the join handshake.
+         * The new peer's ROSTER_REQUEST might be lost (as seen in the logs).
+         * Instead, when existing peers see a new peer join, they schedule a delayed 
+         * ROSTER_BATCH broadcast. The fingerprint suppression ensures only ONE existing 
+         * peer actually sends it, preventing a broadcast storm while guaranteeing delivery.
+         */
+        if (g->roster_reply_deadline == 0) {
+            uint64_t delay = 1 + (uint64_t)(rand() % 5);
+            g->roster_reply_deadline = mid_now_or_time(0) + delay;
+            printf("[MID] peer_join: scheduled roster sync in %llu seconds because a new peer joined.\n", (unsigned long long)delay);
+            fflush(stdout);
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
+static bool mid_on_group_peer_exit_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], Tox_Group_Exit_Type exit_type)
+{
+    (void)exit_type; /* Unused currently */
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    return mid_sync_online_state_group(g, tox, mid_now_or_time(0));
+}
+
+static bool mid_on_group_moderation_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t source_peer_id, uint32_t target_peer_id, Tox_Group_Mod_Event mod_type, bool *out_changed)
+{
+    *out_changed = false;
+
+    if (s == NULL || tox == NULL || chat_id == NULL) return false;
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (g == NULL) return false;
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    printf("[MID] on_group_moderation: event group=%u source_peer=%u target_peer=%u type=%d\n",
+           group_number, source_peer_id, target_peer_id, (int)mod_type);
+    fflush(stdout);
+
+    if (mod_type == TOX_GROUP_MOD_EVENT_KICK) {
+        Tox_Err_Group_Self_Query self_err;
+        uint32_t self_peer_id = tox_group_self_get_peer_id(tox, group_number, &self_err);
+
+        if (self_err == TOX_ERR_GROUP_SELF_QUERY_OK && target_peer_id == self_peer_id) {
+            printf("[MID] on_group_moderation: we were kicked; deleting group state\n");
+            fflush(stdout);
+            mid_on_group_delete_internal(s, chat_id);
+            *out_changed = true;
+            return true;
+        }
+
+        Tox_Err_Group_Peer_Query peer_err;
+        uint8_t kicked_identity[MID_IDENTITY_KEY_SIZE];
+
+        if (tox_group_peer_get_public_key(tox, group_number, target_peer_id, kicked_identity, &peer_err) &&
+            peer_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+            printf("[MID] on_group_moderation: deleting kicked peer from roster\n");
+            fflush(stdout);
+            /*
+             * THREAD-SAFETY FIX:
+             * We are already holding s->mutex (acquired by the public caller).
+             * We must call the _internal variant which does NOT lock.
+             * Calling the public mid_delete_peer_by_identity() here would
+             * deadlock on the non-recursive mutex.
+             */
+            if (mid_delete_peer_by_identity_internal(s, chat_id, kicked_identity)) {
+                *out_changed = true;
+            }
+        } else {
+            printf("[MID] on_group_moderation: kicked peer %u identity no longer queryable\n", target_peer_id);
+            fflush(stdout);
+        }
+    } else if (mod_type == TOX_GROUP_MOD_EVENT_OBSERVER ||
+               mod_type == TOX_GROUP_MOD_EVENT_USER ||
+               mod_type == TOX_GROUP_MOD_EVENT_MODERATOR) {
+        
+        Tox_Err_Group_Peer_Query peer_err;
+        uint8_t target_identity[MID_IDENTITY_KEY_SIZE];
+
+        if (tox_group_peer_get_public_key(tox, group_number, target_peer_id, target_identity, &peer_err) &&
+            peer_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+            
+            int idx = mid_find_identity(g, target_identity);
+            if (idx >= 0) {
+                Tox_Group_Role new_role = TOX_GROUP_ROLE_USER;
+                if (mod_type == TOX_GROUP_MOD_EVENT_OBSERVER) new_role = TOX_GROUP_ROLE_OBSERVER;
+                else if (mod_type == TOX_GROUP_MOD_EVENT_MODERATOR) new_role = TOX_GROUP_ROLE_MODERATOR;
+                
+                if (g->records[idx].role != new_role) {
+                    g->records[idx].role = new_role;
+                    *out_changed = true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+static bool mid_on_group_peer_name_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t peer_id)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    return mid_refresh_peer_name_group(g, tox, peer_id);
+}
+
+static bool mid_self_set_name_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t *nickname, size_t nickname_len)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g || !g->have_keys) return false;
+
+    bool nick_changed = false;
+
+    /* Update the persistent self nickname buffer */
+    if (nickname != NULL && nickname_len > 0) {
+        if (nickname_len > MID_MAX_NICK_SIZE) {
+            nickname_len = MID_MAX_NICK_SIZE;
+        }
+        if (g->self_nickname_len != nickname_len || memcmp(g->self_nickname, nickname, nickname_len) != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            memcpy(g->self_nickname, nickname, nickname_len);
+            g->self_nickname_len = (uint16_t)nickname_len;
+            nick_changed = true;
+        }
+    } else {
+        if (g->self_nickname_len != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            g->self_nickname_len = 0;
+            nick_changed = true;
+        }
+    }
+
+    if (nick_changed) {
+        /* Immediately update the local roster record so it reflects the change
+           even if the timestamp doesn't bump within the same second */
+        int idx = mid_find_identity(g, g->self_identity_key);
+        if (idx >= 0) {
+            MidPeerRecord *e = &g->records[idx];
+            memset(e->nickname, 0, MID_MAX_NICK_SIZE);
+            if (g->self_nickname_len > 0) {
+                memcpy(e->nickname, g->self_nickname, g->self_nickname_len);
+            }
+            e->nickname_len = g->self_nickname_len;
+        }
+
+        /* Re-announce ourselves to broadcast the new signed presence record */
+        if (g->announced) {
+            mid_announce_self_group(s, g, tox);
+        }
+    }
+
+    return nick_changed;
+}
+
+static bool mid_on_group_custom_packet_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t peer_id, const uint8_t *data, size_t length)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    s->recv_bytes += length;
+
+    return mid_on_custom_packet_group(s, g, tox, peer_id, data, length, mid_now_or_time(0));
+}
+
+static bool mid_announce_leave_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], bool *out_changed)
+{
+    *out_changed = false;
+
+    if (!chat_id) return false;
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g || !g->have_keys) return false;
+
+    MidPeerRecord r;
+    memset(&r, 0, sizeof(r));
+    memcpy(r.identity_key, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+    memcpy(r.signing_key, g->self_signing_key, MID_SIGNING_KEY_SIZE);
+    r.status = MID_STATUS_LEFT;
+    r.timestamp = mid_now_or_time(0);
+    r.connection_status = TOX_CONNECTION_NONE;
+
+    if (g->self_nickname_len > 0) {
+        uint16_t nick_copy = g->self_nickname_len;
+        if (nick_copy > MID_MAX_NICK_SIZE) {
+            nick_copy = MID_MAX_NICK_SIZE;
+        }
+        memcpy(r.nickname, g->self_nickname, nick_copy);
+        r.nickname_len = nick_copy;
+    }
+
+    if (!mid_sign_record(g, &r)) return false;
+
+    printf("[MID] announce_leave: broadcasting signed LEFT tombstone\n"); fflush(stdout);
+
+    bool sent = mid_send_presence_record(s, g, tox, &r);
+
+    int idx = mid_find_identity(g, g->self_identity_key);
+    if (idx >= 0) {
+        /* Replacing self with tombstone */
+        g->records[idx] = r;
+        g->records[idx].connection_status = TOX_CONNECTION_NONE;
+        *out_changed = true;
+    }
+
+    g->self_active = false;
+    return sent;
+}
+
+/*
+Internal delete: assumes lock is already held. Does NOT fire callbacks.
+This is the non-locking counterpart of the public mid_delete_peer_by_identity().
+*/
+static bool mid_delete_peer_by_identity_internal(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                                                 const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (s == NULL || identity_key == NULL || chat_id == NULL) return false;
+    if (mid_key_is_zero(identity_key)) return false;
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (g == NULL) return false;
+
+    int idx = mid_find_identity(g, identity_key);
+    if (idx < 0) return false;
+
+    printf("[MID] delete_peer_by_identity: deleting peer from roster\n");
+    fflush(stdout);
+
+    if (g->records[idx].has_signature) {
+        printf("[MID] delete_peer: XOR OUT deleted peer. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        mid_xor_fingerprint(g->roster_fingerprint, g->records[idx].identity_key);
+        printf("[MID] delete_peer: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+    }
+
+    for (size_t k = (size_t)idx; k + 1 < g->count; k++) {
+        g->records[k] = g->records[k+1];
+    }
+    g->count--;
+    return true; /* CHANGED */
+}
+
+/******************************************************************************
+Public state management (Handles Locking and Callbacks)
+
+THREAD-SAFETY:
+Every public entry point follows the same pattern:
+  1. mid_lock(s)
+  2. Call the corresponding _internal function (which assumes lock is held)
+  3. Snapshot the callback pointer under the lock
+  4. mid_unlock(s)
+  5. Fire the callback OUTSIDE the lock (prevents deadlock if the
+     callback calls back into any mid_* public function)
+******************************************************************************/
+
+static bool mid_load_from_disk(MidState *s, const char *path, const uint8_t *passphrase, size_t passphrase_len) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return false;
+
+    fseek(f, 0, SEEK_END);
+    long file_size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (file_size <= 0) { fclose(f); return false; }
+
+    uint8_t *file_data = (uint8_t *)malloc(file_size);
+    if (!file_data || fread(file_data, 1, file_size, f) != (size_t)file_size) {
+        free(file_data); fclose(f); return false;
+    }
+    fclose(f);
+
+    uint8_t *data_to_parse = file_data;
+    size_t data_len = file_size;
+    uint8_t *decrypted_data = NULL;
+
+    // Check if the file was encrypted by TOXENCRYPTSAVE
+    if (file_size >= TOX_PASS_ENCRYPTION_EXTRA_LENGTH && tox_is_data_encrypted(file_data)) {
+        if (!passphrase || passphrase_len == 0) {
+            printf("[MID] load: file is encrypted but no passphrase provided, ignoring\n");
+            free(file_data);
+            return false;
+        }
+        decrypted_data = (uint8_t *)malloc(file_size);
+        if (!decrypted_data) {
+            free(file_data);
+            return false;
+        }
+        Tox_Err_Decryption err;
+        if (!tox_pass_decrypt(file_data, file_size, passphrase, passphrase_len, decrypted_data, &err)) {
+            printf("[MID] load: decryption failed (err=%d)\n", err);
+            free(decrypted_data);
+            free(file_data);
+            return false;
+        }
+        data_to_parse = decrypted_data;
+        data_len = file_size - TOX_PASS_ENCRYPTION_EXTRA_LENGTH;
+    }
+
+    // Parse Header
+    MidReader r = { data_to_parse, data_len, 0 };
+    uint8_t magic[MID_SAVE_MAGIC_SIZE];
+    if (!mid_reader_read(&r, magic, MID_SAVE_MAGIC_SIZE) || memcmp(magic, MID_SAVE_MAGIC, MID_SAVE_MAGIC_SIZE) != 0) {
+        goto parse_fail;
+    }
+
+    uint32_t ver;
+    if (!mid_reader_read_u32(&r, &ver) || ver != MID_SAVE_VERSION) {
+        printf("[MID] load: unsupported or missing version %u\n", ver);
+        goto parse_fail;
+    }
+
+    uint64_t load_time = (uint64_t)time(NULL);
+
+    // Parse Body
+    uint32_t group_count;
+    if (!mid_reader_read_u32(&r, &group_count) || group_count > MID_MAX_GROUPS) goto parse_fail;
+
+    for (uint32_t i = 0; i < group_count; i++) {
+        uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+        if (!mid_reader_read(&r, chat_id, TOX_GROUP_CHAT_ID_SIZE)) goto parse_fail;
+
+        MidGroupState *g = mid_add_group(s, chat_id);
+        if (!g) goto parse_fail;
+
+        if (!mid_reader_read(&r, g->self_identity_key, MID_IDENTITY_KEY_SIZE)) goto parse_fail;
+        if (!mid_reader_read(&r, g->self_signing_key, MID_SIGNING_KEY_SIZE)) goto parse_fail;
+        /*
+         * NEVER load self_secret_signing_key from disk.
+         *
+         * The secret key is fetched from Toxcore once the group becomes
+         * active again via mid_init_self_from_tox().
+         */
+        sodium_memzero(g->self_secret_signing_key, sizeof(g->self_secret_signing_key));
+
+        /*
+         * We only have public keys at this point.
+         * We cannot sign anything until Toxcore gives us the secret signing key.
+         */
+        g->have_keys = false;
+        g->self_active = false;
+        g->announced = false;
+
+        uint16_t nick_len;
+        if (!mid_reader_read_u16(&r, &nick_len) || nick_len > MID_MAX_NICK_SIZE) goto parse_fail;
+        g->self_nickname_len = nick_len;
+        if (!mid_reader_read(&r, g->self_nickname, nick_len)) goto parse_fail;
+
+        uint32_t peer_count;
+        if (!mid_reader_read_u32(&r, &peer_count) || peer_count > MID_MAX_PEERS_PER_GROUP) goto parse_fail;
+
+        for (uint32_t j = 0; j < peer_count; j++) {
+            MidPeerRecord tmp_rec;
+            memset(&tmp_rec, 0, sizeof(tmp_rec));
+
+            if (!mid_reader_read(&r, tmp_rec.identity_key, MID_IDENTITY_KEY_SIZE)) goto parse_fail;
+            if (!mid_reader_read(&r, tmp_rec.signing_key, MID_SIGNING_KEY_SIZE)) goto parse_fail;
+
+            uint8_t status;
+            if (!mid_reader_read_u8(&r, &status)) goto parse_fail;
+            tmp_rec.status = status;
+            if (tmp_rec.status != MID_STATUS_ACTIVE && tmp_rec.status != MID_STATUS_LEFT) goto parse_fail;
+
+            if (!mid_reader_read_u64(&r, &tmp_rec.timestamp)) goto parse_fail;
+
+            uint16_t p_nick_len;
+            if (!mid_reader_read_u16(&r, &p_nick_len) || p_nick_len > MID_MAX_NICK_SIZE) goto parse_fail;
+            tmp_rec.nickname_len = p_nick_len;
+            if (!mid_reader_read(&r, tmp_rec.nickname, p_nick_len)) goto parse_fail;
+
+            if (!mid_reader_read(&r, tmp_rec.signature, MID_SIG_SIZE)) goto parse_fail;
+            uint8_t has_sig;
+            if (!mid_reader_read_u8(&r, &has_sig)) goto parse_fail;
+            tmp_rec.has_signature = has_sig ? true : false;
+
+            uint32_t conn, role;
+            if (!mid_reader_read_u32(&r, &conn)) goto parse_fail;
+            /* HINT: Force all loaded peers to offline.
+                     Leaves status (ACTIVE/LEFT) exactly as it was saved. */
+            // tmp_rec.connection_status = (Tox_Connection)conn;
+            tmp_rec.connection_status = TOX_CONNECTION_NONE;
+
+            if (!mid_reader_read_u32(&r, &role)) goto parse_fail;
+            tmp_rec.role = (Tox_Group_Role)role;
+
+
+            if (!mid_reader_read_u64(&r, &tmp_rec.last_seen)) goto parse_fail;
+            // Only anchor if the saved value was 0 (e.g. corrupted or legacy save).
+            // If you use this, and the app was closed for 31 days, offline peers
+            // WILL be purged immediately upon the first mid_iterate() call.
+            //
+            if (tmp_rec.last_seen == 0) {
+                tmp_rec.last_seen = load_time;
+            }
+
+            if (mid_find_identity(g, tmp_rec.identity_key) >= 0) continue;
+
+            if (!mid_ensure_capacity(g)) goto parse_fail;
+            MidPeerRecord *p = &g->records[g->count];
+            *p = tmp_rec;
+
+            if (p->has_signature) {
+                mid_xor_fingerprint(g->roster_fingerprint, p->identity_key);
+            }
+            g->count++;
+        }
+    }
+
+    if (decrypted_data) free(decrypted_data);
+    free(file_data);
+    return true;
+
+parse_fail:
+    printf("[MID] load: parse error, discarding loaded state\n");
+    if (decrypted_data) free(decrypted_data);
+    free(file_data);
+    for (size_t i = 0; i < s->group_count; i++) free(s->groups[i].records);
+    free(s->groups);
+    s->groups = NULL; s->group_count = 0; s->group_capacity = 0;
+    return false;
+}
+
+bool mid_save(MidState *s, const uint8_t *passphrase, size_t passphrase_len) {
+    if (!s || !s->save_path) return false;
+
+    mid_lock(s);
+    MidBuf buf;
+    mid_buf_init(&buf);
+
+    // 1. Assemble Header and Body
+    mid_buf_append(&buf, MID_SAVE_MAGIC, MID_SAVE_MAGIC_SIZE);
+    uint8_t ver[4]; 
+    mid_put_u32_be(ver, MID_SAVE_VERSION); 
+    mid_buf_append(&buf, ver, sizeof(ver));
+
+    // 2. Serialize Body
+    mid_buf_append_u32(&buf, (uint32_t)s->group_count);
+    for (size_t i = 0; i < s->group_count; i++) {
+        MidGroupState *g = &s->groups[i];
+        mid_buf_append(&buf, g->chat_id, TOX_GROUP_CHAT_ID_SIZE);
+        mid_buf_append(&buf, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+        mid_buf_append(&buf, g->self_signing_key, MID_SIGNING_KEY_SIZE);
+        /*
+         * NEVER save self_secret_signing_key.
+         *
+         * The Ed25519 signing secret key belongs to the NGC group identity
+         * and is owned by Toxcore. It must be re-obtained from Toxcore when
+         * the group is active again.
+         */
+        mid_buf_append_u16(&buf, g->self_nickname_len);
+        mid_buf_append(&buf, g->self_nickname, g->self_nickname_len);
+        mid_buf_append_u32(&buf, (uint32_t)g->count);
+
+        for (size_t j = 0; j < g->count; j++) {
+            MidPeerRecord *p = &g->records[j];
+            mid_buf_append(&buf, p->identity_key, MID_IDENTITY_KEY_SIZE);
+            mid_buf_append(&buf, p->signing_key, MID_SIGNING_KEY_SIZE);
+            mid_buf_append_u8(&buf, p->status);
+            mid_buf_append_u64(&buf, p->timestamp);
+            mid_buf_append_u16(&buf, p->nickname_len);
+            mid_buf_append(&buf, p->nickname, p->nickname_len);
+            mid_buf_append(&buf, p->signature, MID_SIG_SIZE);
+            mid_buf_append_u8(&buf, p->has_signature ? 1 : 0);
+            mid_buf_append_u32(&buf, (uint32_t)p->connection_status);
+            mid_buf_append_u32(&buf, (uint32_t)p->role);
+            mid_buf_append_u64(&buf, p->last_seen);
+        }
+    }
+
+    // 3. Encrypt payload if passphrase provided
+    uint8_t *final_payload = buf.data;
+    size_t final_payload_len = buf.len;
+    uint8_t *free_payload = NULL;
+
+    if (passphrase && passphrase_len > 0) {
+        size_t cipher_len = buf.len + TOX_PASS_ENCRYPTION_EXTRA_LENGTH;
+        free_payload = (uint8_t *)malloc(cipher_len);
+        if (!free_payload) { mid_buf_free(&buf); mid_unlock(s); return false; }
+
+        Tox_Err_Encryption err;
+        if (!tox_pass_encrypt(buf.data, buf.len, passphrase, passphrase_len, free_payload, &err)) {
+            printf("[MID] save: encryption failed (err=%d)\n", err);
+            free(free_payload); mid_buf_free(&buf); mid_unlock(s); return false;
+        }
+        final_payload = free_payload;
+        final_payload_len = cipher_len;
+    }
+
+    char *path_copy = mid_strdup(s->save_path);
+    mid_unlock(s); // <--- CRITICAL: Release lock before doing blocking Disk I/O
+
+    if (!path_copy) {
+        if (free_payload) free(free_payload);
+        mid_buf_free(&buf);
+        return false;
+    }
+
+    // 4. Write to Disk Atomically
+    size_t path_len = strlen(path_copy);
+    char *tmp_path = (char *)malloc(path_len + 6);
+    if (!tmp_path) {
+        free(path_copy);
+        if (free_payload) free(free_payload);
+        mid_buf_free(&buf);
+        return false;
+    }
+    snprintf(tmp_path, path_len + 6, "%s.tmp", path_copy);
+
+    FILE *f = fopen(tmp_path, "wb");
+    if (!f) {
+        free(tmp_path); free(path_copy);
+        if (free_payload) free(free_payload);
+        mid_buf_free(&buf);
+        return false;
+    }
+
+#ifndef _WIN32
+    /* 
+     * FIX: CodeQL TOCTOU Race Condition.
+     * Instead of closing the file and calling chmod() on the path string 
+     * (which allows an attacker to swap the path with a symlink in between),
+     * we use fchmod() on the open file descriptor. This atomically secures 
+     * the exact file we just created, completely bypassing path-based races.
+     */
+    if (fchmod(fileno(f), 0600) != 0) {
+        // Silently ignore permission errors, matching previous behavior
+    }
+#endif
+
+    fwrite(final_payload, 1, final_payload_len, f);
+    fclose(f);
+
+    if (free_payload) free(free_payload);
+    mid_buf_free(&buf);
+
+#ifdef _WIN32
+    /*
+     * Windows filesystem semantics differ from POSIX. Symlink-based TOCTOU 
+     * attacks via _chmod are not part of the standard Windows threat model 
+     * in this context, so _chmod remains the correct and standard approach here.
+     */
+    _chmod(tmp_path, _S_IREAD | _S_IWRITE);
+#endif
+
+#ifdef __MINGW32__
+    // HINT: rename() will refuse to overwrite existing files with WIN32 mingw
+    unlink(path_copy);
+#endif
+
+    bool ok = (rename(tmp_path, path_copy) == 0);
+    if (!ok) remove(tmp_path);
+
+    free(tmp_path);
+    free(path_copy);
+    return ok;
+}
+
+MidState *mid_new(const char *save_path, const uint8_t *passphrase, size_t passphrase_len) {
+    if (sodium_init() < 0) return NULL;
+
+    MidState *s = (MidState *)calloc(1, sizeof(MidState));
+    if (!s) return NULL;
+
+    s->mutex = (pthread_mutex_t *)calloc(1, sizeof(pthread_mutex_t));
+    if (!s->mutex) { free(s); return NULL; }
+    pthread_mutex_init(s->mutex, NULL);
+
+    if (save_path) s->save_path = mid_strdup(save_path);
+
+    if (s->save_path) {
+        mid_load_from_disk(s, s->save_path, passphrase, passphrase_len);
+    }
+
+    return s;
+}
+
+void mid_free(MidState *s) {
+    if (s == NULL) return;
+
+    for (size_t i = 0; i < s->group_count; i++) {
+        sodium_memzero(s->groups[i].self_secret_signing_key, sizeof(s->groups[i].self_secret_signing_key));
+        free(s->groups[i].records);
+    }
+    free(s->groups);
+
+    free(s->save_path);
+
+    if (s->mutex) {
+        pthread_mutex_destroy(s->mutex);
+        free(s->mutex);
+    }
+
+    free(s);
+}
+
+void mid_on_group_self_join(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_self_join_internal(s, tox, chat_id, nickname, nickname_len);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    /* Fire callback OUTSIDE the lock to avoid deadlock */
+    if (changed && cb) cb(chat_id, ud);
+}
+
+void mid_on_group_delete(MidState *s, Tox *tox, uint32_t group_number)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_delete_internal(s, chat_id);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+void mid_on_group_peer_join(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_peer_join_internal(s, tox, chat_id, peer_id);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+void mid_on_group_peer_exit(MidState *s, Tox *tox, uint32_t group_number, Tox_Group_Exit_Type exit_type)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_peer_exit_internal(s, tox, chat_id, exit_type);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+bool mid_on_group_moderation(MidState *s, Tox *tox, uint32_t group_number,
+                             uint32_t source_peer_id, uint32_t target_peer_id,
+                             Tox_Group_Mod_Event mod_type)
+{
+    if (!s || !tox) return false;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return false;
+
+    mid_lock(s);
+    bool changed = false;
+    bool we_were_kicked = mid_on_group_moderation_internal(s, tox, chat_id, source_peer_id, target_peer_id, mod_type, &changed);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+    return we_were_kicked;
+}
+
+void mid_on_group_peer_name(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_peer_name_internal(s, tox, chat_id, peer_id);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+bool mid_self_set_name(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len)
+{
+    if (!s || !tox) return false;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return false;
+
+    mid_lock(s);
+    bool changed = mid_self_set_name_internal(s, tox, chat_id, nickname, nickname_len);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    /* Fire callback OUTSIDE the lock to avoid deadlock */
+    if (changed && cb) cb(chat_id, ud);
+
+    return changed;
+}
+
+void mid_on_group_custom_packet(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data, size_t length)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_custom_packet_internal(s, tox, chat_id, peer_id, data, length);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+bool mid_announce_leave(MidState *s, Tox *tox, uint32_t group_number)
+{
+    if (!s || !tox) return false;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return false;
+
+    mid_lock(s);
+    bool changed = false;
+    bool sent = mid_announce_leave_internal(s, tox, chat_id, &changed);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+    return sent;
+}
+
+void mid_iterate(MidState *s, Tox *tox)
+{
+    if (!s || !tox) return;
+
+    mid_lock(s);
+
+    uint64_t now = mid_now_or_time(0);
+
+    /*
+     * PERFORMANCE THROTTLE:
+     * Do not run the heavy sync/cleanup loop on every 50ms tox_iterate() tick.
+     * Only run it every MID_SYNC_INTERVAL_SEC seconds.
+     */
+    if (now - s->last_sync_time < MID_SYNC_INTERVAL_SEC) {
+        mid_unlock(s);
+        return;
+    }
+
+    s->last_sync_time = now;
+
+    /* Collect changed groups to fire callbacks AFTER unlocking */
+    uint8_t changed_groups[MID_MAX_CHANGED_GROUPS_PER_ITERATE][TOX_GROUP_CHAT_ID_SIZE];
+    size_t num_changed = 0;
+
+    for (size_t i = 0; i < s->group_count; i++) {
+        MidGroupState *g = &s->groups[i];
+        bool changed = false;
+
+        // 1. Sync online state with Toxcore
+        if (mid_sync_online_state_group(g, tox, now)) {
+            changed = true;
+        }
+
+        // 2. Heartbeats (FIX 3: Uses lightweight heartbeat packet)
+        if (g->have_keys && g->self_active && g->announced) {
+            if (now >= g->last_announce && (now - g->last_announce >= MID_HEARTBEAT_SEC)) {
+                printf("[MID] poll: heartbeat triggered\n"); fflush(stdout);
+                if (mid_send_heartbeat_record(s, g, tox)) {
+                    g->last_announce = now;
+                    int idx = mid_find_identity(g, g->self_identity_key);
+                    if (idx >= 0) {
+                        g->records[idx].timestamp = now;
+                    }
+                    changed = true;
+                }
+            }
+        }
+
+        // 3. GRAVEYARD & STALE CLEANUP
+        uint64_t cutoff_tombstone = (now > MID_TOMBSTONE_TTL_SEC) ? (now - MID_TOMBSTONE_TTL_SEC) : 0;
+        uint64_t cutoff_stale = (now > MID_STALE_PEER_TTL_SEC) ? (now - MID_STALE_PEER_TTL_SEC) : 0;
+
+        size_t j = 0;
+        while (j < g->count) {
+            bool purge = false;
+            const MidPeerRecord *rec = &g->records[j];
+
+            // A. Purge expired LEFT tombstones (7 days)
+            if (rec->status == MID_STATUS_LEFT && rec->timestamp < cutoff_tombstone) {
+                purge = true;
+            }
+            // B. Purge stale offline ACTIVE peers (30 days)
+            // Must be ACTIVE, offline, and last_seen is older than the stale cutoff.
+            else if (rec->status == MID_STATUS_ACTIVE &&
+                     rec->connection_status == TOX_CONNECTION_NONE &&
+                     rec->last_seen > 0 &&
+                     rec->last_seen < cutoff_stale) {
+                purge = true;
+            }
+
+            if (purge) {
+                printf("[MID] iterate: purging stale/expired peer %zu\n", j); fflush(stdout);
+                if (rec->has_signature) {
+                    printf("[MID] iterate: XOR OUT purged peer. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                    mid_xor_fingerprint(g->roster_fingerprint, rec->identity_key);
+                    printf("[MID] iterate: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                }
+                // Shift array down to delete
+                for (size_t k = j; k < g->count - 1; k++) {
+                    g->records[k] = g->records[k+1];
+                }
+                g->count--;
+                changed = true;
+                continue; // Do not increment j, check the new record at this index
+            }
+            j++;
+        }
+
+        // 4. FIX 2: Multicast Roster Reply Timer execution
+        if (g->roster_reply_deadline != 0 && now >= g->roster_reply_deadline) {
+            printf("[MID] iterate: Roster reply timer fired! No one else suppressed us. Sending our roster. Our FP[0..3]=%02X%02X%02X%02X\n",
+                   g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]);
+            fflush(stdout);
+            g->roster_reply_deadline = 0;
+            mid_send_roster_group(s, g, tox);
+            changed = true;
+        }
+
+        if (changed && num_changed < MID_MAX_CHANGED_GROUPS_PER_ITERATE) {
+            memcpy(changed_groups[num_changed++], g->chat_id, TOX_GROUP_CHAT_ID_SIZE);
+        }
+    }
+
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+
+    /*
+     * IMPORTANT: Unlock BEFORE firing callbacks.
+     * This prevents deadlocks if the user's callback calls mid_peer_list_get().
+     */
+    mid_unlock(s);
+
+    if (cb) {
+        for (size_t i = 0; i < num_changed; i++) {
+            cb(changed_groups[i], ud);
+        }
+    }
+}
+
+size_t mid_group_count(MidState *s)
+{
+    if (!s) return 0;
+
+    mid_lock(s);
+    size_t count = s->group_count;
+    mid_unlock(s);
+
+    return count;
+}
+
+int mid_find_peer(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (s == NULL || identity_key == NULL || chat_id == NULL) return -1;
+    if (mid_key_is_zero(identity_key)) return -1;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    int idx = -1;
+    if (g != NULL) {
+        idx = mid_find_identity(g, identity_key);
+    }
+    mid_unlock(s);
+
+    return idx;
+}
+
+bool mid_delete_peer_by_identity(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (!s || !chat_id) return false;
+
+    mid_lock(s);
+    bool changed = mid_delete_peer_by_identity_internal(s, chat_id, identity_key);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+    return changed;
+}
+
+size_t mid_peer_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t count = g ? g->count : 0;
+    mid_unlock(s);
+
+    return count;
+}
+
+size_t mid_signed_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t c = 0;
+    if (g) {
+        for (size_t i = 0; i < g->count; i++) {
+            if (g->records[i].has_signature) c++;
+        }
+    }
+    mid_unlock(s);
+
+    return c;
+}
+
+size_t mid_online_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t c = 0;
+    if (g) {
+        for (size_t i = 0; i < g->count; i++) {
+            if (g->records[i].connection_status != TOX_CONNECTION_NONE) c++;
+        }
+    }
+    mid_unlock(s);
+
+    return c;
+}
+
+size_t mid_offline_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t c = 0;
+    if (g) {
+        for (size_t i = 0; i < g->count; i++) {
+            if (g->records[i].connection_status == TOX_CONNECTION_NONE &&
+                g->records[i].status == MID_STATUS_ACTIVE) c++;
+        }
+    }
+    mid_unlock(s);
+
+    return c;
+}
+
+bool mid_peer_is_signed_left(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (s == NULL || identity_key == NULL || chat_id == NULL) return false;
+    if (mid_key_is_zero(identity_key)) return false;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    bool res = false;
+    if (g != NULL) {
+        int idx = mid_find_identity(g, identity_key);
+        if (idx >= 0) {
+            const MidPeerRecord *rec = &g->records[idx];
+            res = rec->has_signature && rec->status == MID_STATUS_LEFT;
+        }
+    }
+    mid_unlock(s);
+
+    return res;
+}
+
+/******************************************************************************
+Network Stats
+******************************************************************************/
+
+void mid_get_network_stats(MidState *s, uint64_t *sent_bytes, uint64_t *recv_bytes)
+{
+    if (s == NULL) {
+        if (sent_bytes) *sent_bytes = 0;
+        if (recv_bytes) *recv_bytes = 0;
+        return;
+    }
+
+    /* Cast away const for locking; the mutex is logically mutable */
+    mid_lock(s);
+    if (sent_bytes) *sent_bytes = s->sent_bytes;
+    if (recv_bytes) *recv_bytes = s->recv_bytes;
+    mid_unlock(s);
+}
+
+/******************************************************************************
+Peer List Query API (for C / JNI clients)
+******************************************************************************/
+
+size_t mid_peer_list_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t count = g ? g->count : 0;
+    mid_unlock(s);
+
+    return count;
+}
+
+bool mid_peer_list_get(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], size_t index, MidPeerInfo *out)
+{
+    if (s == NULL || out == NULL || chat_id == NULL) return false;
+
+    mid_lock(s);
+
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    bool success = false;
+
+    if (g != NULL && index < g->count) {
+        const MidPeerRecord *rec = &g->records[index];
+
+        memset(out, 0, sizeof(*out));
+
+        memcpy(out->identity_key, rec->identity_key, MID_IDENTITY_KEY_SIZE);
+        memcpy(out->signing_key, rec->signing_key, MID_SIGNING_KEY_SIZE);
+
+        out->status        = rec->status;
+        out->connection_status = (uint8_t)rec->connection_status;
+        out->role          = (uint8_t)rec->role;
+        out->has_signature = rec->has_signature ? 1 : 0;
+        out->reserved      = 0;
+        out->last_seen     = rec->last_seen;
+        out->nickname_len  = rec->nickname_len;
+
+        // Safe copy bounded strictly by MID_MAX_NICK_SIZE
+        if (rec->nickname_len > 0 && rec->nickname_len <= MID_MAX_NICK_SIZE) {
+            memcpy(out->nickname, rec->nickname, rec->nickname_len);
+        }
+
+        // The NUL-termination.
+        // Because the array in MidPeerInfo is (MID_MAX_NICK_SIZE + 1),
+        // the index [nickname_len] is ALWAYS a valid memory location.
+        // (Max index written to is MID_MAX_NICK_SIZE, which is the last byte).
+        out->nickname[out->nickname_len] = '\0';
+
+        success = true;
+    }
+
+    mid_unlock(s);
+
+    return success;
+}
+
+/******************************************************************************
+Peer List Changed Callback registration
+******************************************************************************/
+
+void mid_set_peer_list_changed_cb(MidState *s, mid_peer_list_changed_cb cb, void *user_data)
+{
+    if (!s) return;
+
+    mid_lock(s);
+    s->peer_list_changed_cb = cb;
+    s->peer_list_changed_user_data = user_data;
+    mid_unlock(s);
+}
+
+/******************************************************************************
+Peer table printing
+******************************************************************************/
+
+static void mid_hex_short(char *out, size_t out_size, const uint8_t *data, size_t data_len, size_t max_bytes)
+{
+    if (out == NULL || out_size == 0) return;
+    out[0] = '\0';
+    if (data == NULL || data_len == 0 || max_bytes == 0) return;
+    if (max_bytes > data_len) max_bytes = data_len;
+    if (out_size <= (max_bytes * 2)) max_bytes = (out_size - 1) / 2;
+
+    for (size_t i = 0; i < max_bytes; i++) {
+        snprintf(out + (i * 2), 3, "%02X", data[i]);
+    }
+    out[max_bytes * 2] = '\0';
+}
+
+static void mid_make_safe_nick(char *out, size_t out_size, const uint8_t *nick, uint16_t nick_len)
+{
+    if (out == NULL || out_size == 0) return;
+
+    size_t o = 0;
+    if (nick != NULL) {
+        for (uint16_t i = 0; i < nick_len && o + 1 < out_size; i++) {
+            uint8_t c = nick[i];
+            if (c >= 0x20 && c <= 0x7E) out[o] = (char)c;
+            else out[o] = '.';
+            o++;
+        }
+    }
+    out[o] = '\0';
+}
+
+void mid_print_peer_table(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const char *title)
+{
+    if (!s || !chat_id) return;
+
+    mid_lock(s);
+
+    time_t now = time(NULL);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+
+    char chat_id_hex[9];
+    mid_hex_short(chat_id_hex, sizeof(chat_id_hex), chat_id, TOX_GROUP_CHAT_ID_SIZE, 4);
+
+    printf("\n");
+    printf("==========================================================================================\n");
+    printf("MIDDLEWARE PEER TABLE: %s (ChatID %s...)\n", title != NULL ? title : "unknown", chat_id_hex);
+
+    if (g == NULL) {
+        printf("(Group not found in middleware)\n");
+        printf("==========================================================================================\n\n");
+        fflush(stdout);
+        mid_unlock(s);
+        return;
+    }
+
+    size_t active_count = 0;
+    size_t online_count = 0;
+    size_t signed_count = 0;
+
+    for (size_t i = 0; i < g->count; i++) {
+        if (g->records[i].status == MID_STATUS_ACTIVE) active_count++;
+        if (g->records[i].connection_status != TOX_CONNECTION_NONE) online_count++;
+        if (g->records[i].has_signature) signed_count++;
+    }
+
+    printf("records=%zu active=%zu online=%zu signed=%zu sent=%llu recv=%llu\n",
+           g->count, active_count, online_count, signed_count,
+           (unsigned long long)s->sent_bytes, (unsigned long long)s->recv_bytes);
+
+    printf("+----+------+--------------+--------------+--------------+--------+------+--------+--------+----------+\n");
+    printf("| %2s | %-4s | %-12s | %-12s | %-12s | %-6s | %-4s | %-6s | %-6s | %-8s |\n",
+           "#", "Self", "Nickname", "Identity", "Signing", "Status", "Sig", "Conn", "Role", "Last seen");
+    printf("+----+------+--------------+--------------+--------------+--------+------+--------+--------+----------+\n");
+
+    for (size_t i = 0; i < g->count; i++) {
+        const MidPeerRecord *rec = &g->records[i];
+
+        char nick_buf[13];
+        char identity_buf[13];
+        char signing_buf[13];
+        char seen_buf[16];
+
+        mid_make_safe_nick(nick_buf, sizeof(nick_buf), rec->nickname, rec->nickname_len);
+        mid_hex_short(identity_buf, sizeof(identity_buf), rec->identity_key, MID_IDENTITY_KEY_SIZE, 6);
+        mid_hex_short(signing_buf, sizeof(signing_buf), rec->signing_key, MID_SIGNING_KEY_SIZE, 6);
+
+        bool is_self = false;
+        if (g->have_keys) {
+            is_self = mid_same_identity(rec->identity_key, g->self_identity_key);
+        }
+
+        const char *status_str = "?";
+        if (rec->status == MID_STATUS_ACTIVE) status_str = "ACTIVE";
+        else if (rec->status == MID_STATUS_LEFT) status_str = "LEFT";
+
+        const char *conn_str = "NONE";
+        if (rec->connection_status == TOX_CONNECTION_TCP) conn_str = "TCP";
+        else if (rec->connection_status == TOX_CONNECTION_UDP) conn_str = "UDP";
+
+        const char *role_str = "USER";
+        if (rec->role == TOX_GROUP_ROLE_FOUNDER) role_str = "FOUNDER";
+        else if (rec->role == TOX_GROUP_ROLE_MODERATOR) role_str = "MOD";
+        else if (rec->role == TOX_GROUP_ROLE_OBSERVER) role_str = "OBS";
+
+        if (rec->connection_status != TOX_CONNECTION_NONE) {
+            snprintf(seen_buf, sizeof(seen_buf), "now");
+        } else if (rec->last_seen == 0) {
+            snprintf(seen_buf, sizeof(seen_buf), "-");
+        } else if (rec->last_seen > (uint64_t)now) {
+            snprintf(seen_buf, sizeof(seen_buf), "future");
+        } else {
+            unsigned long age = (unsigned long)(now - (time_t)rec->last_seen);
+            snprintf(seen_buf, sizeof(seen_buf), "%lus", age);
+        }
+
+        printf("| %2zu | %-4s | %-12s | %-12s | %-12s | %-6s | %-4s | %-6s | %-6s | %-8s |\n",
+               i,
+               is_self ? "YES" : "no",
+               nick_buf,
+               identity_buf,
+               signing_buf,
+               status_str,
+               rec->has_signature ? "yes" : "no",
+               conn_str,
+               role_str,
+               seen_buf);
+    }
+
+    printf("+----+------+--------------+--------------+--------------+--------+------+--------+--------+----------+\n");
+    printf("\n");
+    fflush(stdout);
+
+    mid_unlock(s);
+}

--- a/ngc_ppeerlist/.gitignore
+++ b/ngc_ppeerlist/.gitignore
@@ -1,0 +1,13 @@
+*
+!.gitignore
+
+#########
+
+!Makefile
+!mid_roster.c
+!mid_roster.h
+!tox
+!tox_ngc_tcp_test.c
+!README.md
+!README_pre.md
+!unit_test/

--- a/ngc_ppeerlist/Makefile
+++ b/ngc_ppeerlist/Makefile
@@ -1,0 +1,15 @@
+TARGET = libngc_ppeerlist.a
+
+all: $(TARGET)
+
+libngc_ppeerlist.o: mid_roster.c
+	$(CC) -c -o $@ $< -O2 -Wno-discarded-qualifiers -fPIC -I. -Wl,-Bstatic $(shell pkg-config --cflags --libs libsodium x264) -Wl,-Bdynamic $(shell pkg-config --cflags --libs opus vpx libavcodec libavutil) -pthread
+
+$(TARGET): libngc_ppeerlist.o
+	$(AR) rcs $@ $^
+
+test:
+	$(CC) -fsanitize=address -g -fno-omit-frame-pointer tox_ngc_tcp_test.c -I. ../amalgamation/libtoxcore.a -lsodium -lopus -lx265 -lx264 -lavcodec -lvpx -lavutil
+
+clean:
+	rm -f libngc_ppeerlist.a libngc_ppeerlist.o

--- a/ngc_ppeerlist/README.md
+++ b/ngc_ppeerlist/README.md
@@ -1,0 +1,628 @@
+# `mid_roster` — Persistent Group Roster Middleware for Tox NGC
+
+**Complete Implementation Specification — Version 3.0**
+
+This document is a complete, from-scratch specification of the `mid_roster` middleware as implemented in `mid_roster.c` / `mid_roster.h`. A C programmer should be able to delete the existing implementation and rewrite it using only this document.
+
+---
+
+## Table of Contents
+
+- [1. Overview](#1-overview)
+- [2. Problem Statement](#2-problem-statement)
+- [3. Requirements & Dependencies](#3-requirements--dependencies)
+- [4. Architecture & Thread-Safety](#4-architecture--thread-safety)
+- [5. Key Model (CRITICAL)](#5-key-model-critical)
+- [6. Data Structures](#6-data-structures)
+- [7. Wire Protocol](#7-wire-protocol)
+- [8. Cryptography & Fingerprint Tracking](#8-cryptography--fingerprint-tracking)
+- [9. Roster Semantics](#9-roster-semantics)
+- [10. Core Algorithm: Record Upsert](#10-core-algorithm-record-upsert)
+- [11. Public API Reference](#11-public-api-reference)
+- [12. Hook Behavior & Sequence Flows](#12-hook-behavior--sequence-flows)
+- [13. Timing Constants & Magic Bytes](#13-timing-constants--magic-bytes)
+- [14. Local Persistence (Save/Load)](#14-local-persistence-saveload)
+- [15. Integration Guide (Step by Step)](#15-integration-guide-step-by-step)
+- [16. Pitfalls & Edge Cases](#16-pitfalls--edge-cases)
+- [17. Validation Checklist](#17-validation-checklist)
+
+---
+
+## 1. Overview
+
+`mid_roster` is a thin C middleware layer that sits between a Tox client and Toxcore's NGC (Next Generation Conferences) group API. It maintains a **persistent, cryptographically signed peer roster** that:
+
+- Survives peers going offline (offline peers remain in the list).
+- Survives *your own* client restart (via local disk persistence AND batched roster sync from online peers).
+- Proves *voluntary departure* using **signed LEFT tombstones**.
+- Handles **kicks** by permanently removing the kicked peer.
+- Minimizes network traffic using **lightweight heartbeats** and **multicast-suppressed batched roster sync**.
+- Requires **no server** — pure peer-to-peer, eventually consistent.
+- Supports **optional local encrypted persistence** via `toxencryptsave`.
+
+Transport is exclusively `tox_group_send_custom_packet()` (lossless). All crypto is libsodium Ed25519.
+
+### Design philosophy
+
+| Principle | Consequence |
+|---|---|
+| Best-effort, eventually consistent | No consensus, no ordering guarantees; last-writer-wins by timestamp |
+| Self-signed records only | A peer only ever signs statements about *itself* |
+| Stateless transport | Every PRESENCE record is fully self-contained and verifiable |
+| Opaque state | Client sees only `MidState *`; all internals are hidden |
+| Thread-safe | Non-recursive mutex protects state; callbacks fire outside the lock |
+| Event-driven | Client forwards Toxcore callbacks; middleware does the rest |
+
+---
+
+## 2. Problem Statement
+
+Toxcore NGC gives each client only a list of **currently online** peers. When a peer disconnects (timeout, network loss), Toxcore forgets them. When *you* restart your client and rejoin, you start with an empty peer list.
+
+The middleware adds:
+
+| Feature | Without middleware | With middleware |
+|---|---|---|
+| See offline members | ❌ | ✅ (status = ACTIVE, connection = NONE) |
+| Know who *permanently left* | ❌ | ✅ (signed LEFT tombstone) |
+| Kicked peers removed | partial | ✅ |
+| Full roster after own restart | ❌ | ✅ (Local save + batched roster sync with fingerprint suppression) |
+| Cryptographic proof of membership | ❌ | ✅ (Ed25519 signatures) |
+| Low bandwidth keep-alive | ❌ | ✅ (Lightweight 41-byte Heartbeat packets) |
+
+---
+
+## 3. Requirements & Dependencies
+
+### 3.1 Libraries
+
+| Dependency | Used for |
+|---|---|
+| `toxcore` (NGC build) | Group API |
+| `toxencryptsave` | Optional local encrypted save/load |
+| `libsodium` | `crypto_sign_detached`, `crypto_sign_verify_detached`, `crypto_sign_ed25519_pk_to_curve25519`, `crypto_sign_ed25519_sk_to_pk`, `sodium_memzero`, `sodium_init` |
+| `pthread` | Non-recursive mutex for thread-safety |
+
+### 3.2 Required Toxcore API functions
+
+**Standard NGC API:**
+
+| Function | Purpose |
+|---|---|
+| `tox_group_send_custom_packet()` | Transport for PRESENCE / HEARTBEAT / ROSTER_BATCH |
+| `tox_group_self_get_public_key()` | Our identity key |
+| `tox_group_self_get_peer_id()` | Detect "we were kicked" |
+| `tox_group_peer_get_public_key()` | Peer identity key |
+| `tox_group_peer_by_public_key()` | Online-state check / find peer_id by key |
+| `tox_group_get_chat_id()` | Map `group_number` to persistent `chat_id` |
+
+**Patched API (must be added to toxcore):**
+
+| Function | Purpose |
+|---|---|
+| `tox_group_self_get_signing_public_key()` | Our Ed25519 group signing public key |
+| `tox_group_self_get_signing_secret_key()` | Our Ed25519 group signing secret key (64 bytes) |
+| `tox_group_peer_get_signing_public_key()` | A peer's Ed25519 signing public key |
+
+> ⚠️ Without the three patched functions the middleware **cannot sign or verify anything** and will not work.
+
+---
+
+## 4. Architecture & Thread-Safety
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                          TOX CLIENT APP                          │
+│        (UI / storage / main loop — knows nothing about crypto)   │
+└───────────────┬───────────────────────────────────▲─────────────┘
+                │ forward Toxcore events            │ query API
+                │ (hooks take group_number)         │ (queries take chat_id)
+                ▼                                   │ 
+┌─────────────────────────────────────────────────────────────────┐
+│                       mid_roster MIDDLEWARE                      │
+│                                                                  │
+│   MidState ──► pthread_mutex_t (non-recursive)                   │
+│            ──► MidGroupState[] ──► MidPeerRecord[]               │
+│                                                                  │
+│   responsibilities:                                              │
+│     • fetch/hold our group keys                                  │
+│     • sign & broadcast presence / lightweight heartbeats         │
+│     • verify & upsert foreign signed records                     │
+│     • answer ROSTER_REQUEST with batched ROSTER_BATCH            │
+│     • multicast suppression via roster_fingerprint               │
+│     • tombstone garbage collection (7-day TTL)                   │
+│     • save/load state to disk (optional encryption)              │
+└───────────────┬───────────────────────────────────▲─────────────┘
+                │ tox_group_send_custom_packet()     │ callbacks
+                │ key query functions                │ (fired OUTSIDE lock)
+                ▼                                   │ 
+┌─────────────────────────────────────────────────────────────────┐
+│                        Toxcore (NGC)                             │
+│           group chat transport over UDP / TCP relays             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Thread-Safety Model
+All public API functions acquire a single **non-recursive `pthread_mutex_t`** before touching internal state. Internal `_internal` helper functions assume the lock is ALREADY held and must NEVER be called without it. Callbacks are always invoked **AFTER** the lock is released to prevent deadlocks when the client calls back into the middleware from within the callback.
+
+---
+
+## 5. Key Model (CRITICAL)
+
+Tox NGC uses several different keys. Confusing them is the #1 implementation mistake. The middleware uses exactly **three** keys per group member:
+
+| Name | Size | Type | What it is | How to obtain (self) | How to obtain (peer) |
+|---|---|---|---|---|---|
+| `identity_key` | 32 B | Curve25519 public key | The persistent NGC group identity; the **roster lookup key** | `tox_group_self_get_public_key()` | `tox_group_peer_get_public_key()` |
+| `signing_key` | 32 B | Ed25519 public key | Verifies signatures made by this peer | `tox_group_self_get_signing_public_key()` [patched] | `tox_group_peer_get_signing_public_key()` [patched] |
+| `self_secret_key` | 64 B | Ed25519 secret key | Signs our own records. **Never transmitted over network.** | `tox_group_self_get_signing_secret_key()` [patched] | — never available for peers — |
+
+### 5.1 Key binding
+
+The middleware must verify that a `signing_key` actually belongs to an `identity_key`. In the NGC extended-key layout:
+
+```text
+identity_key == curve25519_from_ed25519(signing_key)
+```
+
+**`mid_valid_key_binding(identity, signing)` algorithm:**
+
+```text
+1. if identity is all-zero OR signing is all-zero  → REJECT
+2. if identity == signing (byte-equal)             → ACCEPT   (compatibility)
+3. derived = crypto_sign_ed25519_pk_to_curve25519(signing)
+   if derivation fails                             → REJECT
+4. if identity == derived                          → ACCEPT
+5. else                                            → REJECT
+```
+
+---
+
+## 6. Data Structures
+
+### 6.1 Enumerations
+
+```c
+typedef enum {
+    MID_STATUS_ACTIVE = 0,   // peer is (or was) a member
+    MID_STATUS_LEFT   = 1    // peer permanently left (tombstone)
+} MidStatus;
+
+typedef enum {
+    MID_MSG_PRESENCE       = 1,  // full signed presence record
+    MID_MSG_ROSTER_REQUEST = 2,  // request full roster
+    MID_MSG_HEARTBEAT      = 3,  // lightweight keep-alive
+    MID_MSG_ROSTER_BATCH   = 4   // batched roster response
+} MidMsg;
+```
+
+### 6.2 `MidPeerRecord` — one roster entry (internal)
+
+```c
+typedef struct {
+    uint8_t  identity_key[32];      // roster primary key
+    uint8_t  signing_key[32];       // Ed25519 verification key
+    uint8_t  status;                // MidStatus
+    uint64_t timestamp;             // sender-generated unix seconds
+    uint8_t  nickname[128];         // raw nickname bytes
+    uint16_t nickname_len;          // 0..128
+    uint8_t  signature[64];         // Ed25519 detached signature over body
+    bool     has_signature;         // false = locally observed only
+    Tox_Connection connection_status; // LOCAL observation, never transmitted
+    Tox_Group_Role role;            // LOCAL observation, never transmitted
+    uint64_t last_seen;             // LOCAL observation, never transmitted
+} MidPeerRecord;
+```
+
+> **Important:** `connection_status`, `role`, and `last_seen` are *local observations*. They are never part of the signed/transmitted payload.
+
+### 6.3 `MidGroupState` — per-group state (internal)
+
+```c
+typedef struct {
+    uint8_t  chat_id[32];           // persistent group identifier
+
+    uint8_t  self_identity_key[32];
+    uint8_t  self_signing_key[32];
+    uint8_t  self_secret_key[64];   // wipe on free/delete
+    bool     have_keys;
+
+    uint8_t  self_nickname[128];
+    uint16_t self_nickname_len;
+    bool     self_active;           // false after mid_announce_leave()
+    bool     announced;             // we have announced at least once
+
+    MidPeerRecord *records;
+    size_t         count;
+    size_t         capacity;
+
+    uint64_t last_announce;         // for heartbeat scheduling
+    uint64_t roster_reply_deadline; // multicast suppression timer
+    uint8_t  roster_fingerprint[32]; // XOR sum of all signed identity keys
+} MidGroupState;
+```
+
+### 6.4 `MidState` — top-level opaque state
+
+```c
+struct MidState {
+    MidGroupState *groups;
+    size_t         group_count;
+    size_t         group_capacity;
+
+    /* peer-list-changed notification */
+    mid_peer_list_changed_cb peer_list_changed_cb;
+    void                    *peer_list_changed_user_data;
+
+    pthread_mutex_t *mutex;         // non-recursive thread-safety lock
+    uint64_t last_sync_time;        // throttle for heavy sync loop
+    uint64_t sent_bytes;            // network stats
+    uint64_t recv_bytes;            // network stats
+    
+    char *save_path;                // local persistence path
+};
+```
+
+### 6.5 `MidPeerInfo` — public flat peer view (for UI / JNI)
+
+```c
+typedef struct {
+    uint8_t  identity_key[32];
+    uint8_t  signing_key[32];
+    uint8_t  status;              // 0 = ACTIVE, 1 = LEFT
+    uint8_t  connection_status;   // Tox_Connection: 0=NONE, 1=TCP, 2=UDP
+    uint8_t  role;                // Tox_Group_Role
+    uint8_t  has_signature;       // 1/0
+    uint8_t  reserved;            // padding, always 0
+    uint64_t last_seen;           // unix seconds, 0 = never
+    uint16_t nickname_len;
+    char     nickname[129];       // always NUL-terminated
+} MidPeerInfo;
+```
+
+---
+
+## 7. Wire Protocol
+
+All messages are sent with `tox_group_send_custom_packet(tox, group, /*lossless=*/true, ...)`. Maximum packet size is bounded to 1200 bytes.
+
+### 7.1 Common header (5 bytes)
+
+| Offset | Size | Field | Value |
+|---|---|---|---|
+| 0 | 1 | magic byte 0 | `MID_MAGIC_0` |
+| 1 | 1 | magic byte 1 | `MID_MAGIC_1` |
+| 2 | 1 | magic byte 2 | `MID_MAGIC_2` |
+| 3 | 1 | protocol version | `MID_PROTOCOL_VERSION` |
+| 4 | 1 | message type | `1`=PRESENCE, `2`=REQ, `3`=HB, `4`=BATCH |
+
+### 7.2 PRESENCE message (type = 1)
+
+Full signed record containing status, timestamp, nickname, identity key, and signing key. Used for JOINs, LEAVEs, and Name Changes.
+
+### 7.3 HEARTBEAT message (type = 3)
+
+Lightweight keep-alive. Updates `connection_status` and `last_seen` without re-sending nickname or keys.
+**Body layout (41 bytes, signed):**
+```text
+ offset   size   field
+ ──────   ────   ──────────────
+  0       1      status (ACTIVE)
+  1       8      timestamp (uint64 BE)
+  9       32     identity_key
+```
+
+### 7.4 ROSTER_REQUEST (type = 2) & ROSTER_BATCH (type = 4)
+
+Instead of replying with individual PRESENCE packets, peers reply with a **ROSTER_BATCH** message.
+
+**ROSTER_BATCH layout:**
+```text
+ offset   size   field
+ ──────   ────   ─────────────────────────────────
+  0       5      header (magic + version + type=4)
+  5       32     roster_fingerprint (XOR sum of signed identity keys)
+ 37       2      record_count (uint16 BE)
+ 39       ...    [ signature(64) + body_len(2) + body ] ... repeated
+```
+*Note: If the roster is too large for one custom packet (>1200 bytes), it is split into multiple ROSTER_BATCH packets, each repeating the 5-byte header and 32-byte fingerprint.*
+
+---
+
+## 8. Cryptography & Fingerprint Tracking
+
+### 8.1 Roster Fingerprint
+To enable **multicast suppression**, the middleware maintains a 32-byte `roster_fingerprint` per group. This is an incremental XOR sum of the `identity_key` of every peer that currently holds a valid signature.
+- When a peer transitions from unsigned → signed, their key is XORed IN.
+- When a peer is deleted or loses signature status, their key is XORed OUT.
+- Nickname changes or timestamp updates do NOT affect the fingerprint.
+
+### 8.2 Security rules
+
+| Rule | Rationale |
+|---|---|
+| A record is only trusted about the identity named inside it | Prevents impersonation |
+| If the *sender* claims to be the subject, their Toxcore signing key must match the record | Prevents relayed forgery |
+| Only records **self-signed by the subject** are stored long-term | Roster integrity |
+| A signed record's `signing_key` is immutable for that identity | Prevents key rotation attacks |
+
+---
+
+## 9. Roster Semantics
+
+### 9.1 The Graveyard (Tombstones)
+
+- A LEFT tombstone is kept in the roster for **`MID_TOMBSTONE_TTL_SEC = 7 days`**.
+- Reason: a peer who was offline when someone left must later be able to sync and receive cryptographic proof of the departure.
+- `mid_iterate()` purges tombstones with `timestamp < now − TTL`.
+
+### 9.2 Multicast Suppression
+
+When a new peer joins, multiple existing peers might try to send the roster simultaneously. To prevent a broadcast storm:
+1. Existing peers schedule a delayed `ROSTER_BATCH` broadcast (1–5 seconds randomized).
+2. If an existing peer receives a `ROSTER_BATCH` from another peer *before* its timer fires, and the `roster_fingerprint` matches exactly, it **cancels its own pending response**.
+
+---
+
+## 10. Core Algorithm: Record Upsert
+
+`mid_upsert_record(group, record)` handles the insertion and updating of records.
+
+**Precedence summary:**
+
+| Incoming ↓ / Existing → | unsigned | signed ACTIVE | signed LEFT |
+|---|---|---|---|
+| **unsigned** | replaces if `ts >=` | never | never |
+| **signed ACTIVE** | always | replaces if `ts >` | replaces if `ts >` |
+| **signed LEFT** | always | replaces if `ts >=` | replaces if `ts >=` |
+
+> The `>=` for tombstones guarantees a LEFT with the *same* timestamp as the last ACTIVE still wins.
+
+---
+
+## 11. Public API Reference
+
+> **API Note:** Event hooks (`mid_on_group_*`) take `group_number` because Toxcore callbacks provide it. Query and Action functions (`mid_peer_count`, `mid_find_peer`, etc.) take the persistent `chat_id` (32 bytes) because `group_number` can change across client restarts.
+
+### 11.1 Lifecycle
+
+| Function | Description |
+|---|---|
+| `MidState *mid_new(const char *save_path, const uint8_t *passphrase, size_t passphrase_len)` | `sodium_init()`, allocate state, init mutex. Loads from disk if `save_path` is provided. |
+| `bool mid_save(MidState *s, const uint8_t *passphrase, size_t passphrase_len)` | Serializes state and writes atomically to disk (encrypted if passphrase provided). |
+| `void mid_free(MidState *s)` | Wipes keys, frees records, destroys mutex. |
+
+### 11.2 Event hooks (call from Toxcore callbacks)
+
+| Function | When to call |
+|---|---|
+| `mid_on_group_self_join(s, tox, group, nick, len)` | We joined or created a group |
+| `mid_on_group_delete(s, tox, group)` | We leave/delete a group |
+| `mid_on_group_peer_join(s, tox, group, peer_id)` | `group_peer_join` callback |
+| `mid_on_group_peer_exit(s, tox, group, exit_type)` | `group_peer_exit` callback |
+| `mid_on_group_peer_name(s, tox, group, peer_id)` | `group_peer_name` callback |
+| `mid_on_group_moderation(s, tox, group, src, dst, type)` → `bool` | Returns **true if WE were kicked** |
+| `mid_on_group_custom_packet(s, tox, group, peer_id, data, len)` | `group_custom_packet` callback |
+| `mid_iterate(s, tox)` | Every main-loop iteration |
+
+### 11.3 Actions
+
+| Function | Description |
+|---|---|
+| `bool mid_announce_leave(s, tox, group)` | Broadcast signed LEFT tombstone. Call **immediately before** `tox_group_leave()`. |
+| `bool mid_self_set_name(s, tox, group, nick, len)` | Update our own nickname, update local record, and re-announce signed PRESENCE. |
+| `bool mid_delete_peer_by_identity(s, chat_id, id_key)` | Manually remove a peer. **Required for the kicker**. |
+
+### 11.4 Queries (Take `chat_id`)
+
+| Function | Returns |
+|---|---|
+| `mid_group_count(s)` | Number of managed groups |
+| `mid_peer_count(s, chat_id)` | Total roster entries |
+| `mid_signed_count(s, chat_id)` | Entries with valid signatures |
+| `mid_online_count(s, chat_id)` | Entries currently observed online |
+| `mid_find_peer(s, chat_id, id_key)` | Index ≥ 0, or −1 |
+| `mid_peer_is_signed_left(s, chat_id, id_key)` | true if a signed LEFT tombstone exists |
+
+### 11.5 Flat peer-list API (for UI / JNI)
+
+```c
+size_t mid_peer_list_count(MidState *s, const uint8_t chat_id[32]);
+bool   mid_peer_list_get(MidState *s, const uint8_t chat_id[32], size_t index, MidPeerInfo *out);
+```
+
+### 11.6 Change notification
+
+```c
+typedef void (*mid_peer_list_changed_cb)(const uint8_t chat_id[32], void *user_data);
+void mid_set_peer_list_changed_cb(MidState *s, mid_peer_list_changed_cb cb, void *user_data);
+```
+Called **outside the mutex lock**. It is safe to call `mid_peer_list_get()` from within the callback.
+
+### 11.7 Utilities
+
+```c
+void mid_get_network_stats(MidState *s, uint64_t *sent_bytes, uint64_t *recv_bytes);
+void mid_print_peer_table(MidState *s, const uint8_t chat_id[32], const char *title);
+```
+
+---
+
+## 12. Hook Behavior & Sequence Flows
+
+### 12.1 `mid_on_group_peer_join` (Reliability Fix)
+
+Toxcore often drops custom packets sent immediately during the join handshake. Instead of unicasting immediately, existing peers schedule a delayed `ROSTER_BATCH` broadcast (1–5s). The fingerprint suppression ensures only ONE existing peer actually sends it.
+
+### 12.2 `mid_on_group_custom_packet`
+
+- **HEARTBEAT (Type 3):** Updates `connection_status`, `role`, and `last_seen`. Does NOT overwrite full signed records or modify `timestamp`.
+- **ROSTER_BATCH (Type 4):** Parses the batch. If structurally complete and `sender_fp == our_fp`, cancels our pending `roster_reply_deadline` (multicast suppression).
+
+### 12.3 `mid_iterate` (Throttled)
+
+1. **Throttle:** Heavy sync only runs every `MID_SYNC_INTERVAL_SEC` (5 seconds) to avoid hammering Toxcore on 50ms ticks.
+2. **Sync:** Marks vanished peers offline via `tox_group_peer_by_public_key()`.
+3. **Heartbeat:** If `now - last_announce >= 300s`, sends lightweight `HEARTBEAT` packet.
+4. **Tombstone GC:** Purges LEFT records older than 7 days.
+5. **Roster Timer:** If `roster_reply_deadline` is reached, sends `ROSTER_BATCH`.
+
+---
+
+## 13. Timing Constants & Magic Bytes
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `MID_MAGIC_0` / `1` / `2` | `0xA0` / `0x91` / `...` | Packet identification |
+| `MID_PROTOCOL_VERSION` | `1` | Version gate |
+| `MID_HEARTBEAT_SEC` | `300` (5 min) | Lightweight keep-alive interval |
+| `MID_SYNC_INTERVAL_SEC` | `5` | Throttle for heavy sync loop |
+| `MID_ROSTER_COOLDOWN_SEC` | `30` | Min gap between roster responses |
+| `MID_TOMBSTONE_TTL_SEC` | `604800` (7 d) | Graveyard retention |
+| `MID_MAX_PACKET_SIZE` | `1200` | Maximum custom packet payload size |
+
+---
+
+## 14. Local Persistence (Save/Load)
+
+If a `save_path` is provided to `mid_new()`, the middleware attempts to load the roster from disk. Calling `mid_save()` writes the current state back atomically (using a `.tmp` file and `rename()`).
+
+### 14.1 Encryption
+If a `passphrase` is provided, the entire serialized payload is encrypted using `tox_pass_encrypt()` (from `toxencryptsave`). The resulting file begins with the standard Tox encryption magic bytes. Upon loading, `tox_is_data_encrypted()` detects this and decrypts it before parsing.
+
+### 14.2 Binary File Format (`MIDR`)
+The unencrypted payload follows this exact binary layout (all multi-byte integers are Big-Endian):
+
+```text
+[Header]
+- Magic:        "MIDR" (4 bytes)
+- Version:      uint32 (Must be 2)
+- Group Count:  uint32
+
+[Group Data] (Repeated Group Count times)
+- chat_id:             32 bytes
+- self_identity_key:   32 bytes
+- self_signing_key:    32 bytes
+- self_secret_key:     64 bytes
+- self_nickname_len:   uint16
+- self_nickname:       N bytes
+- peer_count:          uint32
+
+  [Peer Data] (Repeated peer_count times)
+  - identity_key:      32 bytes
+  - signing_key:       32 bytes
+  - status:            uint8
+  - timestamp:         uint64
+  - nickname_len:      uint16
+  - nickname:          N bytes
+  - signature:         64 bytes
+  - has_signature:     uint8 (1 or 0)
+  - connection_status: uint32
+  - role:              uint32
+  - last_seen:         uint64
+```
+
+> **Note on Loading:** When peers are loaded from disk, their `connection_status` is intentionally forced to `TOX_CONNECTION_NONE` (offline). This forces the middleware to do a fresh online-state sync with Toxcore on the next `mid_iterate()` tick.
+
+---
+
+## 15. Integration Guide (Step by Step)
+
+### Step 1 — Add state to your client object
+
+```c
+#include "mid_roster.h"
+
+typedef struct {
+    Tox      *tox;
+    MidState *mid;            
+    uint32_t  group_number;   
+    uint8_t   chat_id[32];    // ← Cache the chat_id for queries!
+} MyClient;
+```
+
+### Step 2 — Initialize with Persistence
+
+```c
+// On startup
+c->mid = mid_new("/path/to/roster.mid", (const uint8_t *)"my_password", 11);
+
+// On shutdown
+mid_save(c->mid, (const uint8_t *)"my_password", 11);
+mid_free(c->mid);
+```
+
+### Step 3 — Forward every group callback
+
+```c
+static void group_self_join_cb(Tox *tox, uint32_t group_number, void *ud)
+{
+    MyClient *c = ud;
+    c->group_number = group_number;
+    
+    // Cache chat_id for future queries
+    tox_group_get_chat_id(tox, group_number, c->chat_id, NULL);
+    
+    mid_on_group_self_join(c->mid, tox, group_number,
+                           (const uint8_t *)c->name, strlen(c->name));
+}
+
+static void group_custom_packet_cb(Tox *tox, uint32_t g, uint32_t peer_id,
+                                   const uint8_t *data, size_t len, void *ud)
+{
+    MyClient *c = ud;
+    mid_on_group_custom_packet(c->mid, tox, g, peer_id, data, len);
+}
+```
+
+### Step 4 — Render the roster in your UI (Using `chat_id`)
+
+```c
+static void on_peer_list_changed(const uint8_t chat_id[32], void *ud)
+{
+    MyClient *c = ud;
+    // Note: mid_peer_list_count takes chat_id, not group_number!
+    size_t n = mid_peer_list_count(c->mid, chat_id);
+    for (size_t i = 0; i < n; i++) {
+        MidPeerInfo p;
+        if (!mid_peer_list_get(c->mid, chat_id, i, &p)) continue;
+        /* push p into your UI model */
+    }
+}
+```
+
+---
+
+## 16. Pitfalls & Edge Cases
+
+| # | Pitfall | Correct behavior |
+|---|---|---|
+| 16.1 | Founder never announces | Call `mid_on_group_self_join` manually after `tox_group_new` |
+| 16.2 | Kicked peer stays in kicker's roster | Kicker must call `mid_delete_peer_by_identity` |
+| 16.3 | Deadlock in callback | Callbacks fire OUTSIDE the mutex lock; safe to call queries |
+| 16.4 | Internal function calls public API | `_internal` functions must NEVER call public wrappers (deadlock) |
+| 16.5 | Queries fail after restart | Use `chat_id` for queries, not `group_number` |
+| 16.6 | Broadcast storm on peer join | Solved by randomized delay + fingerprint suppression |
+| 16.7 | High CPU usage in main loop | `mid_iterate` throttles heavy sync to every 5 seconds |
+| 16.8 | Saving blocks the UI thread | `mid_save` releases the mutex *before* doing blocking Disk I/O |
+
+---
+
+## 17. Validation Checklist
+
+A correct implementation must pass this scenario sequence:
+
+| Phase | Scenario | Expected result |
+|---|---|---|
+| 1 | 3 clients join one private group | All 3 rosters show 3 **signed** peers |
+| 2 | Client 3 hard-disconnects | Others detect exit; client 3 stays in roster as offline ACTIVE |
+| 3 | Client 4 joins late | Receives `ROSTER_BATCH`, syncs full persistent roster |
+| 4 | Client 2 gracefully leaves | `mid_announce_leave` → `tox_group_leave`; others hold signed LEFT tombstone |
+| 5 | Heartbeat test | Wait 5 minutes; observe lightweight `HEARTBEAT` packets (41 bytes) instead of full PRESENCE |
+| 6 | Name change test | Call `mid_self_set_name`; observe new signed PRESENCE broadcast and UI update |
+| 7 | Restart test | Kill Client 1, restart it. It loads from disk and immediately syncs missing offline states via Toxcore. |
+| ∞ | Tombstone GC | LEFT records older than 7 days purged by `mid_iterate` |
+
+---
+
+*End of specification.*

--- a/ngc_ppeerlist/README_pre.md
+++ b/ngc_ppeerlist/README_pre.md
@@ -1,0 +1,544 @@
+# Tox NGC Persistent Roster Middleware — `mid_roster` Specification
+
+**Version:** 1.0
+**Target reader:** A C programmer who wants to (re)implement or integrate this middleware.
+**Dependencies:** `toxcore` (with the NGC signing-key API), `libsodium`.
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Tox NGC (New Group Chats) only keeps a peer in the peer list **while that peer is online and connected**. When a peer goes offline, Toxcore removes it from the live peer list, so other peers "forget" that the peer was ever in the group.
+
+`mid_roster` adds a **persistent, eventually-consistent group roster** on top of Tox NGC using only `tox_group_send_custom_packet()`. It lets every client remember **all** members of a group — including members who are currently offline — and lets a brand-new joiner learn the full member history.
+
+### 1.2 Design goals
+
+| Goal | How it is achieved |
+|---|---|
+| No central server | Pure peer-to-peer gossip over group custom packets |
+| Authenticity | Every membership change is signed with the member's Ed25519 group key |
+| Offline peers remembered | Signed records persist in each client's roster, independent of connectivity |
+| Offline peers can re-sync | Signed records are forwarded to late joiners on request |
+| Graceful leave is permanent | A signed `LEFT` tombstone propagates and overrides earlier `ACTIVE` records |
+| Easy integration | A small, opaque C API driven entirely from Tox callbacks + one loop call |
+
+### 1.3 Non-goals (deliberate limitations)
+
+- **Not strongly consistent.** It is *eventually* consistent. During a network partition, some peers will temporarily disagree.
+- **No trusted "last seen" for offline peers.** `last_seen` is a **local, transient** observation, not an authenticated global fact.
+- **No trusted global timestamp.** Timestamps are sender-generated and used only for per-identity ordering, not wall-clock truth.
+- **No persistence across client restart is built in.** The middleware keeps state in RAM. Persistence is delegated to the application through save/load hooks.
+
+---
+
+## 2. Key Concepts
+
+| Term | Meaning |
+|---|---|
+| **Identity key** | The normal 32-byte Tox NGC group peer public key (`tox_group_peer_get_public_key`). This is the *primary roster lookup key*. |
+| **Signing key** | The 32-byte Ed25519 public key that verifies a peer's signatures (`tox_group_peer_get_signing_public_key`). |
+| **Secret signing key** | The 64-byte Ed25519 private key a peer uses to sign its own records (`tox_group_self_get_signing_secret_key`). |
+| **Record** | A signed statement about one peer: *status + timestamp + nickname + keys*. |
+| **Tombstone** | A signed record with `status = LEFT`. It permanently overrides earlier `ACTIVE` records for that identity. |
+| **Roster** | The local set of all known records (active + left). |
+| **Presence** | Transient online/offline state. Not signed, not persistent. |
+
+> **Core distinction:** *Membership* is persistent and signed. *Presence* is transient and local. Do not conflate them.
+
+---
+
+## 3. High-Level Architecture
+
+```
+                        ┌──────────────────────────────────────┐
+                        │             Tox Client               │
+                        │  (your app: UI, storage, logic)      │
+                        └───────────────┬──────────────────────┘
+                                        │  forwards Tox events
+                                        ▼
+                        ┌──────────────────────────────────────┐
+                        │           mid_roster (this)          │
+                        │  - roster table (records[])          │
+                        │  - signing / verification            │
+                        │  - gossip (custom packets)           │
+                        │  - heartbeat + roster sync           │
+                        └───────────────┬──────────────────────┘
+                                        │  tox_group_send_custom_packet()
+                                        ▼
+                        ┌──────────────────────────────────────┐
+                        │             toxcore (NGC)            │
+                        │  (group chat transport over DHT/TCP) │
+                        └──────────────────────────────────────┘
+```
+
+The middleware is a **passenger** on the Tox group transport. It never opens sockets. It:
+1. Receives events *from* the client (who joined, who left, incoming custom packet).
+2. Maintains the roster table.
+3. Emits signed records *back out* through `tox_group_send_custom_packet()`.
+
+---
+
+## 4. Cryptographic Identity Model
+
+### 4.1 The three keys
+
+Tox NGC uses an **extended keypair**. The middleware needs three distinct keys:
+
+| Key | Size | Obtained via | Purpose |
+|---|---|---|---|
+| Identity key | 32 bytes | `tox_group_self_get_public_key` / `tox_group_peer_get_public_key` | Roster lookup key; stable identity |
+| Signing public key | 32 bytes | `tox_group_self_get_signing_public_key` / `tox_group_peer_get_signing_public_key` | Verify signatures |
+| Signing secret key | 64 bytes | `tox_group_self_get_signing_secret_key` | Sign our own records |
+
+> ⚠️ The **identity key is NOT the signing key.** The identity key is the Curve25519 encryption key; the signing key is a separate Ed25519 key. You must fetch both.
+
+### 4.2 Key binding (anti-spoofing)
+
+A malicious peer could try to attach a signing key to someone else's identity key. To prevent this, every record must satisfy a **binding check** before it is accepted:
+
+```
+valid_binding(identity, signing) =
+        (identity == signing)                                   # 32-byte equality
+     OR (curve25519_from_ed25519(signing) == identity)        # derivation
+```
+
+- The first branch handles implementations where the exposed identity key *is* the signing key.
+- The second branch handles the normal NGC extended-key case, where the identity key is the Curve25519 key *derived from* the Ed25519 signing key.
+
+If neither holds, the record is rejected as forged.
+
+### 4.3 What is signed
+
+A record's **body** (see §6.3) is signed with the member's own secret signing key. Because the identity key and signing key are both *inside* the signed body, a signature proves:
+
+> "The owner of this signing key asserts this status/nickname for this identity."
+
+Combined with the binding check (§4.2), this proves the record came from the owner of the identity.
+
+---
+
+## 5. Data Structures
+
+### 5.1 `MidPeerRecord` — one roster entry
+
+```c
+typedef struct {
+    uint8_t  identity_key[MID_IDENTITY_KEY_SIZE];  // 32 — primary key
+    uint8_t  signing_key[MID_SIGNING_KEY_SIZE];    // 32 — verifies signatures
+
+    uint8_t  status;        // MID_STATUS_ACTIVE (0) or MID_STATUS_LEFT (1)
+    uint64_t timestamp;     // sender-generated, for per-identity ordering
+
+    uint8_t  nickname[MID_MAX_NICK_SIZE];          // 128
+    uint16_t nickname_len;
+
+    uint8_t  signature[MID_SIG_SIZE];              // 64 — Ed25519 over body
+    bool     has_signature;
+
+    bool     online;        // TRANSIENT — local observation only
+    uint64_t last_seen;     // TRANSIENT — local observation only
+} MidPeerRecord;
+```
+
+| Field | Persistent? | Signed? | Notes |
+|---|---|---|---|
+| `identity_key` | ✅ | ✅ | Primary key |
+| `signing_key` | ✅ | ✅ | For verification |
+| `status` | ✅ | ✅ | ACTIVE or LEFT |
+| `timestamp` | ✅ | ✅ | Ordering |
+| `nickname` | ✅ | ✅ | Display name |
+| `signature` | ✅ | — | The signature itself |
+| `online` | ❌ | ❌ | Local only |
+| `last_seen` | ❌ | ❌ | Local only |
+
+### 5.2 `MidState` — one middleware instance
+
+```c
+typedef struct {
+    uint8_t  self_identity_key[MID_IDENTITY_KEY_SIZE];
+    uint8_t  self_signing_key[MID_SIGNING_KEY_SIZE];
+    uint8_t  self_secret_key[MID_SIGNING_SECRET_KEY_SIZE]; // wipe on free!
+    bool     have_keys;
+
+    uint8_t  self_nickname[MID_MAX_NICK_SIZE];
+    uint16_t self_nickname_len;
+    bool     self_active;
+
+    MidPeerRecord *records;   // dynamic array = the roster
+    size_t         count;
+    size_t         capacity;
+
+    uint64_t last_announce;          // last time we broadcast our own record
+    uint64_t last_roster_response;   // rate-limit for roster responses
+} MidState;
+```
+
+> One `MidState` can manage **multiple groups** if you keep one roster per group. In the simple one-group test, there is one `MidState`.
+
+---
+
+## 6. Wire Protocol
+
+### 6.1 Framing
+
+Every middleware packet begins with a 4-byte header:
+
+```
+offset  size  field
+─────   ────  ─────────────────────────
+0       1     MID_MAGIC_0        = 0xC7
+1       1     MID_MAGIC_1        = 0x91
+2       1     MID_PROTOCOL_VERSION = 1
+3       1     message_type       (see below)
+4       …     payload
+```
+
+The magic bytes let the middleware ignore custom packets that belong to other protocols sharing the same group.
+
+### 6.2 Message types
+
+| Value | Name | Direction | Payload |
+|---|---|---|---|
+| `1` | `MID_MSG_PRESENCE` | broadcast | One signed record |
+| `2` | `MID_MSG_ROSTER_REQUEST` | broadcast | empty (or optional) |
+
+### 6.3 `PRESENCE` payload layout
+
+```
+offset  size              field
+─────   ────────────────  ──────────────────────────────────────
+0       64                signature (Ed25519 over the body below)
+64      …                 ── record body (the part that is signed) ──
+  +0      1               status            (0=ACTIVE, 1=LEFT)
+  +1      8               timestamp         (big-endian)
+  +9      2               nickname_len      (big-endian)
+  +11     nickname_len    nickname bytes
+  …       2               identity_key_len  (big-endian)
+  …       identity_key_len identity_key
+  …       32              signing_key
+```
+
+> All multi-byte integers are **big-endian**.
+> The **signature covers the body only** (everything after the 64-byte signature), not the signature itself and not the 4-byte packet header.
+
+### 6.4 `ROSTER_REQUEST` payload
+
+Empty. It simply asks "does anyone have records I'm missing?" Receivers respond by broadcasting their signed records (see §8.4).
+
+---
+
+## 7. Record Lifecycle
+
+```
+                    ┌─────────────────────────────┐
+                    │        peer joins group      │
+                    └───────────────┬─────────────┘
+                                    │ signs ACTIVE record, broadcasts
+                                    ▼
+                    ┌─────────────────────────────┐
+                    │   ACTIVE record in roster    │◄────────────┐
+                    │   online = true              │             │ heartbeat
+                    └───────────────┬─────────────┘             │ re-signs &
+                                    │                            │ re-broadcasts
+                ┌───────────────────┼───────────────────┐        │
+                │                   │                   │        │
+       peer goes offline    peer sends LEFT      peer kicked/timeout
+                │                   │                   │
+                ▼                   ▼                   ▼
+        online=false         LEFT tombstone       online=false
+        (still in roster)    (status=LEFT,        (local only)
+                             overrides ACTIVE)
+```
+
+Key points:
+- Going **offline** only sets `online = false`. The record stays in the roster.
+- **Leaving** produces a signed `LEFT` tombstone that is *gossiped* and *overrides* earlier `ACTIVE` records.
+- Being kicked or timing out is detected locally (via Tox exit callback) and only flips `online`.
+
+---
+
+## 8. Core Algorithms
+
+### 8.1 Upsert (conflict resolution)
+
+This is the heart of the middleware. When a record arrives (over the wire or locally), it is merged into the roster:
+
+```
+upsert(incoming):
+    normalize(incoming)                       # clamp nickname, coerce status
+    if incoming.has_signature and not verify(incoming): REJECT
+
+    existing = find_by_identity(incoming.identity_key)
+
+    if not found:
+        insert(incoming); return
+
+    # Signing keys must never change for the same identity
+    if existing.has_signature and incoming.has_signature
+       and existing.signing_key != incoming.signing_key: REJECT
+
+    replace = false
+    if incoming.has_signature:
+        # signed beats unsigned; newer signed beats older signed
+        replace = (not existing.has_signature) or (incoming.timestamp > existing.timestamp)
+    else:
+        # unsigned only replaces unsigned, and only if not older
+        replace = (not existing.has_signature) and (incoming.timestamp >= existing.timestamp)
+
+    if replace:
+        merge(incoming into existing)
+        # preserve online flag heuristically
+        if incoming.status==ACTIVE and not incoming.online and existing.online:
+            keep online = true
+        if incoming.status==LEFT: online = false
+
+    # Live observation always refreshes presence (never membership)
+    if incoming.online and incoming.status==ACTIVE and incoming.last_seen >= existing.last_seen:
+        existing.online = true
+        existing.last_seen = incoming.last_seen
+```
+
+**Conflict-resolution summary:**
+
+| Incoming | Existing | Rule |
+|---|---|---|
+| signed, newer timestamp | signed | **replace** |
+| signed, older timestamp | signed | keep existing |
+| signed | unsigned | **replace** (signed beats unsigned) |
+| unsigned, newer | unsigned | **replace** |
+| unsigned, older | unsigned | keep existing |
+| any | signed with *different* signing key | **REJECT** (spoof) |
+
+### 8.2 Verification
+
+```
+verify(record):
+    if not record.has_signature: return false
+    if not valid_binding(record.identity_key, record.signing_key): return false
+    body = pack_body(record)                 # status+timestamp+nick+keys
+    return ed25519_verify(record.signature, body, record.signing_key)
+```
+
+### 8.3 Heartbeat (self announce)
+
+Inside `mid_iterate()`, if the peer is active and `MID_HEARTBEAT_SEC` has elapsed since the last announce, the peer re-signs and re-broadcasts its own `ACTIVE` record. This:
+- keeps the record fresh,
+- re-asserts membership after reconnects,
+- lets others refresh their view.
+
+### 8.4 Roster request / response
+
+- A peer broadcasts `MID_MSG_ROSTER_REQUEST` when it joins (or suspects it is behind).
+- Receivers respond by broadcasting all their signed records.
+- Responses are **rate-limited** (`MID_ROSTER_COOLDOWN_SEC`) to avoid flooding when many peers request at once.
+
+### 8.5 Online/offline sync with Tox
+
+`mid_iterate()` also reconciles the transient `online` flags with Tox's live peer list: any record marked `online` whose identity is **not** in Tox's current peer list is flipped to `online = false`. This keeps presence honest without touching the signed membership.
+
+---
+
+## 9. Public API Reference
+
+| Function | Purpose |
+|---|---|
+| `mid_new()` | Create a middleware instance (initialises libsodium). |
+| `mid_free(s)` | Free the instance; **wipes the secret key**. |
+| `mid_on_group_self_join(s, tox, group, nick, len)` | Call when *we* join/create a group. Fetches keys, announces self, requests roster. |
+| `mid_on_group_delete(s, group)` | Call when we leave/delete a group. Wipes keys & roster. |
+| `mid_on_group_peer_join(s, tox, group, peer_id)` | Call when another peer joins. Records them online & re-syncs. |
+| `mid_on_group_peer_exit(s, tox, group, exit_type)` | Call when a peer exits. Handles `QUIT` tombstone vs. offline. |
+| `mid_on_group_peer_name(s, tox, group, peer_id)` | Call when a peer renames. Updates local nickname. |
+| `mid_on_custom_packet(s, tox, group, peer_id, data, len)` | Feed incoming custom packets. Verifies & upserts. |
+| `mid_iterate(s, tox, group, now)` | Call every loop tick: heartbeat + online/offline sync. |
+| `mid_announce_leave(s, tox, group)` | Broadcast a signed `LEFT` tombstone (call before `tox_group_leave`). |
+| `mid_peer_count(s, group)` | Number of roster records. |
+| `mid_signed_count(s, group)` | Number of *signed* records. |
+| `mid_online_count(s, group)` | Number currently online. |
+| `mid_peer_is_signed_left(s, group, identity)` | Is there a signed `LEFT` tombstone for this identity? |
+| `mid_print_peer_table(s, group, title)` | Debug: print the roster table. |
+
+---
+
+## 10. Integration Guide (for a novice)
+
+This section shows exactly how to wire the middleware into a Tox NGC client.
+
+### Step 0 — Prerequisites
+
+Make sure your `toxcore` build exposes the three signing-key functions:
+
+- `tox_group_self_get_signing_secret_key()`
+- `tox_group_self_get_signing_public_key()`
+- `tox_group_peer_get_signing_public_key()`
+
+…and that you link `libsodium`.
+
+### Step 1 — Create the middleware
+
+After you create your `Tox` object:
+
+```c
+MidState *mid = mid_new();
+```
+
+### Step 2 — Register the Tox callbacks
+
+Register the normal NGC callbacks **and** forward each one into the middleware. Here is the wiring table:
+
+| Tox callback | What to call in the middleware |
+|---|---|
+| `tox_callback_group_self_join` | `mid_on_group_self_join(mid, tox, group, nick, nick_len)` |
+| `tox_callback_group_peer_join` | `mid_on_group_peer_join(mid, tox, group, peer_id)` |
+| `tox_callback_group_peer_exit` | `mid_on_group_peer_exit(mid, tox, group, exit_type)` |
+| `tox_callback_group_peer_name` | `mid_on_group_peer_name(mid, tox, group, peer_id)` |
+| `tox_callback_group_custom_packet` | `mid_on_custom_packet(mid, tox, group, peer_id, data, len)` |
+
+Example callback bodies:
+
+```c
+void on_group_self_join(Tox *tox, uint32_t group, void *ud) {
+    Client *c = ud;
+    mid_on_group_self_join(c->mid, tox, group, (const uint8_t*)c->nick, strlen(c->nick));
+}
+
+void on_group_peer_join(Tox *tox, uint32_t group, uint32_t peer_id, void *ud) {
+    Client *c = ud;
+    mid_on_group_peer_join(c->mid, tox, group, peer_id);
+}
+
+void on_group_peer_exit(Tox *tox, uint32_t group, uint32_t peer_id,
+                        Tox_Group_Exit_Type exit_type,
+                        const uint8_t *name, size_t name_len,
+                        const uint8_t *part, size_t part_len, void *ud) {
+    Client *c = ud;
+    mid_on_group_peer_exit(c->mid, tox, group, exit_type);
+}
+
+void on_group_custom_packet(Tox *tox, uint32_t group, uint32_t peer_id,
+                            const uint8_t *data, size_t len, void *ud) {
+    Client *c = ud;
+    mid_on_custom_packet(c->mid, tox, group, peer_id, data, len);
+}
+```
+
+### Step 3 — Drive the loop
+
+In your main loop, after `tox_iterate()`, call `mid_iterate()`:
+
+```c
+while (running) {
+    tox_iterate(tox, &client);
+    mid_iterate(client.mid, tox, group_number, time(NULL));
+    usleep(tox_iteration_interval(tox) * 1000);
+}
+```
+
+### Step 4 — Leaving a group
+
+**Before** calling `tox_group_leave()`, broadcast the `LEFT` tombstone so others remember you left:
+
+```c
+mid_announce_leave(client.mid, tox, group_number);
+tox_group_leave(tox, group_number, NULL, 0);
+mid_on_group_delete(client.mid, group_number);
+```
+
+### Step 5 — (Optional) Persistence
+
+The middleware keeps state in RAM. To persist across restarts, save/load the `records[]` array yourself. A simple approach:
+
+- **Save:** iterate `mid_peer_count()` / a getter and write each record to a file/DB.
+- **Load:** read them back and feed them into the middleware at startup (before joining).
+
+Because records are **signed**, you can safely reload them and the middleware will re-verify them.
+
+---
+
+## 11. Worked Scenarios
+
+### Scenario A — Peer joins, then goes offline, then a new peer joins
+
+```
+A, B online.  E joins.  → A, B, E all have ACTIVE(E).
+E goes offline.          → A, B set online(E)=false, keep the record.
+C joins (was offline).   → C requests roster.
+A/B broadcast records    → C receives ACTIVE(E) and learns E exists,
+                           even though E is offline.
+```
+
+✅ `C` sees `E` in the roster (marked offline), even though `E` is offline.
+
+### Scenario B — Peer leaves while others are offline
+
+```
+A, B online.  E sends LEFT tombstone.  → A, B store LEFT(E).
+E, A, B go offline.
+C, D come online (they never saw E).
+A or B comes back, syncs → C, D receive LEFT(E) tombstone.
+```
+
+✅ `C` and `D` learn that `E` existed and left, via the signed tombstone.
+
+### Scenario C — Why a signed tombstone is needed
+
+Without a tombstone, if `E` joined while `C`/`D` were offline and then everyone who saw `E` joined went offline, `C`/`D` would have no way to know `E` existed. The signed tombstone guarantees the *leave* event itself is propagated.
+
+---
+
+## 12. Edge Cases & Failure Modes
+
+| Case | Behaviour |
+|---|---|
+| Duplicate record arrives | Upsert is idempotent; same timestamp → no change. |
+| Forged record (wrong signing key) | Rejected by binding check or signature check. |
+| Signing key changes for an identity | Rejected (identity is bound to one signing key). |
+| Older signed record arrives after newer | Rejected (timestamp ordering). |
+| Peer crashes (no tombstone) | Detected locally via Tox exit; `online=false` only. No tombstone propagated. |
+| Peer leaves gracefully | Signed `LEFT` tombstone propagated; permanent. |
+| Network partition | Temporary disagreement; resolves when partitions heal and records re-gossip. |
+| Many peers request roster at once | Responses rate-limited by `MID_ROSTER_COOLDOWN_SEC`. |
+| Client restart | In-RAM state lost unless the app persists it (see §10 Step 5). |
+
+---
+
+## 13. Constants Reference
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `MID_IDENTITY_KEY_SIZE` | 32 | Identity key size |
+| `MID_SIGNING_KEY_SIZE` | 32 | Signing public key size |
+| `MID_SIGNING_SECRET_KEY_SIZE` | 64 | Signing secret key size |
+| `MID_MAX_NICK_SIZE` | 128 | Max nickname bytes |
+| `MID_SIG_SIZE` | 64 | Ed25519 signature size |
+| `MID_MAX_PACKET_SIZE` | 1200 | Max custom packet size used |
+| `MID_MAGIC_0` | `0xC7` | Magic byte 0 |
+| `MID_MAGIC_1` | `0x91` | Magic byte 1 |
+| `MID_PROTOCOL_VERSION` | 1 | Protocol version |
+| `MID_MSG_PRESENCE` | 1 | Signed-record message |
+| `MID_MSG_ROSTER_REQUEST` | 2 | Roster request message |
+| `MID_STATUS_ACTIVE` | 0 | Member is active |
+| `MID_STATUS_LEFT` | 1 | Member left (tombstone) |
+| `MID_HEARTBEAT_SEC` | 10 | Self re-announce interval |
+| `MID_ROSTER_COOLDOWN_SEC` | 30 | Roster-response rate limit |
+
+---
+
+## 14. Summary for Reimplementation
+
+To rebuild this middleware from scratch, a C programmer needs to implement:
+
+1. **Identity handling** — fetch identity + signing + secret keys; enforce the binding check.
+2. **Record format** — the exact byte layout in §6, big-endian, signature-over-body.
+3. **Ed25519 sign/verify** — via libsodium, over the packed body.
+4. **Upsert with conflict rules** — §8.1 (signed beats unsigned; newer timestamp wins; signing key immutable).
+5. **Gossip** — broadcast signed records; respond to roster requests (rate-limited).
+6. **Heartbeat** — periodically re-sign & re-broadcast our own `ACTIVE` record.
+7. **Online/offline sync** — reconcile transient presence with Tox's live peer list.
+8. **Tombstones** — on graceful leave, sign & broadcast `LEFT`; let it override `ACTIVE`.
+9. **A tiny public API** — the table in §9, driven entirely from Tox callbacks + one loop call.
+
+That is the entire middleware. It is deliberately small, stateless across the network, and eventually consistent — relying on **signed records + gossip** rather than any server.

--- a/ngc_ppeerlist/mid_roster.c
+++ b/ngc_ppeerlist/mid_roster.c
@@ -1,0 +1,3817 @@
+/*
+mid_roster.c
+Minimal persistent group-roster middleware for Tox NGC.
+
+Goal:
+Maintain a stable peer list that can include offline peers.
+This is a best-effort, eventually consistent P2P solution.
+
+Transport:
+Uses only tox_group_send_custom_packet().
+
+Crypto:
+Uses libsodium Ed25519 signatures.
+Each peer signs their own JOIN / LEAVE / presence updates.
+
+KEY MODEL -- VERY IMPORTANT
+
+Tox NGC has multiple keys. This middleware uses three distinct keys:
+
+identity_key
+This is the normal 32-byte Tox NGC group peer public key.
+Tox NGC exposes a 32-byte group identity public key:
+tox_group_self_get_public_key()
+tox_group_peer_get_public_key()
+This key is used as the main roster lookup key.
+It is the persistent peer identity inside the group.
+In typical NGC extended-key layout, this is the Curve25519 encryption
+public key derived from the peer's Ed25519 signing key.
+
+signing_key
+This is the 32-byte Ed25519 public signing key belonging to the same
+NGC group identity.
+For signing/verification we also need Ed25519 keys:
+tox_group_self_get_signing_secret_key()      [patched]
+tox_group_self_get_signing_public_key()      [patched]
+For other peers we need:
+tox_group_peer_get_signing_public_key()      [patched]
+This key is used to verify signatures made by that peer.
+
+self_secret_signing_key
+This is the Ed25519 secret signing key for our own NGC group identity.
+It is obtained from the patched API:
+tox_group_self_get_signing_secret_key()
+This is NOT:
+the long-term Tox one-to-one secret key
+the NGC encryption secret key
+the group shared secret
+It is specifically the Ed25519 signing secret key.
+
+Signed presence records
+A presence record contains:
+status          ACTIVE / LEFT
+timestamp       sender-generated timestamp / logical version
+nickname        optional peer nickname
+identity_key    normal Tox NGC identity public key
+signing_key     Ed25519 public signing key
+The record is signed with the peer's Ed25519 signing secret key.
+The signature is verified with the Ed25519 signing public key.
+The identity_key and signing_key are both included in the signed body so
+that offline peers can be verified later as long as their signing key is
+known.
+
+Key binding:
+This middleware checks that the Ed25519 signing key belongs to the Tox
+NGC identity key.
+In normal NGC extended-key design:
+identity_key == curve25519_from_ed25519(signing_key)
+For compatibility, direct equality is also accepted:
+identity_key == signing_key
+
+Storage:
+No storage backend is implemented.
+Use:
+mid_peer_count()
+mid_signed_count()
+mid_online_count()
+to attach any storage backend later.
+
+Nickname safety:
+Toxcore nicknames are raw uint8_t buffers. They are NOT guaranteed to be
+valid UTF-8, NOT guaranteed to be printable ASCII, and NOT guaranteed to
+be NUL-terminated. They may contain embedded NUL bytes or arbitrary binary.
+This middleware treats all nicknames as opaque byte arrays with an
+explicit length. No C-string functions (strlen, strcmp, strcpy, printf %s)
+are ever used on nickname data. All copies are bounded by explicit lengths
+and destination buffers are zero-filled before use.
+
+Thread-safety model:
+All public API functions acquire a single non-recursive pthread_mutex_t
+(similar to tox_lock/tox_unlock in Toxcore) before touching any internal
+state. Internal "_internal" helper functions assume the lock is ALREADY
+held and must NEVER be called without it. Callbacks are always invoked
+AFTER the lock is released to prevent deadlocks when the client calls
+back into the middleware from within the callback.
+
+IMPORTANT: Internal functions must only call other "_internal" functions,
+never the public (locking) wrappers. This guarantees no deadlock with a
+non-recursive mutex.
+
+Requirements:
+Toxcore NGC
+tox_group_send_custom_packet()
+tox_group_self_get_public_key()
+tox_group_peer_get_public_key()
+tox_group_self_get_signing_secret_key()      [patched]
+tox_group_self_get_signing_public_key()      [patched]
+tox_group_peer_get_signing_public_key()      [patched]
+libsodium
+*/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+#include <pthread.h>
+#include "../toxcore/tox.h"
+#include "../toxencryptsave/toxencryptsave.h"
+#include <sodium.h>
+#include "mid_roster.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+#ifndef MID_DEBUG_LOGGING
+#define printf(...) ((void)0)
+#define fflush(x)   ((void)0)
+#endif
+
+
+/******************************************************************************
+Tox key-size constants
+******************************************************************************/
+
+#ifndef TOX_GROUP_PEER_PUBLIC_KEY_SIZE
+#define TOX_GROUP_PEER_PUBLIC_KEY_SIZE 32
+#endif
+
+#ifndef TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE
+#define TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE 32
+#endif
+
+#ifndef TOX_GROUP_SIGNING_SECRET_KEY_SIZE
+#define TOX_GROUP_SIGNING_SECRET_KEY_SIZE 64
+#endif
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+/******************************************************************************
+Middleware key-size constants
+******************************************************************************/
+
+static const uint8_t MID_MAGIC[MID_MAGIC_BYTES_TOTAL] = {
+    MID_MAGIC_0,
+    MID_MAGIC_1,
+    MID_MAGIC_2
+};
+
+#define MID_SAVE_MAGIC       "MIDR"
+#define MID_SAVE_MAGIC_SIZE  4
+#define MID_SAVE_VERSION     3
+#define MID_MAX_GROUPS       1000
+
+#define MID_BUF_INIT_CAP 4096
+#define MID_MAX_CHANGED_GROUPS_PER_ITERATE 256
+
+#define MID_SIGNING_SECRET_KEY_SIZE TOX_GROUP_SIGNING_SECRET_KEY_SIZE
+
+#if MID_IDENTITY_KEY_SIZE != 32
+#error "mid_roster.c currently requires TOX_GROUP_PEER_PUBLIC_KEY_SIZE == 32"
+#endif
+
+#if MID_SIGNING_KEY_SIZE != 32
+#error "mid_roster.c currently requires TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE == 32"
+#endif
+
+#if MID_SIGNING_SECRET_KEY_SIZE != 64
+#error "mid_roster.c requires TOX_GROUP_SIGNING_SECRET_KEY_SIZE == 64"
+#endif
+
+#define MID_SIG_SIZE            64
+#define MID_MAX_PACKET_SIZE     1200
+#define MID_ROSTER_COOLDOWN_SEC 30
+/* FIX 4: Increased heartbeat interval from 50s to 300s (5 mins) to save traffic */
+#define MID_HEARTBEAT_SEC       300
+
+#define MID_RECORD_STATUS_SIZE    sizeof(uint8_t)
+#define MID_RECORD_TIMESTAMP_SIZE sizeof(uint64_t)
+#define MID_RECORD_NICKLEN_SIZE   sizeof(uint16_t)
+
+#define MID_RECORD_FIXED_BODY_SIZE (MID_RECORD_STATUS_SIZE + MID_RECORD_TIMESTAMP_SIZE + MID_RECORD_NICKLEN_SIZE)
+
+#define MID_HEARTBEAT_BODY_SIZE (MID_RECORD_STATUS_SIZE + MID_RECORD_TIMESTAMP_SIZE + MID_IDENTITY_KEY_SIZE)
+
+
+/*
+Throttle for the heavy sync/cleanup loop in mid_iterate().
+xx second is fast enough for responsive UI, but slow enough to avoid
+hammering Toxcore on every 50ms tox_iterate() tick.
+*/
+#define MID_SYNC_INTERVAL_SEC   5
+
+
+#define MID_MAX_BODY_SIZE (MID_RECORD_FIXED_BODY_SIZE + MID_MAX_NICK_SIZE + \
+                           MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE)
+
+/*
+Time-To-Live for LEFT tombstones.
+We keep them in the roster for 7 days so that offline peers who come
+back online can sync and receive cryptographic proof of the departure.
+*/
+#define MID_TOMBSTONE_TTL_SEC (7 * 24 * 60 * 60)
+
+/*
+Time-To-Live for "Zombie" peers (offline ACTIVE peers who never sent a LEFT tombstone).
+30 days is safe because Toxcore's network timeout is much shorter, and our 5-minute
+heartbeats guarantee last_seen stays fresh for actually active peers.
+*/
+#define MID_STALE_PEER_TTL_SEC (30 * 24 * 60 * 60)
+
+
+typedef enum {
+    MID_STATUS_ACTIVE = 0,
+    MID_STATUS_LEFT   = 1
+} MidStatus;
+
+typedef enum {
+    MID_MSG_PRESENCE       = 1,
+    MID_MSG_ROSTER_REQUEST = 2,
+    MID_MSG_HEARTBEAT      = 3, /* FIX 3: Lightweight heartbeat message */
+    MID_MSG_ROSTER_BATCH   = 4  /* FIX 5: Batched roster response message */
+} MidMsg;
+
+typedef struct {
+    uint8_t identity_key[MID_IDENTITY_KEY_SIZE];
+    uint8_t signing_key[MID_SIGNING_KEY_SIZE];
+    uint8_t  status;
+    uint64_t timestamp;
+    uint8_t  nickname[MID_MAX_NICK_SIZE];
+    uint16_t nickname_len;
+    uint8_t  signature[MID_SIG_SIZE];
+    bool     has_signature;
+    Tox_Connection connection_status;
+    Tox_Group_Role role;
+    uint64_t last_seen;
+} MidPeerRecord;
+
+typedef struct {
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    uint8_t self_identity_key[MID_IDENTITY_KEY_SIZE];
+    uint8_t self_signing_key[MID_SIGNING_KEY_SIZE];
+    uint8_t self_secret_signing_key[MID_SIGNING_SECRET_KEY_SIZE];
+    bool     have_keys;
+    uint8_t  self_nickname[MID_MAX_NICK_SIZE];
+    uint16_t self_nickname_len;
+    bool     self_active;
+    bool     announced;
+    MidPeerRecord *records;
+    size_t         count;
+    size_t         capacity;
+    uint64_t last_announce;
+    uint64_t last_roster_response;
+    uint64_t roster_reply_deadline; /* FIX 2: Multicast suppression timer */
+    uint8_t  roster_fingerprint[MID_IDENTITY_KEY_SIZE]; /* Incremental XOR sum of all signed identity keys */
+} MidGroupState;
+
+/*
+The actual definition of the opaque MidState struct.
+*/
+struct MidState {
+    MidGroupState *groups;
+    size_t         group_count;
+    size_t         group_capacity;
+
+    /*
+     * Peer-list-changed callback.
+     * Called whenever the roster for any group is mutated.
+     */
+    mid_peer_list_changed_cb peer_list_changed_cb;
+    void                    *peer_list_changed_user_data;
+
+    /*
+     * Thread-safety mutex (non-recursive).
+     * Protects all internal state. Modeled after tox->mutex in Toxcore.
+     * All public entry points call mid_lock()/mid_unlock().
+     * Internal "_internal" functions assume the lock is already held.
+     */
+    pthread_mutex_t *mutex;
+
+    /*
+     * Timestamp of the last heavy sync/cleanup pass in mid_iterate().
+     */
+    uint64_t last_sync_time;
+
+    /*
+     * Network statistics (custom packets only).
+     */
+    uint64_t sent_bytes;
+    uint64_t recv_bytes;
+
+    char *save_path;
+};
+
+/******************************************************************************
+Thread-safety helpers
+Modeled after tox_lock()/tox_unlock() in Toxcore.
+The mutex is non-recursive; internal code paths must never re-lock.
+******************************************************************************/
+
+static void mid_lock(MidState *s)
+{
+    if (s != NULL && s->mutex != NULL) {
+        pthread_mutex_lock(s->mutex);
+    }
+}
+
+static void mid_unlock(MidState *s)
+{
+    if (s != NULL && s->mutex != NULL) {
+        pthread_mutex_unlock(s->mutex);
+    }
+}
+
+/******************************************************************************
+Small helper functions
+******************************************************************************/
+
+static uint64_t mid_now_or_time(uint64_t now)
+{
+    if (now != 0) {
+        return now;
+    }
+    return (uint64_t)time(NULL);
+}
+
+static void mid_put_u16_be(uint8_t *p, uint16_t v)
+{
+    p[0] = (uint8_t)(v >> 8);
+    p[1] = (uint8_t)(v & 0xFF);
+}
+
+static void mid_put_u64_be(uint8_t *p, uint64_t v)
+{
+    p[0] = (uint8_t)(v >> 56);
+    p[1] = (uint8_t)(v >> 48);
+    p[2] = (uint8_t)(v >> 40);
+    p[3] = (uint8_t)(v >> 32);
+    p[4] = (uint8_t)(v >> 24);
+    p[5] = (uint8_t)(v >> 16);
+    p[6] = (uint8_t)(v >> 8);
+    p[7] = (uint8_t)(v & 0xFF);
+}
+
+static uint16_t mid_get_u16_be(const uint8_t *p)
+{
+    return (uint16_t)((uint16_t)p[0] << 8 | p[1]);
+}
+
+static uint64_t mid_get_u64_be(const uint8_t *p)
+{
+    uint64_t v = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); i++) {
+        v = (v << 8) | p[i];
+    }
+    return v;
+}
+
+static char *mid_strdup(const char *s) {
+    if (!s) return NULL;
+    size_t len = strlen(s) + 1;
+    char *d = (char *)malloc(len);
+    if (d) memcpy(d, s, len);
+    return d;
+}
+
+static void mid_put_u32_be(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v >> 24); p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);  p[3] = (uint8_t)(v & 0xFF);
+}
+
+static uint32_t mid_get_u32_be(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8)  | ((uint32_t)p[3]);
+}
+
+/* Dynamic Buffer for Serialization */
+typedef struct { uint8_t *data; size_t len; size_t cap; } MidBuf;
+
+static void mid_buf_init(MidBuf *b) { b->data = NULL; b->len = 0; b->cap = 0; }
+
+static void mid_buf_free(MidBuf *b) { free(b->data); b->data = NULL; b->len = 0; b->cap = 0; }
+
+static bool mid_buf_ensure(MidBuf *b, size_t extra) {
+    if (b->len + extra <= b->cap) return true;
+
+    // Prevent overflow in b->len + extra
+    if (extra > SIZE_MAX - b->len) return false;
+    size_t required = b->len + extra;
+
+    size_t new_cap = (b->cap == 0) ? MID_BUF_INIT_CAP : b->cap;
+    while (new_cap < required) {
+        if (new_cap > SIZE_MAX / 2) return false; // Prevent overflow
+        new_cap *= 2;
+    }
+
+    uint8_t *tmp = realloc(b->data, new_cap);
+    if (!tmp) return false;
+    b->data = tmp; b->cap = new_cap; return true;
+}
+
+static void mid_buf_append(MidBuf *b, const void *data, size_t len) {
+    if (len == 0) return;
+    if (mid_buf_ensure(b, len)) { memcpy(b->data + b->len, data, len); b->len += len; }
+}
+
+static void mid_buf_append_u8(MidBuf *b, uint8_t v) { mid_buf_append(b, &v, 1); }
+static void mid_buf_append_u16(MidBuf *b, uint16_t v) { uint8_t tmp[2]; mid_put_u16_be(tmp, v); mid_buf_append(b, tmp, 2); }
+static void mid_buf_append_u32(MidBuf *b, uint32_t v) { uint8_t tmp[4]; mid_put_u32_be(tmp, v); mid_buf_append(b, tmp, 4); }
+static void mid_buf_append_u64(MidBuf *b, uint64_t v) { uint8_t tmp[8]; mid_put_u64_be(tmp, v); mid_buf_append(b, tmp, 8); }
+
+/* Binary Reader for Deserialization */
+typedef struct { const uint8_t *data; size_t len; size_t pos; } MidReader;
+
+static bool mid_reader_has(MidReader *r, size_t need) { return r->pos + need <= r->len; }
+
+static bool mid_reader_read(MidReader *r, void *out, size_t len) {
+    if (!mid_reader_has(r, len)) return false;
+    memcpy(out, r->data + r->pos, len); r->pos += len; return true;
+}
+
+static bool mid_reader_read_u8(MidReader *r, uint8_t *out) { return mid_reader_read(r, out, 1); }
+
+static bool mid_reader_read_u16(MidReader *r, uint16_t *out) {
+    uint8_t tmp[2]; if (!mid_reader_read(r, tmp, 2)) return false;
+    *out = mid_get_u16_be(tmp); return true;
+}
+
+static bool mid_reader_read_u32(MidReader *r, uint32_t *out) {
+    uint8_t tmp[4]; if (!mid_reader_read(r, tmp, 4)) return false;
+    *out = mid_get_u32_be(tmp); return true;
+}
+
+static bool mid_reader_read_u64(MidReader *r, uint64_t *out) {
+    uint8_t tmp[8]; if (!mid_reader_read(r, tmp, 8)) return false;
+    *out = mid_get_u64_be(tmp); return true;
+}
+
+static bool mid_key_is_zero(const uint8_t key[32])
+{
+    for (int i = 0; i < 32; i++) {
+        if (key[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void mid_xor_fingerprint(uint8_t fp[MID_IDENTITY_KEY_SIZE], const uint8_t key[MID_IDENTITY_KEY_SIZE])
+{
+    for (size_t i = 0; i < MID_IDENTITY_KEY_SIZE; i++) {
+        fp[i] ^= key[i];
+    }
+}
+
+static bool mid_same_identity(const uint8_t a[MID_IDENTITY_KEY_SIZE],
+                              const uint8_t b[MID_IDENTITY_KEY_SIZE])
+{
+    return memcmp(a, b, MID_IDENTITY_KEY_SIZE) == 0;
+}
+
+static bool mid_same_signing_key(const uint8_t a[MID_SIGNING_KEY_SIZE],
+                                 const uint8_t b[MID_SIGNING_KEY_SIZE])
+{
+    return memcmp(a, b, MID_SIGNING_KEY_SIZE) == 0;
+}
+
+static bool mid_valid_key_binding(const uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                                  const uint8_t signing_key[MID_SIGNING_KEY_SIZE])
+{
+    if (mid_key_is_zero(identity_key) || mid_key_is_zero(signing_key)) {
+        printf("[MID] valid_key_binding: rejected, zero key\n"); fflush(stdout);
+        return false;
+    }
+
+    uint8_t derived_curve_pk[32];
+    if (crypto_sign_ed25519_pk_to_curve25519(derived_curve_pk, signing_key) != 0) {
+        printf("[MID] valid_key_binding: rejected, curve25519 derivation failed\n"); fflush(stdout);
+        return false;
+    }
+
+    if (mid_same_identity(identity_key, derived_curve_pk)) {
+        printf("[MID] valid_key_binding: accepted, curve25519 derived match\n"); fflush(stdout);
+        return true;
+    }
+
+    printf("[MID] valid_key_binding: rejected, no match\n"); fflush(stdout);
+    return false;
+}
+
+static uint32_t mid_chat_id_to_group_number(const Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (tox == NULL || chat_id == NULL) return UINT32_MAX;
+    Tox_Err_Group_State_Queries err;
+    uint32_t gnum = tox_group_by_chat_id(tox, chat_id, &err);
+    if (err != TOX_ERR_GROUP_STATE_QUERIES_OK) {
+        return UINT32_MAX;
+    }
+    return gnum;
+}
+
+static MidGroupState *mid_find_group(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (s == NULL || chat_id == NULL) return NULL;
+    for (size_t i = 0; i < s->group_count; i++) {
+        if (memcmp(s->groups[i].chat_id, chat_id, TOX_GROUP_CHAT_ID_SIZE) == 0) {
+            return &s->groups[i];
+        }
+    }
+    return NULL;
+}
+
+static const MidGroupState *mid_find_group_const(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    return mid_find_group((MidState *)s, chat_id);
+}
+
+static MidGroupState *mid_add_group(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (s == NULL || chat_id == NULL) return NULL;
+
+    if (s->group_count >= s->group_capacity) {
+        size_t new_cap = (s->group_capacity == 0) ? 4 : s->group_capacity * 2;
+        MidGroupState *tmp = realloc(s->groups, new_cap * sizeof(MidGroupState));
+        if (tmp == NULL) return NULL;
+        s->groups = tmp;
+        s->group_capacity = new_cap;
+    }
+
+    MidGroupState *g = &s->groups[s->group_count++];
+    memset(g, 0, sizeof(*g));
+    memcpy(g->chat_id, chat_id, TOX_GROUP_CHAT_ID_SIZE);
+    return g;
+}
+
+static bool mid_evict_oldest_offline_active(MidGroupState *g)
+{
+    if (g == NULL || g->count == 0) {
+        return false;
+    }
+
+    size_t oldest = g->count;
+    uint64_t oldest_seen = 0;
+
+    for (size_t i = 0; i < g->count; i++) {
+        const MidPeerRecord *r = &g->records[i];
+
+        /* Only ACTIVE peers that are currently offline are evictable. */
+        if (r->status != MID_STATUS_ACTIVE ||
+            r->connection_status != TOX_CONNECTION_NONE) {
+            continue;
+        }
+
+        /* Never evict our own record. */
+        if (!mid_key_is_zero(g->self_identity_key) &&
+            mid_same_identity(r->identity_key, g->self_identity_key)) {
+            continue;
+        }
+
+        /* last_seen == 0 is treated as the oldest possible value. */
+        if (oldest == g->count || r->last_seen < oldest_seen) {
+            oldest = i;
+            oldest_seen = r->last_seen;
+        }
+    }
+
+    if (oldest == g->count) {
+        return false;
+    }
+
+    printf("[MID] evict_peer: evicting oldest offline ACTIVE peer %zu\n", oldest); fflush(stdout);
+
+    if (g->records[oldest].has_signature) {
+        printf("[MID] evict_peer: XOR OUT evicted peer. Old FP[0..3]=%02X%02X%02X%02X\n",
+               g->roster_fingerprint[0],
+               g->roster_fingerprint[1],
+               g->roster_fingerprint[2],
+               g->roster_fingerprint[3]);
+        fflush(stdout);
+
+        mid_xor_fingerprint(g->roster_fingerprint, g->records[oldest].identity_key);
+
+        printf("[MID] evict_peer: New FP[0..3]=%02X%02X%02X%02X\n",
+               g->roster_fingerprint[0],
+               g->roster_fingerprint[1],
+               g->roster_fingerprint[2],
+               g->roster_fingerprint[3]);
+        fflush(stdout);
+    }
+
+    for (size_t k = oldest; k + 1 < g->count; k++) {
+        g->records[k] = g->records[k + 1];
+    }
+
+    g->count--;
+
+    return true;
+}
+
+static bool mid_ensure_capacity(MidGroupState *g)
+{
+    if (g == NULL) {
+        return false;
+    }
+
+    if (g->count >= MID_MAX_PEERS_PER_GROUP) {
+        printf("[MID] ensure_capacity: peer limit %d reached, trying eviction\n", MID_MAX_PEERS_PER_GROUP); fflush(stdout);
+
+        if (!mid_evict_oldest_offline_active(g)) {
+            printf("[MID] ensure_capacity: rejected, peer limit %d reached and no offline ACTIVE peer to evict\n", MID_MAX_PEERS_PER_GROUP); fflush(stdout);
+            return false;
+        }
+
+        if (g->count >= MID_MAX_PEERS_PER_GROUP) {
+            printf("[MID] ensure_capacity: still at peer limit after eviction\n"); fflush(stdout);
+            return false;
+        }
+    }
+
+    if (g->count < g->capacity) {
+        return true;
+    }
+
+    size_t new_capacity = (g->capacity == 0) ? 16 : g->capacity * 2;
+
+    if (new_capacity > MID_MAX_PEERS_PER_GROUP) {
+        new_capacity = MID_MAX_PEERS_PER_GROUP;
+        printf("[MID] ensure_capacity: new_capacity cut to limit\n"); fflush(stdout);
+    }
+
+    printf("[MID] ensure_capacity: reallocating from %zu to %zu\n", g->capacity, new_capacity); fflush(stdout);
+
+    MidPeerRecord *tmp = realloc(g->records, new_capacity * sizeof(MidPeerRecord));
+    if (tmp == NULL) {
+        printf("[MID] ensure_capacity: realloc failed\n"); fflush(stdout);
+        return false;
+    }
+
+    g->records = tmp;
+    g->capacity = new_capacity;
+    return true;
+}
+
+static int mid_find_identity(const MidGroupState *g,
+                             const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    for (size_t i = 0; i < g->count; i++) {
+        if (mid_same_identity(g->records[i].identity_key, identity_key)) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+/******************************************************************************
+Record serialization and crypto
+******************************************************************************/
+
+static bool mid_pack_record_body(uint8_t *buf,
+                                 size_t cap,
+                                 const MidPeerRecord *r,
+                                 size_t *out_len)
+{
+    if (r->nickname_len > MID_MAX_NICK_SIZE) {
+        return false;
+    }
+
+    if (mid_key_is_zero(r->identity_key)) {
+        return false;
+    }
+
+    size_t need = MID_RECORD_FIXED_BODY_SIZE + r->nickname_len + MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE;
+
+    if (need > cap) {
+        printf("[MID] pack_record_body: rejected, need %zu > cap %zu\n", need, cap); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] pack_record_body: packing %zu bytes\n", need); fflush(stdout);
+
+    size_t o = 0;
+    buf[o++] = r->status;
+    mid_put_u64_be(buf + o, r->timestamp);
+    o += 8;
+    mid_put_u16_be(buf + o, r->nickname_len);
+    o += 2;
+    if (r->nickname_len > 0) {
+        memcpy(buf + o, r->nickname, r->nickname_len);
+        o += r->nickname_len;
+    }
+    memcpy(buf + o, r->identity_key, MID_IDENTITY_KEY_SIZE);
+    o += MID_IDENTITY_KEY_SIZE;
+    memcpy(buf + o, r->signing_key, MID_SIGNING_KEY_SIZE);
+    o += MID_SIGNING_KEY_SIZE;
+
+    if (out_len != NULL) {
+        *out_len = o;
+    }
+    return true;
+}
+
+static bool mid_unpack_record_body(MidPeerRecord *r,
+                                   const uint8_t *buf,
+                                   size_t len)
+{
+    memset(r, 0, sizeof(*r));
+
+    size_t o = 0;
+    size_t min_len = MID_RECORD_FIXED_BODY_SIZE + MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE;
+
+    if (len < min_len) {
+        printf("[MID] unpack_record_body: rejected, len %zu < min_len %zu\n", len, min_len); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] unpack_record_body: unpacking %zu bytes\n", len); fflush(stdout);
+
+    r->status = buf[o++];
+    if (r->status != MID_STATUS_ACTIVE && r->status != MID_STATUS_LEFT) {
+        return false;
+    }
+
+    r->timestamp = mid_get_u64_be(buf + o);
+    o += 8;
+
+    r->nickname_len = mid_get_u16_be(buf + o);
+    o += 2;
+
+    if (r->nickname_len > MID_MAX_NICK_SIZE) {
+        return false;
+    }
+
+    if (o + r->nickname_len + MID_IDENTITY_KEY_SIZE + MID_SIGNING_KEY_SIZE > len) {
+        return false;
+    }
+
+    if (r->nickname_len > 0) {
+        memcpy(r->nickname, buf + o, r->nickname_len);
+        o += r->nickname_len;
+    }
+
+    memcpy(r->identity_key, buf + o, MID_IDENTITY_KEY_SIZE);
+    o += MID_IDENTITY_KEY_SIZE;
+
+    memcpy(r->signing_key, buf + o, MID_SIGNING_KEY_SIZE);
+    o += MID_SIGNING_KEY_SIZE;
+
+    if (mid_key_is_zero(r->identity_key)) {
+        return false;
+    }
+
+    r->has_signature = false;
+    r->connection_status = TOX_CONNECTION_NONE;
+    r->role = TOX_GROUP_ROLE_USER;
+    r->last_seen = 0;
+    return true;
+}
+
+static bool mid_verify_record(const MidPeerRecord *r)
+{
+    if (!r->has_signature) {
+        printf("[MID] verify_record: rejected, no signature\n"); fflush(stdout);
+        return false;
+    }
+
+    if (!mid_valid_key_binding(r->identity_key, r->signing_key)) {
+        printf("[MID] verify_record: rejected, invalid key binding\n"); fflush(stdout);
+        return false;
+    }
+
+    uint8_t body[MID_MAX_BODY_SIZE];
+    size_t body_len = 0;
+    if (!mid_pack_record_body(body, sizeof(body), r, &body_len)) {
+        return false;
+    }
+
+    int res = crypto_sign_verify_detached(r->signature,
+                                          body,
+                                          body_len,
+                                          r->signing_key);
+
+    if (res == 0) {
+        printf("[MID] verify_record: signature VALID\n"); fflush(stdout);
+        return true;
+    } else {
+        printf("[MID] verify_record: signature INVALID\n"); fflush(stdout);
+        return false;
+    }
+}
+
+static bool mid_sign_record(MidGroupState *g, MidPeerRecord *r)
+{
+    if (!g->have_keys) {
+        printf("[MID] sign_record: failed, no keys\n"); fflush(stdout);
+        return false;
+    }
+
+    uint8_t body[MID_MAX_BODY_SIZE];
+    size_t body_len = 0;
+    if (!mid_pack_record_body(body, sizeof(body), r, &body_len)) {
+        return false;
+    }
+
+    unsigned long long sig_len = 0;
+    if (crypto_sign_detached(r->signature,
+                             &sig_len,
+                             body,
+                             body_len,
+                             g->self_secret_signing_key) != 0) {
+        printf("[MID] sign_record: crypto_sign_detached failed\n"); fflush(stdout);
+        return false;
+    }
+
+    if (sig_len != MID_SIG_SIZE) {
+        printf("[MID] sign_record: unexpected sig_len %llu\n", sig_len); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] sign_record: successfully signed %zu bytes\n", body_len); fflush(stdout);
+    r->has_signature = true;
+    return true;
+}
+
+/******************************************************************************
+Roster record upsert
+Returns true if the roster was actually modified (inserted or updated).
+
+This version maintains g->roster_fingerprint by XORing the 32-byte 
+identity_key of every peer that has a valid signature. 
+
+This means the fingerprint tracks the SET of signed peers. It changes when:
+  - a signed peer is added
+  - a signed peer is removed
+  - an unsigned peer becomes signed
+  
+It does NOT change when a signed peer updates their nickname or timestamp.
+******************************************************************************/
+
+static bool mid_upsert_record(MidGroupState *g, const MidPeerRecord *in)
+{
+    printf("[MID] upsert_record: processing record\n");
+    fflush(stdout);
+
+    if (g == NULL || in == NULL) {
+        return false;
+    }
+
+    MidPeerRecord tmp = *in;
+
+    if (mid_key_is_zero(tmp.identity_key)) {
+        printf("[MID] upsert_record: rejected, zero identity key\n");
+        fflush(stdout);
+        return false;
+    }
+
+    if (tmp.status != MID_STATUS_ACTIVE && tmp.status != MID_STATUS_LEFT) {
+        printf("[MID] upsert_record: rejected, invalid status\n");
+        fflush(stdout);
+        return false;
+    }
+
+    if (tmp.nickname_len > MID_MAX_NICK_SIZE) {
+        printf("[MID] upsert_record: rejected, nickname too long\n");
+        fflush(stdout);
+        return false;
+    }
+
+    /*
+     * Unsigned records do not carry a valid persistent signature.
+     * Zero the signature field so it cannot accidentally influence later logic.
+     */
+    if (!tmp.has_signature) {
+        memset(tmp.signature, 0, sizeof(tmp.signature));
+    }
+
+    /*
+     * Verify signed records before touching any state.
+     */
+    if (tmp.has_signature && !mid_verify_record(&tmp)) {
+        printf("[MID] upsert_record: rejected, signature verification failed\n");
+        fflush(stdout);
+        return false;
+    }
+
+    /**************************************************************************
+     * SIGNED LEFT TOMBSTONE PATH
+     *
+     * Signed LEFT tombstones are authoritative departure records.
+     * They must be stored and forwarded so offline peers can later learn
+     * cryptographically that this identity left.
+     *************************************************************************/
+    if (tmp.has_signature && tmp.status == MID_STATUS_LEFT) {
+        int idx = mid_find_identity(g, tmp.identity_key);
+
+        if (idx >= 0) {
+            MidPeerRecord *ex = &g->records[idx];
+
+            /*
+             * If we already have a signed record for this identity, the
+             * signing key may not change.
+             */
+            if (ex->has_signature &&
+                tmp.has_signature &&
+                !mid_same_signing_key(ex->signing_key, tmp.signing_key)) {
+                printf("[MID] upsert_record: rejected LEFT tombstone, signing key changed\n");
+                fflush(stdout);
+                return false;
+            }
+
+            /*
+             * For tombstones we use >= so that a LEFT tombstone with the
+             * same timestamp as the last ACTIVE record still wins.
+             */
+            if (tmp.timestamp >= ex->timestamp) {
+                bool same_signature =
+                    ex->has_signature &&
+                    tmp.has_signature &&
+                    memcmp(ex->signature, tmp.signature, MID_SIG_SIZE) == 0;
+
+                /*
+                 * If we already have this exact tombstone and it is already
+                 * marked offline, there is nothing to do.
+                 */
+                if (same_signature && ex->connection_status == TOX_CONNECTION_NONE) {
+                    printf("[MID] upsert_record: identical LEFT tombstone already stored\n");
+                    fflush(stdout);
+                    return false;
+                }
+
+                /* 
+                 * Track if this peer is transitioning from unsigned to signed.
+                 * If they were already signed, they are already in the fingerprint set.
+                 */
+                bool gained_signature = !ex->has_signature && tmp.has_signature;
+
+                *ex = tmp;
+                ex->connection_status = TOX_CONNECTION_NONE;
+
+                if (gained_signature) {
+                    printf("[MID] upsert_record: XOR IN tombstone transition. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                    mid_xor_fingerprint(g->roster_fingerprint, ex->identity_key);
+                    printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                }
+
+                printf("[MID] upsert_record: stored signed LEFT tombstone\n");
+                fflush(stdout);
+
+                return true; /* CHANGED */
+            }
+
+            /*
+             * Older tombstone than our current record. Ignore.
+             */
+            return false;
+        }
+
+        /* Insert new tombstone for unknown peer */
+        if (!mid_ensure_capacity(g)) {
+            printf("[MID] upsert_record: failed to ensure capacity for tombstone\n");
+            fflush(stdout);
+            return false;
+        }
+
+        g->records[g->count] = tmp;
+        g->records[g->count].connection_status = TOX_CONNECTION_NONE;
+
+        if (g->records[g->count].has_signature) {
+            printf("[MID] upsert_record: XOR IN new tombstone. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, g->records[g->count].identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        }
+
+        g->count++;
+
+        printf("[MID] upsert_record: inserted new signed LEFT tombstone\n");
+        fflush(stdout);
+
+        return true; /* CHANGED */
+    }
+
+    /**************************************************************************
+     * NORMAL ACTIVE / UNSIGNED / SIGNED PATH
+     *************************************************************************/
+
+    int idx = mid_find_identity(g, tmp.identity_key);
+
+    if (idx < 0) {
+        if (!mid_ensure_capacity(g)) {
+            printf("[MID] upsert_record: failed to ensure capacity\n");
+            fflush(stdout);
+            return false;
+        }
+
+        g->records[g->count] = tmp;
+
+        if (g->records[g->count].status == MID_STATUS_LEFT) {
+            g->records[g->count].connection_status = TOX_CONNECTION_NONE;
+        }
+
+        if (g->records[g->count].has_signature) {
+            printf("[MID] upsert_record: XOR IN new peer. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, g->records[g->count].identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        }
+
+        g->count++;
+
+        printf("[MID] upsert_record: inserted new peer (count=%zu)\n", g->count);
+        fflush(stdout);
+
+        return true; /* CHANGED */
+    }
+
+    MidPeerRecord *existing = &g->records[idx];
+
+    /*
+     * If we already have a signed record for this identity, the signing key
+     * is immutable. Reject records signed by a different key.
+     */
+    if (existing->has_signature &&
+        tmp.has_signature &&
+        !mid_same_signing_key(existing->signing_key, tmp.signing_key)) {
+        printf("[MID] upsert_record: rejected, signing key changed for same identity\n");
+        fflush(stdout);
+        return false;
+    }
+
+    bool replace = false;
+
+    if (tmp.has_signature) {
+        /*
+         * Signed records always replace unsigned records.
+         * Signed records replace older signed records only if the timestamp
+         * is strictly newer.
+         */
+        if (!existing->has_signature || tmp.timestamp > existing->timestamp) {
+            replace = true;
+        }
+    } else {
+        /*
+         * Unsigned records only replace other unsigned records.
+         * They never replace signed records.
+         */
+        if (!existing->has_signature && tmp.timestamp >= existing->timestamp) {
+            replace = true;
+        }
+    }
+
+    bool changed = false;
+
+    if (replace) {
+        printf("[MID] upsert_record: replacing existing record\n");
+        fflush(stdout);
+
+        bool old_had_signature = existing->has_signature;
+        bool new_has_signature = tmp.has_signature;
+
+        Tox_Connection old_conn = existing->connection_status;
+        Tox_Group_Role old_role = existing->role;
+        uint64_t old_last_seen = existing->last_seen;
+
+        /*
+         * If the incoming record does not know the signing key but we already
+         * have it, preserve it. This only matters for unsigned records.
+         */
+        if (mid_key_is_zero(tmp.signing_key) &&
+            !mid_key_is_zero(existing->signing_key)) {
+            memcpy(tmp.signing_key, existing->signing_key, MID_SIGNING_KEY_SIZE);
+        }
+
+        /*
+         * If the incoming signed ACTIVE record has no local connection state,
+         * preserve our previous observation.
+         */
+        if (tmp.status == MID_STATUS_ACTIVE &&
+            tmp.connection_status == TOX_CONNECTION_NONE &&
+            old_conn != TOX_CONNECTION_NONE) {
+            tmp.connection_status = old_conn;
+        }
+
+        /*
+         * LEFT records are never online.
+         */
+        if (tmp.status == MID_STATUS_LEFT) {
+            tmp.connection_status = TOX_CONNECTION_NONE;
+        }
+
+        /*
+         * Role is a local observation. Preserve it unless the caller updates
+         * it through moderation / sync logic.
+         */
+        tmp.role = old_role;
+
+        /*
+         * Preserve the newest last_seen value.
+         */
+        if (old_last_seen > tmp.last_seen) {
+            tmp.last_seen = old_last_seen;
+        }
+
+        *existing = tmp;
+
+        /*
+         * Update fingerprint ONLY if the peer's signature status changed.
+         * If they were signed before, and are signed now, they are already 
+         * in the XOR set, so we do nothing.
+         */
+        if (!old_had_signature && new_has_signature) {
+            printf("[MID] upsert_record: XOR IN peer transition to signed. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, existing->identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        } else if (old_had_signature && !new_has_signature) {
+            printf("[MID] upsert_record: XOR OUT peer transition to unsigned. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            mid_xor_fingerprint(g->roster_fingerprint, existing->identity_key);
+            printf("[MID] upsert_record: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        }
+
+        changed = true;
+    } else {
+        printf("[MID] upsert_record: keeping existing record\n");
+        fflush(stdout);
+    }
+
+    /**************************************************************************
+     * LOCAL ONLINE STATE UPDATE
+     *
+     * This updates connection_status / last_seen only.
+     * It never modifies signed fields.
+     *
+     * Important:
+     * Do not allow connection updates to resurrect a LEFT tombstone.
+     *************************************************************************/
+    if (in->connection_status != TOX_CONNECTION_NONE &&
+        in->status == MID_STATUS_ACTIVE &&
+        existing->status == MID_STATUS_ACTIVE) {
+
+        if (existing->connection_status != in->connection_status) {
+            existing->connection_status = in->connection_status;
+            changed = true;
+        }
+
+        if (in->last_seen >= existing->last_seen) {
+            if (in->last_seen > existing->last_seen) {
+                existing->last_seen = in->last_seen;
+
+                /*
+                 * If you do not want last_seen-only changes to trigger the
+                 * peer-list-changed callback, remove the next line.
+                 */
+                changed = true;
+            }
+        }
+    }
+
+    return changed;
+}
+
+/******************************************************************************
+Packet sending
+******************************************************************************/
+
+static bool mid_send_custom(MidState *s,
+                            const Tox *tox,
+                            const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                            bool lossless,
+                            const uint8_t *data,
+                            size_t length)
+{
+    printf("[MID] send_custom: sending %zu bytes (lossless=%d)\n", length, lossless); fflush(stdout);
+
+    if (tox == NULL || data == NULL || length == 0) {
+        return false;
+    }
+
+    if (length > MID_MAX_PACKET_SIZE) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) {
+        printf("[MID] send_custom: failed to resolve chat_id to group_number\n"); fflush(stdout);
+        return false;
+    }
+
+    Tox_Err_Group_Send_Custom_Packet err;
+    bool ok = tox_group_send_custom_packet(tox,
+                                           group_number,
+                                           lossless,
+                                           data,
+                                           length,
+                                           &err);
+
+    printf("[MID] send_custom:err=%d ok=%d group_number=%d\n", (int)err, (int)ok, (int)group_number); fflush(stdout);
+
+    if (!ok) {
+        printf("[MID] send_custom: tox_group_send_custom_packet failed (err=%d)\n", err); fflush(stdout);
+    } else {
+        if (s != NULL) {
+            s->sent_bytes += length;
+        }
+    }
+    return ok;
+}
+
+static bool mid_send_presence_record(MidState *s,
+                                     MidGroupState *g,
+                                     const Tox *tox,
+                                     const MidPeerRecord *r)
+{
+    if (g == NULL || tox == NULL || r == NULL) {
+        return false;
+    }
+
+    if (!r->has_signature) {
+        return false;
+    }
+
+    uint8_t body[MID_MAX_BODY_SIZE];
+    size_t body_len = 0;
+    if (!mid_pack_record_body(body, sizeof(body), r, &body_len)) {
+        return false;
+    }
+
+    size_t packet_len = MID_HEADER_SIZE + MID_SIG_SIZE + body_len;
+    if (packet_len > MID_MAX_PACKET_SIZE) {
+        return false;
+    }
+
+    uint8_t packet[MID_MAX_PACKET_SIZE];
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_PRESENCE;
+
+    size_t o = MID_HEADER_SIZE;
+    memcpy(packet + o, r->signature, MID_SIG_SIZE);
+    o += MID_SIG_SIZE;
+    memcpy(packet + o, body, body_len);
+    o += body_len;
+
+    return mid_send_custom(s, tox, g->chat_id, true, packet, o);
+}
+
+/* FIX 3: Lightweight Heartbeat Sending */
+static bool mid_send_heartbeat_record(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    if (!g || !tox || !g->have_keys) return false;
+
+    uint8_t body[MID_HEARTBEAT_BODY_SIZE];
+    size_t o = 0;
+    body[o++] = MID_STATUS_ACTIVE;
+    mid_put_u64_be(body + o, mid_now_or_time(0));
+    o += 8;
+    memcpy(body + o, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+    o += MID_IDENTITY_KEY_SIZE;
+
+    uint8_t sig[MID_SIG_SIZE];
+    unsigned long long sig_len = 0;
+    if (crypto_sign_detached(sig, &sig_len, body, o, g->self_secret_signing_key) != 0) return false;
+
+    uint8_t packet[128];
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_HEARTBEAT;
+
+    memcpy(packet + MID_HEADER_SIZE, sig, MID_SIG_SIZE);
+    memcpy(packet + MID_HEADER_SIZE + MID_SIG_SIZE, body, o);
+
+    return mid_send_custom(s, tox, g->chat_id, true, packet, MID_HEADER_SIZE + MID_SIG_SIZE + o);
+}
+
+static bool mid_send_roster_request_group(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    printf("[MID] send_roster_request: sending request\n"); fflush(stdout);
+
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    uint8_t packet[MID_HEADER_SIZE];
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_ROSTER_REQUEST;
+
+    return mid_send_custom(s, tox, g->chat_id, true, packet, sizeof(packet));
+}
+
+static bool mid_send_roster_group(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    printf("[MID] send_roster: syncing %zu records\n", g->count); fflush(stdout);
+    if (g == NULL || tox == NULL) return false;
+
+    printf("[MID] send_roster: Injecting FP[0..3]=%02X%02X%02X%02X into batch header\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+
+    uint8_t packet[MID_MAX_PACKET_SIZE];
+    size_t p_idx = 0;
+    
+    memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+    packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+    packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_ROSTER_BATCH;
+    p_idx = MID_HEADER_SIZE;
+    
+    // Define sizes dynamically based on actual types/arrays
+    const size_t fp_size = sizeof(g->roster_fingerprint);
+    const size_t count_size = sizeof(uint16_t);
+    
+    // Inject Set Fingerprint
+    memcpy(packet + p_idx, g->roster_fingerprint, fp_size);
+    p_idx += fp_size;
+    
+    size_t count_idx = p_idx;
+    p_idx += count_size;
+    uint16_t count = 0;
+    bool ok = true;
+    
+    // Header + Fingerprint + Count
+    size_t batch_header_size = MID_HEADER_SIZE + fp_size + count_size;
+
+    for (size_t i = 0; i < g->count; i++) {
+        if (!g->records[i].has_signature) continue;
+        
+        uint8_t body[MID_MAX_BODY_SIZE];
+        size_t body_len = 0;
+        if (!mid_pack_record_body(body, sizeof(body), &g->records[i], &body_len)) continue;
+        
+        // Signature + body_len prefix + body
+        size_t needed = MID_SIG_SIZE + count_size + body_len;
+
+        if (p_idx + needed > MID_MAX_PACKET_SIZE) {
+            mid_put_u16_be(packet + count_idx, count);
+            if (!mid_send_custom(s, tox, g->chat_id, true, packet, p_idx)) ok = false;
+            
+            p_idx = batch_header_size; 
+            printf("[MID] send_roster: Re-injecting FP[0..3]=%02X%02X%02X%02X into next batch packet\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+            
+            // Re-inject full header for next packet
+            memcpy(packet, MID_MAGIC, MID_MAGIC_BYTES_TOTAL);
+            packet[MID_MAGIC_BYTES_TOTAL] = MID_PROTOCOL_VERSION;
+            packet[MID_MAGIC_BYTES_TOTAL + 1] = MID_MSG_ROSTER_BATCH;
+            memcpy(packet + MID_HEADER_SIZE, g->roster_fingerprint, fp_size);
+            
+            count_idx = MID_HEADER_SIZE + fp_size;
+            count = 0;
+        }
+        
+        memcpy(packet + p_idx, g->records[i].signature, MID_SIG_SIZE);
+        p_idx += MID_SIG_SIZE;
+        mid_put_u16_be(packet + p_idx, (uint16_t)body_len);
+        p_idx += count_size;
+        memcpy(packet + p_idx, body, body_len);
+        p_idx += body_len;
+        count++;
+    }
+    
+    if (count > 0) {
+        mid_put_u16_be(packet + count_idx, count);
+        if (!mid_send_custom(s, tox, g->chat_id, true, packet, p_idx)) ok = false;
+    }
+    
+    return ok;
+}
+
+/******************************************************************************
+Online state sync
+Returns true if any peer's online status changed.
+******************************************************************************/
+
+/*
+Stamps the FOUNDER role on the roster entry whose identity_key matches
+the group founder's public key obtained from Toxcore's shared state.
+
+This works regardless of whether the founder is currently online, because
+the founder key is part of the group's cryptographic shared state, not
+the live peer list.
+*/
+static void mid_apply_founder_role(MidGroupState *g, const Tox *tox)
+{
+    if (g == NULL || tox == NULL) {
+        return;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) {
+        return;
+    }
+
+    uint8_t founder_identity[MID_IDENTITY_KEY_SIZE];
+    Tox_Err_Group_State_Queries err;
+
+    if (!tox_group_get_founder_public_key(tox, group_number, founder_identity, &err)) {
+        return;
+    }
+
+    if (mid_key_is_zero(founder_identity)) {
+        return;
+    }
+
+    int idx = mid_find_identity(g, founder_identity);
+    if (idx < 0) {
+        return;
+    }
+
+    if (g->records[idx].role != TOX_GROUP_ROLE_FOUNDER) {
+        printf("[MID] apply_founder_role: stamping FOUNDER role on peer %zu\n", (size_t)idx);
+        fflush(stdout);
+        g->records[idx].role = TOX_GROUP_ROLE_FOUNDER;
+    }
+}
+
+static bool mid_sync_online_state_group(MidGroupState *g, const Tox *tox, uint64_t now)
+{
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    now = mid_now_or_time(now);
+    bool changed = false;
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    /* Ensure the founder role is always correctly stamped */
+    Tox_Group_Role old_founder_role = TOX_GROUP_ROLE_USER;
+    int founder_idx = -1;
+    uint8_t founder_identity[MID_IDENTITY_KEY_SIZE];
+    Tox_Err_Group_State_Queries founder_err;
+
+    if (tox_group_get_founder_public_key(tox, group_number, founder_identity, &founder_err)) {
+        founder_idx = mid_find_identity(g, founder_identity);
+        if (founder_idx >= 0) {
+            old_founder_role = g->records[founder_idx].role;
+        }
+    }
+
+    mid_apply_founder_role(g, tox);
+
+    if (founder_idx >= 0 && g->records[founder_idx].role != old_founder_role) {
+        changed = true;
+    }
+
+    for (size_t i = 0; i < g->count; i++) {
+        MidPeerRecord *e = &g->records[i];
+        if (e->connection_status == TOX_CONNECTION_NONE) {
+            continue;
+        }
+
+        Tox_Err_Group_Peer_Query err;
+        uint32_t peer_id = tox_group_peer_by_public_key(tox, group_number, e->identity_key, &err);
+
+        if (err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+            printf("[MID] sync_online_state: peer %zu is no longer in Toxcore, marking offline\n", i); fflush(stdout);
+            if (e->connection_status != TOX_CONNECTION_NONE) {
+                e->connection_status = TOX_CONNECTION_NONE;
+                changed = true;
+            }
+            if (now >= e->last_seen) {
+                e->last_seen = now;
+            }
+        } else {
+            Tox_Err_Group_Peer_Query conn_err;
+            Tox_Connection conn = tox_group_peer_get_connection_status(tox, group_number, peer_id, &conn_err);
+            if (conn_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                if (e->connection_status != conn) {
+                    e->connection_status = conn;
+                    changed = true;
+                }
+                if (conn != TOX_CONNECTION_NONE && now >= e->last_seen) {
+                    e->last_seen = now;
+                }
+            }
+
+            Tox_Err_Group_Peer_Query role_err;
+            Tox_Group_Role role = tox_group_peer_get_role(tox, group_number, peer_id, &role_err);
+            if (role_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                if (e->role != role) {
+                    e->role = role;
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    return changed;
+}
+
+/******************************************************************************
+Key setup
+******************************************************************************/
+
+static bool mid_set_self_keys(MidGroupState *g,
+                              const uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                              const uint8_t signing_key[MID_SIGNING_KEY_SIZE],
+                              const uint8_t secret_key[MID_SIGNING_SECRET_KEY_SIZE])
+{
+    printf("[MID] set_self_keys: setting keys\n"); fflush(stdout);
+
+    if (g == NULL ||
+        identity_key == NULL ||
+        signing_key == NULL ||
+        secret_key == NULL) {
+        return false;
+    }
+
+    if (mid_key_is_zero(identity_key) || mid_key_is_zero(signing_key)) {
+        return false;
+    }
+
+    uint8_t derived_signing_key[MID_SIGNING_KEY_SIZE];
+    if (crypto_sign_ed25519_sk_to_pk(derived_signing_key, secret_key) != 0) {
+        printf("[MID] set_self_keys: sk_to_pk failed\n"); fflush(stdout);
+        return false;
+    }
+
+    if (!mid_same_signing_key(derived_signing_key, signing_key)) {
+        printf("[MID] set_self_keys: derived signing key mismatch\n"); fflush(stdout);
+        return false;
+    }
+
+    if (!mid_valid_key_binding(identity_key, signing_key)) {
+        printf("[MID] set_self_keys: invalid key binding\n"); fflush(stdout);
+        return false;
+    }
+
+    memcpy(g->self_identity_key, identity_key, MID_IDENTITY_KEY_SIZE);
+    memcpy(g->self_signing_key, signing_key, MID_SIGNING_KEY_SIZE);
+    memcpy(g->self_secret_signing_key, secret_key, MID_SIGNING_SECRET_KEY_SIZE);
+    g->have_keys = true;
+
+    printf("[MID] set_self_keys: keys set successfully\n"); fflush(stdout);
+    return true;
+}
+
+static bool mid_init_self_from_tox(MidGroupState *g, const Tox *tox)
+{
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    if (g->have_keys) {
+        return true;
+    }
+
+    printf("[MID] init_self_from_tox: fetching keys from Toxcore\n"); fflush(stdout);
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) {
+        return false;
+    }
+
+    uint8_t identity[MID_IDENTITY_KEY_SIZE];
+    uint8_t signing[MID_SIGNING_KEY_SIZE];
+    uint8_t sk[MID_SIGNING_SECRET_KEY_SIZE];
+
+    Tox_Err_Group_Self_Query err;
+
+    if (!tox_group_self_get_public_key(tox, group_number, identity, &err)) {
+        printf("[MID] init_self_from_tox: get_public_key failed\n"); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] init_self_from_tox: got identity key\n");
+    fflush(stdout);
+
+    /*
+     * We now have the current Toxcore identity in the local variable
+     * "identity".
+     *
+     * g->self_identity_key may contain the public identity that was loaded
+     * from the middleware save file.
+     *
+     * This comparison must happen BEFORE mid_set_self_keys(), because
+     * mid_set_self_keys() will overwrite g->self_identity_key.
+     */
+    if (!mid_key_is_zero(g->self_identity_key) &&
+        !mid_same_identity(identity, g->self_identity_key)) {
+
+        printf("[MID] init_self_from_tox: Toxcore identity differs from saved middleware identity\n"); fflush(stdout);
+
+        /*
+         * Choose your policy here.
+         *
+         * Option 1: Strict mode.
+         *
+         * If the saved middleware state must belong to exactly the same
+         * identity that Toxcore currently has, fail here.
+         *
+         * return false;
+         *
+         *
+         * Option 2: Adopt the current Toxcore identity.
+         *
+         * Toxcore is the authority for the current group identity.
+         * Continue and let mid_set_self_keys() install the keys reported
+         * by Toxcore.
+         *
+         * This is usually the more robust choice.
+         */
+    }
+
+    if (!tox_group_self_get_signing_public_key(tox, group_number, signing, &err)) {
+        printf("[MID] init_self_from_tox: get_signing_public_key failed\n"); fflush(stdout);
+        return false;
+    }
+    printf("[MID] init_self_from_tox: got signing public key\n"); fflush(stdout);
+
+    if (!tox_group_self_get_signing_secret_key(tox, group_number, sk, &err)) {
+        printf("[MID] init_self_from_tox: get_signing_secret_key failed\n"); fflush(stdout);
+        return false;
+    }
+    printf("[MID] init_self_from_tox: got signing secret key\n"); fflush(stdout);
+
+    bool ok = mid_set_self_keys(g, identity, signing, sk);
+    sodium_memzero(sk, sizeof(sk));
+    return ok;
+}
+
+/******************************************************************************
+Tox peer key helpers
+******************************************************************************/
+
+static bool mid_get_peer_keys(const Tox *tox,
+                              const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                              uint32_t peer_id,
+                              uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                              uint8_t signing_key[MID_SIGNING_KEY_SIZE])
+{
+    printf("[MID] get_peer_keys: fetching keys for peer %u\n", peer_id); fflush(stdout);
+
+    if (tox == NULL || identity_key == NULL || signing_key == NULL) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    Tox_Err_Group_Peer_Query err;
+
+    if (!tox_group_peer_get_public_key(tox, group_number, peer_id,
+                                       identity_key, &err)) {
+        printf("[MID] get_peer_keys: get_public_key failed for peer %u\n", peer_id); fflush(stdout);
+        return false;
+    }
+
+    if (!tox_group_peer_get_signing_public_key(tox, group_number, peer_id,
+                                               signing_key, &err)) {
+        printf("[MID] get_peer_keys: get_signing_public_key failed for peer %u\n", peer_id); fflush(stdout);
+        return false;
+    }
+
+    printf("[MID] get_peer_keys: got both keys for peer %u\n", peer_id); fflush(stdout);
+    return mid_valid_key_binding(identity_key, signing_key);
+}
+
+/******************************************************************************
+Internal group operations
+******************************************************************************/
+
+static bool mid_announce_self_group(MidState *s, MidGroupState *g, const Tox *tox)
+{
+    printf("[MID] announce_self: announcing ACTIVE\n"); fflush(stdout);
+
+    if (g == NULL) {
+        return false;
+    }
+
+    if (!g->have_keys) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    MidPeerRecord r;
+    memset(&r, 0, sizeof(r));
+    memcpy(r.identity_key, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+    memcpy(r.signing_key, g->self_signing_key, MID_SIGNING_KEY_SIZE);
+    r.status = MID_STATUS_ACTIVE;
+    r.timestamp = mid_now_or_time(0);
+
+    Tox_Err_Group_Peer_Query conn_err;
+    Tox_Connection conn = tox_group_peer_get_connection_status(tox, group_number, 0, &conn_err);
+    if (conn_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+        r.connection_status = conn;
+    } else {
+        r.connection_status = TOX_CONNECTION_NONE;
+    }
+
+    Tox_Err_Group_Self_Query self_role_err;
+    r.role = tox_group_self_get_role(tox, group_number, &self_role_err);
+    if (self_role_err != TOX_ERR_GROUP_SELF_QUERY_OK) {
+        r.role = TOX_GROUP_ROLE_USER;
+    }
+
+    /*
+     * Copy self nickname into the record.
+     *
+     * self_nickname_len was already bounded to MID_MAX_NICK_SIZE when it was
+     * stored in mid_on_group_self_join, but we add a defensive bounds check
+     * here as well to guard against any corruption.
+     */
+    if (g->self_nickname_len > 0) {
+        uint16_t nick_copy = g->self_nickname_len;
+        if (nick_copy > MID_MAX_NICK_SIZE) {
+            nick_copy = MID_MAX_NICK_SIZE;
+        }
+        memcpy(r.nickname, g->self_nickname, nick_copy);
+        r.nickname_len = nick_copy;
+    }
+
+    if (!mid_sign_record(g, &r)) {
+        return false;
+    }
+
+    r.last_seen = r.timestamp;
+
+    bool changed = mid_upsert_record(g, &r);
+    g->self_active = true;
+    g->last_announce = r.timestamp;
+
+    mid_send_presence_record(s, g, tox, &r);
+    return changed;
+}
+
+static bool mid_on_peer_online_keys(MidGroupState *g,
+                                    const uint8_t identity_key[MID_IDENTITY_KEY_SIZE],
+                                    const uint8_t signing_key[MID_SIGNING_KEY_SIZE],
+                                    Tox_Connection conn,
+                                    Tox_Group_Role role,
+                                    uint64_t now)
+{
+    printf("[MID] on_peer_online_keys: peer observed online\n"); fflush(stdout);
+
+    if (g == NULL || identity_key == NULL || mid_key_is_zero(identity_key)) {
+        return false;
+    }
+
+    now = mid_now_or_time(now);
+
+    bool have_signing = (signing_key != NULL &&
+                         !mid_key_is_zero(signing_key) &&
+                         mid_valid_key_binding(identity_key, signing_key));
+
+    int idx = mid_find_identity(g, identity_key);
+
+    if (idx < 0) {
+        if (!mid_ensure_capacity(g)) {
+            return false;
+        }
+        MidPeerRecord r;
+        memset(&r, 0, sizeof(r));
+        memcpy(r.identity_key, identity_key, MID_IDENTITY_KEY_SIZE);
+        if (have_signing) {
+            memcpy(r.signing_key, signing_key, MID_SIGNING_KEY_SIZE);
+        }
+        r.status = MID_STATUS_ACTIVE;
+        r.timestamp = now;
+        r.connection_status = conn;
+        r.role = role;
+        r.last_seen = now;
+        g->records[g->count] = r;
+        g->count++;
+        return true; /* CHANGED */
+    }
+
+    MidPeerRecord *e = &g->records[idx];
+    bool changed = false;
+
+    if (e->connection_status != conn) {
+        e->connection_status = conn;
+        changed = true;
+    }
+
+    if (e->role != role) {
+        e->role = role;
+        changed = true;
+    }
+
+    if (conn != TOX_CONNECTION_NONE && now >= e->last_seen) {
+        e->last_seen = now;
+        changed = true;
+    }
+
+    if (!e->has_signature) {
+        e->status = MID_STATUS_ACTIVE;
+        if (now >= e->timestamp) {
+            e->timestamp = now;
+            changed = true;
+        }
+        if (have_signing) {
+            memcpy(e->signing_key, signing_key, MID_SIGNING_KEY_SIZE);
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
+static bool mid_refresh_peer_name_group(MidGroupState *g, const Tox *tox, uint32_t peer_id)
+{
+    if (g == NULL || tox == NULL) {
+        return false;
+    }
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    uint8_t identity[MID_IDENTITY_KEY_SIZE];
+    Tox_Err_Group_Peer_Query err;
+
+    if (!tox_group_peer_get_public_key(tox, group_number, peer_id, identity, &err)) {
+        return false;
+    }
+
+    int idx = mid_find_identity(g, identity);
+    if (idx < 0) {
+        return false;
+    }
+
+    size_t name_size = tox_group_peer_get_name_size(tox, group_number, peer_id, &err);
+    if (err != TOX_ERR_GROUP_PEER_QUERY_OK || name_size == 0) {
+        return false;
+    }
+
+    /*
+     * SAFETY: tox_group_peer_get_name() writes exactly name_size bytes into
+     * the output buffer. We must NOT truncate name_size before calling it,
+     * because the buffer must be large enough for the full write.
+     *
+     * We heap-allocate a buffer of exactly name_size bytes to guarantee no
+     * overflow even if Toxcore returns a name larger than MID_MAX_NICK_SIZE
+     * (e.g. from a patched or broken Toxcore).
+     */
+    uint8_t *name = (uint8_t *)malloc(name_size);
+    if (name == NULL) {
+        return false;
+    }
+
+    if (!tox_group_peer_get_name(tox, group_number, peer_id, name, &err)) {
+        free(name);
+        return false;
+    }
+
+    MidPeerRecord *e = &g->records[idx];
+    bool changed = false;
+
+    if (!e->has_signature) {
+        size_t copy_len = name_size;
+        if (copy_len > MID_MAX_NICK_SIZE) {
+            copy_len = MID_MAX_NICK_SIZE;
+        }
+
+        /* Only update if the name actually changed */
+        if (e->nickname_len != copy_len || memcmp(e->nickname, name, copy_len) != 0) {
+            /*
+             * Zero-fill the destination first so no stale bytes remain past
+             * the end of the (possibly truncated) nickname.
+             *
+             * The nickname is treated as opaque binary. We do NOT assume
+             * valid UTF-8, printable ASCII, or NUL termination.
+             */
+            memset(e->nickname, 0, MID_MAX_NICK_SIZE);
+            if (copy_len > 0) {
+                memcpy(e->nickname, name, copy_len);
+            }
+            e->nickname_len = (uint16_t)copy_len;
+            changed = true;
+        }
+    }
+
+    free(name);
+    return changed;
+}
+
+static bool mid_on_custom_packet_group(MidState *s,
+                                       MidGroupState *g,
+                                       const Tox *tox,
+                                       uint32_t peer_id,
+                                       const uint8_t *data,
+                                       size_t length,
+                                       uint64_t now)
+{
+    printf("[MID] on_custom_packet: received %zu bytes from peer %u\n",
+           length, peer_id);
+    fflush(stdout);
+
+    if (g == NULL || data == NULL || length < MID_HEADER_SIZE) {
+        return false;
+    }
+
+    if (memcmp(data, MID_MAGIC, MID_MAGIC_BYTES_TOTAL) != 0 ||
+        data[MID_MAGIC_BYTES_TOTAL] != MID_PROTOCOL_VERSION) {
+        return false;
+    }
+
+    uint8_t type = data[MID_MAGIC_BYTES_TOTAL + 1];
+    const uint8_t *payload = data + MID_HEADER_SIZE;
+    size_t payload_len = length - MID_HEADER_SIZE;
+
+    now = mid_now_or_time(now);
+
+    uint8_t sender_identity[MID_IDENTITY_KEY_SIZE];
+    uint8_t sender_signing[MID_SIGNING_KEY_SIZE];
+    bool sender_has_keys = false;
+
+    if (tox != NULL && peer_id != UINT32_MAX) {
+        sender_has_keys = mid_get_peer_keys(tox,
+                                            g->chat_id,
+                                            peer_id,
+                                            sender_identity,
+                                            sender_signing);
+    }
+
+    bool changed = false;
+
+    /**************************************************************************
+     * FULL SIGNED PRESENCE RECORD
+     *
+     * This is a full signed record containing status, timestamp, nickname,
+     * identity key, and signing key.
+     *
+     * It does NOT suppress pending roster responses, because one presence
+     * record does not prove that the sender has the full roster.
+     *************************************************************************/
+    if (type == MID_MSG_PRESENCE) {
+        printf("[MID] on_custom_packet: processing PRESENCE message\n");
+        fflush(stdout);
+
+        if (payload_len < MID_SIG_SIZE) {
+            return false;
+        }
+
+        size_t body_len = payload_len - MID_SIG_SIZE;
+
+        if (body_len > MID_MAX_BODY_SIZE) {
+            return false;
+        }
+
+        MidPeerRecord r;
+        memset(&r, 0, sizeof(r));
+
+        if (!mid_unpack_record_body(&r, payload + MID_SIG_SIZE, body_len)) {
+            return false;
+        }
+
+        memcpy(r.signature, payload, MID_SIG_SIZE);
+        r.has_signature = true;
+
+        if (!mid_verify_record(&r)) {
+            printf("[MID] on_custom_packet: PRESENCE verification failed\n");
+            fflush(stdout);
+            return false;
+        }
+
+        printf("[MID] on_custom_packet: PRESENCE verified, upserting\n");
+        fflush(stdout);
+
+        /* Never process our own signed presence echoed back to us. */
+        if (g->have_keys && mid_same_identity(r.identity_key, g->self_identity_key)) {
+            return false;
+        }
+
+        bool sender_is_subject = false;
+
+        if (sender_has_keys && mid_same_identity(sender_identity, r.identity_key)) {
+            sender_is_subject = true;
+
+            /*
+             * If the packet came directly from the subject, the signing key
+             * observed from Toxcore must match the signing key in the record.
+             */
+            if (!mid_same_signing_key(sender_signing, r.signing_key)) {
+                return false;
+            }
+        }
+
+        if (sender_is_subject && r.status == MID_STATUS_ACTIVE) {
+            Tox_Err_Group_Peer_Query conn_err;
+            Tox_Connection conn = TOX_CONNECTION_NONE;
+
+            uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+            if (group_number != UINT32_MAX && tox != NULL && peer_id != UINT32_MAX) {
+                conn = tox_group_peer_get_connection_status(tox,
+                                                            group_number,
+                                                            peer_id,
+                                                            &conn_err);
+                if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                    conn = TOX_CONNECTION_NONE;
+                }
+            }
+
+            /*
+             * They just sent a packet, so they are online from our point of
+             * view even if Toxcore has not updated the connection state yet.
+             */
+            if (conn == TOX_CONNECTION_NONE) {
+                conn = TOX_CONNECTION_TCP;
+            }
+
+            r.connection_status = conn;
+            r.last_seen = now;
+        } else {
+            /*
+             * Forwarded / relayed presence, or LEFT tombstone.
+             * Do not mark the peer online.
+             */
+            r.connection_status = TOX_CONNECTION_NONE;
+            /* Anchor last_seen so we can purge them if they never come online */
+            if (r.last_seen == 0) r.last_seen = now;
+        }
+
+        if (mid_upsert_record(g, &r)) {
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    /**************************************************************************
+     * LIGHTWEIGHT HEARTBEAT
+     *
+     * Body:
+     *   status       1 byte
+     *   timestamp    8 bytes
+     *   identity_key 32 bytes
+     *
+     * Signature:
+     *   detached Ed25519 signature over the 41-byte body.
+     *
+     * Heartbeats are used only for liveness / connection state.
+     *
+     * IMPORTANT:
+     * A heartbeat must NOT modify fields belonging to a stored full signed
+     * record, otherwise the stored signature would become invalid.
+     * Therefore, if we already have a signed full record, the heartbeat only
+     * updates connection_status, role, and last_seen.
+     *
+     * Heartbeats do NOT suppress roster responses.
+     *************************************************************************/
+    if (type == MID_MSG_HEARTBEAT) {
+        printf("[MID] on_custom_packet: processing HEARTBEAT message\n");
+        fflush(stdout);
+
+        const size_t hb_body_len = MID_HEARTBEAT_BODY_SIZE;
+
+        if (payload_len < MID_SIG_SIZE + hb_body_len) {
+            return false;
+        }
+
+        const uint8_t *sig = payload;
+        const uint8_t *body = payload + MID_SIG_SIZE;
+
+        uint8_t status = body[0];
+
+        if (status != MID_STATUS_ACTIVE && status != MID_STATUS_LEFT) {
+            return false;
+        }
+
+        uint64_t ts = mid_get_u64_be(body + 1);
+
+        uint8_t hb_identity[MID_IDENTITY_KEY_SIZE];
+        memcpy(hb_identity, body + 9, MID_IDENTITY_KEY_SIZE);
+
+        /* Ignore our own heartbeat if it is echoed back. */
+        if (g->have_keys && mid_same_identity(hb_identity, g->self_identity_key)) {
+            return false;
+        }
+
+        int idx = mid_find_identity(g, hb_identity);
+        if (idx < 0) {
+            /*
+             * We do not know this peer yet.
+             * A heartbeat alone is not enough to create a persistent roster
+             * entry; wait for a full signed PRESENCE record.
+             */
+            return false;
+        }
+
+        MidPeerRecord *e = &g->records[idx];
+
+        bool sender_is_subject = false;
+        if (sender_has_keys && mid_same_identity(sender_identity, hb_identity)) {
+            sender_is_subject = true;
+        }
+
+        uint8_t verify_key[MID_SIGNING_KEY_SIZE];
+        bool have_verify_key = false;
+
+        /*
+         * Prefer the signing key already stored in the roster record.
+         */
+        if (!mid_key_is_zero(e->signing_key) &&
+            mid_valid_key_binding(e->identity_key, e->signing_key)) {
+            memcpy(verify_key, e->signing_key, MID_SIGNING_KEY_SIZE);
+            have_verify_key = true;
+        }
+        /*
+         * If we do not have a stored signing key yet, but the packet comes
+         * directly from the subject, use the signing key observed from
+         * Toxcore.
+         */
+        else if (sender_is_subject &&
+                 mid_valid_key_binding(sender_identity, sender_signing)) {
+            memcpy(verify_key, sender_signing, MID_SIGNING_KEY_SIZE);
+            have_verify_key = true;
+        }
+
+        if (!have_verify_key) {
+            return false;
+        }
+
+        if (crypto_sign_verify_detached(sig,
+                                        body,
+                                        hb_body_len,
+                                        verify_key) != 0) {
+            printf("[MID] on_custom_packet: HEARTBEAT signature invalid\n");
+            fflush(stdout);
+            return false;
+        }
+
+        printf("[MID] on_custom_packet: HEARTBEAT signature valid\n");
+        fflush(stdout);
+
+        /*
+         * Heartbeats are intended as ACTIVE keep-alives.
+         * A LEFT state should be propagated by a full signed LEFT tombstone,
+         * not by a lightweight heartbeat.
+         */
+        if (status != MID_STATUS_ACTIVE) {
+            return changed;
+        }
+
+        /*
+         * If we only have an unsigned local observation, it is safe to update
+         * the unsigned logical fields.
+         */
+        if (!e->has_signature) {
+            if (mid_key_is_zero(e->signing_key)) {
+                memcpy(e->signing_key, verify_key, MID_SIGNING_KEY_SIZE);
+                changed = true;
+            }
+
+            if (e->status != MID_STATUS_ACTIVE) {
+                e->status = MID_STATUS_ACTIVE;
+                changed = true;
+            }
+
+            if (ts > e->timestamp) {
+                e->timestamp = ts;
+                changed = true;
+            }
+        } else {
+            /*
+             * If we have a signed LEFT tombstone, do not resurrect the peer
+             * from a heartbeat alone. Require a full signed ACTIVE presence.
+             */
+            if (e->status == MID_STATUS_LEFT) {
+                return changed;
+            }
+        }
+
+        /*
+         * Only the direct sender can be considered online because of this
+         * heartbeat. A relayed heartbeat does not prove current connectivity.
+         */
+        if (sender_is_subject) {
+            uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+            if (group_number == UINT32_MAX) return changed;
+
+            Tox_Err_Group_Peer_Query conn_err;
+            Tox_Connection conn = tox_group_peer_get_connection_status(tox,
+                                                                       group_number,
+                                                                       peer_id,
+                                                                       &conn_err);
+
+            if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                conn = TOX_CONNECTION_NONE;
+            }
+
+            if (conn == TOX_CONNECTION_NONE) {
+                conn = TOX_CONNECTION_TCP;
+            }
+
+            if (e->connection_status != conn) {
+                e->connection_status = conn;
+                changed = true;
+            }
+
+            Tox_Err_Group_Peer_Query role_err;
+            Tox_Group_Role role = tox_group_peer_get_role(tox,
+                                                          group_number,
+                                                          peer_id,
+                                                          &role_err);
+
+            if (role_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                if (e->role != role) {
+                    e->role = role;
+                    changed = true;
+                }
+            }
+
+            if (now >= e->last_seen) {
+                e->last_seen = now;
+                /*
+                 * Intentionally not setting changed=true only for last_seen.
+                 * This avoids excessive peer-list-changed callbacks when only
+                 * the last-seen timestamp moves forward.
+                 */
+            }
+        }
+
+        return changed;
+    }
+
+    /**************************************************************************
+     * BATCHED ROSTER RESPONSE
+     *
+     * Payload layout:
+     *   fingerprint  32 bytes
+     *   count         2 bytes
+     *   records...
+     *
+     * Each record:
+     *   signature    64 bytes
+     *   body_len      2 bytes
+     *   body          body_len bytes
+     *
+     * Suppression rule:
+     *
+     * We cancel our own pending roster response ONLY if the batch is complete
+     * and the sender's roster fingerprint exactly matches ours.
+     *
+     * This prevents:
+     *   - a partial peer list from suppressing a fuller list
+     *   - a different set of the same size from suppressing another set
+     *   - stale state from suppressing newer state if the fingerprint includes
+     *     record signatures / versions
+     *************************************************************************/
+    if (type == MID_MSG_ROSTER_BATCH) {
+        printf("[MID] on_custom_packet: processing ROSTER_BATCH message\n");
+        fflush(stdout);
+
+        /* Minimum: MID_IDENTITY_KEY_SIZE fingerprint + 2-byte record count */
+        if (payload_len < MID_IDENTITY_KEY_SIZE + sizeof(uint16_t)) {
+            return false;
+        }
+
+        uint8_t sender_fp[MID_IDENTITY_KEY_SIZE];
+        memcpy(sender_fp, payload, MID_IDENTITY_KEY_SIZE);
+
+        uint16_t record_count = mid_get_u16_be(payload + MID_IDENTITY_KEY_SIZE);
+        size_t p_idx = MID_IDENTITY_KEY_SIZE + sizeof(uint16_t);
+
+        bool batch_complete = true;
+
+        for (uint16_t i = 0; i < record_count; i++) {
+            if (p_idx + MID_SIG_SIZE + sizeof(uint16_t) > payload_len) {
+                batch_complete = false;
+                break;
+            }
+
+            const uint8_t *sig = payload + p_idx;
+            p_idx += MID_SIG_SIZE;
+
+            uint16_t body_len = mid_get_u16_be(payload + p_idx);
+            p_idx += sizeof(uint16_t);
+
+            if (p_idx + body_len > payload_len) {
+                batch_complete = false;
+                break;
+            }
+
+            /*
+             * Defensive limit. The current protocol body cannot exceed
+             * MID_MAX_BODY_SIZE.
+             */
+            if (body_len > MID_MAX_BODY_SIZE) {
+                p_idx += body_len;
+                continue;
+            }
+
+            MidPeerRecord r;
+            memset(&r, 0, sizeof(r));
+
+            if (mid_unpack_record_body(&r, payload + p_idx, body_len)) {
+                memcpy(r.signature, sig, MID_SIG_SIZE);
+                r.has_signature = true;
+
+                if (mid_verify_record(&r)) {
+                    /* Ignore our own record if it is echoed back. */
+                    if (!(g->have_keys &&
+                          mid_same_identity(r.identity_key, g->self_identity_key))) {
+
+                        bool sender_is_subject = false;
+
+                        if (sender_has_keys &&
+                            mid_same_identity(sender_identity, r.identity_key)) {
+                            sender_is_subject = true;
+                        }
+
+                        /*
+                         * If the packet sender claims to be the subject, their
+                         * Toxcore-observed signing key must match the record.
+                         */
+                        if (sender_is_subject &&
+                            !mid_same_signing_key(sender_signing, r.signing_key)) {
+                            sender_is_subject = false;
+                        }
+
+                        if (sender_is_subject && r.status == MID_STATUS_ACTIVE) {
+                            uint32_t group_number = mid_chat_id_to_group_number(tox, g->chat_id);
+                            Tox_Connection conn = TOX_CONNECTION_NONE;
+                            Tox_Group_Role role = TOX_GROUP_ROLE_USER;
+
+                            if (group_number != UINT32_MAX && tox != NULL && peer_id != UINT32_MAX) {
+                                Tox_Err_Group_Peer_Query conn_err;
+                                conn = tox_group_peer_get_connection_status(tox,
+                                                                            group_number,
+                                                                            peer_id,
+                                                                            &conn_err);
+
+                                if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                                    conn = TOX_CONNECTION_NONE;
+                                }
+
+                                if (conn == TOX_CONNECTION_NONE) {
+                                    conn = TOX_CONNECTION_TCP;
+                                }
+
+                                Tox_Err_Group_Peer_Query role_err;
+                                role = tox_group_peer_get_role(tox,
+                                                               group_number,
+                                                               peer_id,
+                                                               &role_err);
+
+                                if (role_err != TOX_ERR_GROUP_PEER_QUERY_OK) {
+                                    role = TOX_GROUP_ROLE_USER;
+                                }
+                            }
+
+                            r.connection_status = conn;
+                            r.last_seen = now;
+                            r.role = role;
+                        } else {
+                            r.connection_status = TOX_CONNECTION_NONE;
+                            /* Anchor last_seen so we can purge them if they never come online */
+                            if (r.last_seen == 0) r.last_seen = now;
+                        }
+
+                        if (mid_upsert_record(g, &r)) {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+
+            p_idx += body_len;
+        }
+
+        /*
+         * SAFE MULTICAST SUPPRESSION
+         *
+         * Only suppress if the batch was structurally complete and the
+         * fingerprint matches exactly.
+         */
+        if (batch_complete) {
+            printf("[MID] ROSTER_BATCH: Sender FP[0..3]=%02X%02X%02X%02X, Our FP[0..3]=%02X%02X%02X%02X\n",
+                   sender_fp[0], sender_fp[1], sender_fp[2], sender_fp[3],
+                   g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]);
+            fflush(stdout);
+            if (memcmp(sender_fp, g->roster_fingerprint, MID_IDENTITY_KEY_SIZE) == 0) {
+                if (g->roster_reply_deadline != 0) {
+                    printf("[MID] ROSTER_BATCH: MATCH! Suppressing our pending roster reply because another peer already sent the exact same set.\n");
+                    fflush(stdout);
+                    g->roster_reply_deadline = 0;
+                } else {
+                    printf("[MID] ROSTER_BATCH: MATCH! But we had no pending reply to suppress.\n");
+                    fflush(stdout);
+                }
+            } else {
+                printf("[MID] ROSTER_BATCH: MISMATCH. Sender has a different peer set. Keeping our pending roster reply scheduled.\n");
+                fflush(stdout);
+            }
+        } else {
+            printf("[MID] ROSTER_BATCH: batch incomplete/truncated. "
+                   "Not suppressing roster reply.\n");
+            fflush(stdout);
+        }
+
+        return changed;
+    }
+
+    /**************************************************************************
+     * ROSTER REQUEST
+     *
+     * We do not answer immediately. We schedule a delayed response.
+     *
+     * If another peer responds first with a roster whose fingerprint matches
+     * ours, our pending response will be cancelled by the ROSTER_BATCH
+     * suppression logic above.
+     *************************************************************************/
+    if (type == MID_MSG_ROSTER_REQUEST) {
+        printf("[MID] on_custom_packet: processing ROSTER_REQUEST message\n");
+        fflush(stdout);
+
+        if (tox == NULL) {
+            return false;
+        }
+
+        /*
+         * Ignore our own request if it is ever echoed back.
+         */
+        if (sender_has_keys &&
+            g->have_keys &&
+            mid_same_identity(sender_identity, g->self_identity_key)) {
+            return false;
+        }
+
+        /*
+         * Only respond if we have joined/announced ourselves and have keys.
+         */
+        if (g->have_keys && g->announced) {
+            if (g->roster_reply_deadline == 0) {
+                /*
+                 * Randomized delay for multicast suppression.
+                 *
+                 * 1 to 5 seconds is enough for the first responder to be heard
+                 * by the other peers before their timers fire.
+                 */
+                uint64_t delay = 1 + (uint64_t)(rand() % 5);
+                g->roster_reply_deadline = now + delay;
+
+                printf("[MID] ROSTER_REQUEST: scheduled roster reply in %llu seconds. Our FP[0..3]=%02X%02X%02X%02X\n",
+                       (unsigned long long)delay,
+                       g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]);
+                fflush(stdout);
+            }
+        }
+
+        return changed;
+    }
+
+    /* Unknown message type. */
+    return false;
+}
+
+/******************************************************************************
+Forward declaration for internal use.
+mid_delete_peer_by_identity_internal is defined later in this file but is
+needed by mid_on_group_moderation_internal. We must NOT call the public
+mid_delete_peer_by_identity() from within a locked section because it would
+attempt to re-acquire the non-recursive mutex → deadlock.
+******************************************************************************/
+static bool mid_delete_peer_by_identity_internal(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                                                 const uint8_t identity_key[MID_IDENTITY_KEY_SIZE]);
+
+/******************************************************************************
+Internal state management (Assumes lock is held, does NOT fire callbacks)
+
+THREAD-SAFETY CONTRACT:
+Every function in this section expects the caller to already hold s->mutex.
+These functions must ONLY call other "_internal" or static helpers.
+They must NEVER call the public (locking) API wrappers.
+******************************************************************************/
+
+static bool mid_on_group_self_join_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t *nickname, size_t nickname_len)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    bool is_new = false;
+
+    if (!g) {
+        g = mid_add_group(s, chat_id);
+        is_new = true;
+    }
+
+    if (!g || !mid_init_self_from_tox(g, tox)) return is_new;
+
+    /* Stamp the founder role as soon as we join */
+    mid_apply_founder_role(g, tox);
+
+    bool nick_changed = false;
+
+    /*
+     * Store the self nickname as raw bytes.
+     */
+    if (nickname != NULL && nickname_len > 0) {
+        if (nickname_len > MID_MAX_NICK_SIZE) {
+            nickname_len = MID_MAX_NICK_SIZE;
+        }
+        if (g->self_nickname_len != nickname_len || memcmp(g->self_nickname, nickname, nickname_len) != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            memcpy(g->self_nickname, nickname, nickname_len);
+            g->self_nickname_len = (uint16_t)nickname_len;
+            nick_changed = true;
+        }
+    } else {
+        if (g->self_nickname_len != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            g->self_nickname_len = 0;
+            nick_changed = true;
+        }
+    }
+
+    g->announced = true;
+
+    bool announce_changed = mid_announce_self_group(s, g, tox);
+    mid_send_roster_request_group(s, g, tox);
+
+    return is_new || nick_changed || announce_changed;
+}
+
+static bool mid_on_group_delete_internal(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return false;
+
+    for (size_t i = 0; i < s->group_count; i++) {
+        if (memcmp(s->groups[i].chat_id, chat_id, TOX_GROUP_CHAT_ID_SIZE) == 0) {
+            sodium_memzero(s->groups[i].self_secret_signing_key, sizeof(s->groups[i].self_secret_signing_key));
+            free(s->groups[i].records);
+            for (size_t j = i; j < s->group_count - 1; j++) {
+                s->groups[j] = s->groups[j+1];
+            }
+            s->group_count--;
+            return true; /* CHANGED */
+        }
+    }
+    return false;
+}
+
+static bool mid_on_group_peer_join_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t peer_id)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    bool changed = false;
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    uint8_t id[MID_IDENTITY_KEY_SIZE];
+    uint8_t sig[MID_SIGNING_KEY_SIZE];
+
+    Tox_Err_Group_Peer_Query conn_err;
+    Tox_Connection conn = tox_group_peer_get_connection_status(tox, group_number, peer_id, &conn_err);
+    if (conn_err != TOX_ERR_GROUP_PEER_QUERY_OK) conn = TOX_CONNECTION_NONE;
+
+    Tox_Err_Group_Peer_Query role_err;
+    Tox_Group_Role role = tox_group_peer_get_role(tox, group_number, peer_id, &role_err);
+    if (role_err != TOX_ERR_GROUP_PEER_QUERY_OK) role = TOX_GROUP_ROLE_USER;
+
+    if (mid_get_peer_keys(tox, chat_id, peer_id, id, sig)) {
+        if (mid_on_peer_online_keys(g, id, sig, conn, role, mid_now_or_time(0))) {
+            changed = true;
+        }
+    }
+
+    if (mid_refresh_peer_name_group(g, tox, peer_id)) {
+        changed = true;
+    }
+
+    if (g->announced) {
+        if (mid_announce_self_group(s, g, tox)) {
+            changed = true;
+        }
+        
+        /* 
+         * RELIABILITY FIX:
+         * Toxcore often drops custom packets sent immediately during the join handshake.
+         * The new peer's ROSTER_REQUEST might be lost (as seen in the logs).
+         * Instead, when existing peers see a new peer join, they schedule a delayed 
+         * ROSTER_BATCH broadcast. The fingerprint suppression ensures only ONE existing 
+         * peer actually sends it, preventing a broadcast storm while guaranteeing delivery.
+         */
+        if (g->roster_reply_deadline == 0) {
+            uint64_t delay = 1 + (uint64_t)(rand() % 5);
+            g->roster_reply_deadline = mid_now_or_time(0) + delay;
+            printf("[MID] peer_join: scheduled roster sync in %llu seconds because a new peer joined.\n", (unsigned long long)delay);
+            fflush(stdout);
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
+static bool mid_on_group_peer_exit_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], Tox_Group_Exit_Type exit_type)
+{
+    (void)exit_type; /* Unused currently */
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    return mid_sync_online_state_group(g, tox, mid_now_or_time(0));
+}
+
+static bool mid_on_group_moderation_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t source_peer_id, uint32_t target_peer_id, Tox_Group_Mod_Event mod_type, bool *out_changed)
+{
+    *out_changed = false;
+
+    if (s == NULL || tox == NULL || chat_id == NULL) return false;
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (g == NULL) return false;
+
+    uint32_t group_number = mid_chat_id_to_group_number(tox, chat_id);
+    if (group_number == UINT32_MAX) return false;
+
+    printf("[MID] on_group_moderation: event group=%u source_peer=%u target_peer=%u type=%d\n",
+           group_number, source_peer_id, target_peer_id, (int)mod_type);
+    fflush(stdout);
+
+    if (mod_type == TOX_GROUP_MOD_EVENT_KICK) {
+        Tox_Err_Group_Self_Query self_err;
+        uint32_t self_peer_id = tox_group_self_get_peer_id(tox, group_number, &self_err);
+
+        if (self_err == TOX_ERR_GROUP_SELF_QUERY_OK && target_peer_id == self_peer_id) {
+            printf("[MID] on_group_moderation: we were kicked; deleting group state\n");
+            fflush(stdout);
+            mid_on_group_delete_internal(s, chat_id);
+            *out_changed = true;
+            return true;
+        }
+
+        Tox_Err_Group_Peer_Query peer_err;
+        uint8_t kicked_identity[MID_IDENTITY_KEY_SIZE];
+
+        if (tox_group_peer_get_public_key(tox, group_number, target_peer_id, kicked_identity, &peer_err) &&
+            peer_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+            printf("[MID] on_group_moderation: deleting kicked peer from roster\n");
+            fflush(stdout);
+            /*
+             * THREAD-SAFETY FIX:
+             * We are already holding s->mutex (acquired by the public caller).
+             * We must call the _internal variant which does NOT lock.
+             * Calling the public mid_delete_peer_by_identity() here would
+             * deadlock on the non-recursive mutex.
+             */
+            if (mid_delete_peer_by_identity_internal(s, chat_id, kicked_identity)) {
+                *out_changed = true;
+            }
+        } else {
+            printf("[MID] on_group_moderation: kicked peer %u identity no longer queryable\n", target_peer_id);
+            fflush(stdout);
+        }
+    } else if (mod_type == TOX_GROUP_MOD_EVENT_OBSERVER ||
+               mod_type == TOX_GROUP_MOD_EVENT_USER ||
+               mod_type == TOX_GROUP_MOD_EVENT_MODERATOR) {
+        
+        Tox_Err_Group_Peer_Query peer_err;
+        uint8_t target_identity[MID_IDENTITY_KEY_SIZE];
+
+        if (tox_group_peer_get_public_key(tox, group_number, target_peer_id, target_identity, &peer_err) &&
+            peer_err == TOX_ERR_GROUP_PEER_QUERY_OK) {
+            
+            int idx = mid_find_identity(g, target_identity);
+            if (idx >= 0) {
+                Tox_Group_Role new_role = TOX_GROUP_ROLE_USER;
+                if (mod_type == TOX_GROUP_MOD_EVENT_OBSERVER) new_role = TOX_GROUP_ROLE_OBSERVER;
+                else if (mod_type == TOX_GROUP_MOD_EVENT_MODERATOR) new_role = TOX_GROUP_ROLE_MODERATOR;
+                
+                if (g->records[idx].role != new_role) {
+                    g->records[idx].role = new_role;
+                    *out_changed = true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+static bool mid_on_group_peer_name_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t peer_id)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    return mid_refresh_peer_name_group(g, tox, peer_id);
+}
+
+static bool mid_self_set_name_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t *nickname, size_t nickname_len)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g || !g->have_keys) return false;
+
+    bool nick_changed = false;
+
+    /* Update the persistent self nickname buffer */
+    if (nickname != NULL && nickname_len > 0) {
+        if (nickname_len > MID_MAX_NICK_SIZE) {
+            nickname_len = MID_MAX_NICK_SIZE;
+        }
+        if (g->self_nickname_len != nickname_len || memcmp(g->self_nickname, nickname, nickname_len) != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            memcpy(g->self_nickname, nickname, nickname_len);
+            g->self_nickname_len = (uint16_t)nickname_len;
+            nick_changed = true;
+        }
+    } else {
+        if (g->self_nickname_len != 0) {
+            memset(g->self_nickname, 0, MID_MAX_NICK_SIZE);
+            g->self_nickname_len = 0;
+            nick_changed = true;
+        }
+    }
+
+    if (nick_changed) {
+        /* Immediately update the local roster record so it reflects the change
+           even if the timestamp doesn't bump within the same second */
+        int idx = mid_find_identity(g, g->self_identity_key);
+        if (idx >= 0) {
+            MidPeerRecord *e = &g->records[idx];
+            memset(e->nickname, 0, MID_MAX_NICK_SIZE);
+            if (g->self_nickname_len > 0) {
+                memcpy(e->nickname, g->self_nickname, g->self_nickname_len);
+            }
+            e->nickname_len = g->self_nickname_len;
+        }
+
+        /* Re-announce ourselves to broadcast the new signed presence record */
+        if (g->announced) {
+            mid_announce_self_group(s, g, tox);
+        }
+    }
+
+    return nick_changed;
+}
+
+static bool mid_on_group_custom_packet_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], uint32_t peer_id, const uint8_t *data, size_t length)
+{
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g) return false;
+
+    s->recv_bytes += length;
+
+    return mid_on_custom_packet_group(s, g, tox, peer_id, data, length, mid_now_or_time(0));
+}
+
+static bool mid_announce_leave_internal(MidState *s, Tox *tox, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], bool *out_changed)
+{
+    *out_changed = false;
+
+    if (!chat_id) return false;
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (!g || !g->have_keys) return false;
+
+    MidPeerRecord r;
+    memset(&r, 0, sizeof(r));
+    memcpy(r.identity_key, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+    memcpy(r.signing_key, g->self_signing_key, MID_SIGNING_KEY_SIZE);
+    r.status = MID_STATUS_LEFT;
+    r.timestamp = mid_now_or_time(0);
+    r.connection_status = TOX_CONNECTION_NONE;
+
+    if (g->self_nickname_len > 0) {
+        uint16_t nick_copy = g->self_nickname_len;
+        if (nick_copy > MID_MAX_NICK_SIZE) {
+            nick_copy = MID_MAX_NICK_SIZE;
+        }
+        memcpy(r.nickname, g->self_nickname, nick_copy);
+        r.nickname_len = nick_copy;
+    }
+
+    if (!mid_sign_record(g, &r)) return false;
+
+    printf("[MID] announce_leave: broadcasting signed LEFT tombstone\n"); fflush(stdout);
+
+    bool sent = mid_send_presence_record(s, g, tox, &r);
+
+    int idx = mid_find_identity(g, g->self_identity_key);
+    if (idx >= 0) {
+        /* Replacing self with tombstone */
+        g->records[idx] = r;
+        g->records[idx].connection_status = TOX_CONNECTION_NONE;
+        *out_changed = true;
+    }
+
+    g->self_active = false;
+    return sent;
+}
+
+/*
+Internal delete: assumes lock is already held. Does NOT fire callbacks.
+This is the non-locking counterpart of the public mid_delete_peer_by_identity().
+*/
+static bool mid_delete_peer_by_identity_internal(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                                                 const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (s == NULL || identity_key == NULL || chat_id == NULL) return false;
+    if (mid_key_is_zero(identity_key)) return false;
+
+    MidGroupState *g = mid_find_group(s, chat_id);
+    if (g == NULL) return false;
+
+    int idx = mid_find_identity(g, identity_key);
+    if (idx < 0) return false;
+
+    printf("[MID] delete_peer_by_identity: deleting peer from roster\n");
+    fflush(stdout);
+
+    if (g->records[idx].has_signature) {
+        printf("[MID] delete_peer: XOR OUT deleted peer. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+        mid_xor_fingerprint(g->roster_fingerprint, g->records[idx].identity_key);
+        printf("[MID] delete_peer: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+    }
+
+    for (size_t k = (size_t)idx; k + 1 < g->count; k++) {
+        g->records[k] = g->records[k+1];
+    }
+    g->count--;
+    return true; /* CHANGED */
+}
+
+/******************************************************************************
+Public state management (Handles Locking and Callbacks)
+
+THREAD-SAFETY:
+Every public entry point follows the same pattern:
+  1. mid_lock(s)
+  2. Call the corresponding _internal function (which assumes lock is held)
+  3. Snapshot the callback pointer under the lock
+  4. mid_unlock(s)
+  5. Fire the callback OUTSIDE the lock (prevents deadlock if the
+     callback calls back into any mid_* public function)
+******************************************************************************/
+
+static bool mid_load_from_disk(MidState *s, const char *path, const uint8_t *passphrase, size_t passphrase_len) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return false;
+
+    fseek(f, 0, SEEK_END);
+    long file_size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (file_size <= 0) { fclose(f); return false; }
+
+    uint8_t *file_data = (uint8_t *)malloc(file_size);
+    if (!file_data || fread(file_data, 1, file_size, f) != (size_t)file_size) {
+        free(file_data); fclose(f); return false;
+    }
+    fclose(f);
+
+    uint8_t *data_to_parse = file_data;
+    size_t data_len = file_size;
+    uint8_t *decrypted_data = NULL;
+
+    // Check if the file was encrypted by TOXENCRYPTSAVE
+    if (file_size >= TOX_PASS_ENCRYPTION_EXTRA_LENGTH && tox_is_data_encrypted(file_data)) {
+        if (!passphrase || passphrase_len == 0) {
+            printf("[MID] load: file is encrypted but no passphrase provided, ignoring\n");
+            free(file_data);
+            return false;
+        }
+        decrypted_data = (uint8_t *)malloc(file_size);
+        if (!decrypted_data) {
+            free(file_data);
+            return false;
+        }
+        Tox_Err_Decryption err;
+        if (!tox_pass_decrypt(file_data, file_size, passphrase, passphrase_len, decrypted_data, &err)) {
+            printf("[MID] load: decryption failed (err=%d)\n", err);
+            free(decrypted_data);
+            free(file_data);
+            return false;
+        }
+        data_to_parse = decrypted_data;
+        data_len = file_size - TOX_PASS_ENCRYPTION_EXTRA_LENGTH;
+    }
+
+    // Parse Header
+    MidReader r = { data_to_parse, data_len, 0 };
+    uint8_t magic[MID_SAVE_MAGIC_SIZE];
+    if (!mid_reader_read(&r, magic, MID_SAVE_MAGIC_SIZE) || memcmp(magic, MID_SAVE_MAGIC, MID_SAVE_MAGIC_SIZE) != 0) {
+        goto parse_fail;
+    }
+
+    uint32_t ver;
+    if (!mid_reader_read_u32(&r, &ver) || ver != MID_SAVE_VERSION) {
+        printf("[MID] load: unsupported or missing version %u\n", ver);
+        goto parse_fail;
+    }
+
+    uint64_t load_time = (uint64_t)time(NULL);
+
+    // Parse Body
+    uint32_t group_count;
+    if (!mid_reader_read_u32(&r, &group_count) || group_count > MID_MAX_GROUPS) goto parse_fail;
+
+    for (uint32_t i = 0; i < group_count; i++) {
+        uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+        if (!mid_reader_read(&r, chat_id, TOX_GROUP_CHAT_ID_SIZE)) goto parse_fail;
+
+        MidGroupState *g = mid_add_group(s, chat_id);
+        if (!g) goto parse_fail;
+
+        if (!mid_reader_read(&r, g->self_identity_key, MID_IDENTITY_KEY_SIZE)) goto parse_fail;
+        if (!mid_reader_read(&r, g->self_signing_key, MID_SIGNING_KEY_SIZE)) goto parse_fail;
+        /*
+         * NEVER load self_secret_signing_key from disk.
+         *
+         * The secret key is fetched from Toxcore once the group becomes
+         * active again via mid_init_self_from_tox().
+         */
+        sodium_memzero(g->self_secret_signing_key, sizeof(g->self_secret_signing_key));
+
+        /*
+         * We only have public keys at this point.
+         * We cannot sign anything until Toxcore gives us the secret signing key.
+         */
+        g->have_keys = false;
+        g->self_active = false;
+        g->announced = false;
+
+        uint16_t nick_len;
+        if (!mid_reader_read_u16(&r, &nick_len) || nick_len > MID_MAX_NICK_SIZE) goto parse_fail;
+        g->self_nickname_len = nick_len;
+        if (!mid_reader_read(&r, g->self_nickname, nick_len)) goto parse_fail;
+
+        uint32_t peer_count;
+        if (!mid_reader_read_u32(&r, &peer_count) || peer_count > MID_MAX_PEERS_PER_GROUP) goto parse_fail;
+
+        for (uint32_t j = 0; j < peer_count; j++) {
+            MidPeerRecord tmp_rec;
+            memset(&tmp_rec, 0, sizeof(tmp_rec));
+
+            if (!mid_reader_read(&r, tmp_rec.identity_key, MID_IDENTITY_KEY_SIZE)) goto parse_fail;
+            if (!mid_reader_read(&r, tmp_rec.signing_key, MID_SIGNING_KEY_SIZE)) goto parse_fail;
+
+            uint8_t status;
+            if (!mid_reader_read_u8(&r, &status)) goto parse_fail;
+            tmp_rec.status = status;
+            if (tmp_rec.status != MID_STATUS_ACTIVE && tmp_rec.status != MID_STATUS_LEFT) goto parse_fail;
+
+            if (!mid_reader_read_u64(&r, &tmp_rec.timestamp)) goto parse_fail;
+
+            uint16_t p_nick_len;
+            if (!mid_reader_read_u16(&r, &p_nick_len) || p_nick_len > MID_MAX_NICK_SIZE) goto parse_fail;
+            tmp_rec.nickname_len = p_nick_len;
+            if (!mid_reader_read(&r, tmp_rec.nickname, p_nick_len)) goto parse_fail;
+
+            if (!mid_reader_read(&r, tmp_rec.signature, MID_SIG_SIZE)) goto parse_fail;
+            uint8_t has_sig;
+            if (!mid_reader_read_u8(&r, &has_sig)) goto parse_fail;
+            tmp_rec.has_signature = has_sig ? true : false;
+
+            uint32_t conn, role;
+            if (!mid_reader_read_u32(&r, &conn)) goto parse_fail;
+            /* HINT: Force all loaded peers to offline.
+                     Leaves status (ACTIVE/LEFT) exactly as it was saved. */
+            // tmp_rec.connection_status = (Tox_Connection)conn;
+            tmp_rec.connection_status = TOX_CONNECTION_NONE;
+
+            if (!mid_reader_read_u32(&r, &role)) goto parse_fail;
+            tmp_rec.role = (Tox_Group_Role)role;
+
+
+            if (!mid_reader_read_u64(&r, &tmp_rec.last_seen)) goto parse_fail;
+            // Only anchor if the saved value was 0 (e.g. corrupted or legacy save).
+            // If you use this, and the app was closed for 31 days, offline peers
+            // WILL be purged immediately upon the first mid_iterate() call.
+            //
+            if (tmp_rec.last_seen == 0) {
+                tmp_rec.last_seen = load_time;
+            }
+
+            if (mid_find_identity(g, tmp_rec.identity_key) >= 0) continue;
+
+            if (!mid_ensure_capacity(g)) goto parse_fail;
+            MidPeerRecord *p = &g->records[g->count];
+            *p = tmp_rec;
+
+            if (p->has_signature) {
+                mid_xor_fingerprint(g->roster_fingerprint, p->identity_key);
+            }
+            g->count++;
+        }
+    }
+
+    if (decrypted_data) free(decrypted_data);
+    free(file_data);
+    return true;
+
+parse_fail:
+    printf("[MID] load: parse error, discarding loaded state\n");
+    if (decrypted_data) free(decrypted_data);
+    free(file_data);
+    for (size_t i = 0; i < s->group_count; i++) free(s->groups[i].records);
+    free(s->groups);
+    s->groups = NULL; s->group_count = 0; s->group_capacity = 0;
+    return false;
+}
+
+bool mid_save(MidState *s, const uint8_t *passphrase, size_t passphrase_len) {
+    if (!s || !s->save_path) return false;
+
+    mid_lock(s);
+    MidBuf buf;
+    mid_buf_init(&buf);
+
+    // 1. Assemble Header and Body
+    mid_buf_append(&buf, MID_SAVE_MAGIC, MID_SAVE_MAGIC_SIZE);
+    uint8_t ver[4]; 
+    mid_put_u32_be(ver, MID_SAVE_VERSION); 
+    mid_buf_append(&buf, ver, sizeof(ver));
+
+    // 2. Serialize Body
+    mid_buf_append_u32(&buf, (uint32_t)s->group_count);
+    for (size_t i = 0; i < s->group_count; i++) {
+        MidGroupState *g = &s->groups[i];
+        mid_buf_append(&buf, g->chat_id, TOX_GROUP_CHAT_ID_SIZE);
+        mid_buf_append(&buf, g->self_identity_key, MID_IDENTITY_KEY_SIZE);
+        mid_buf_append(&buf, g->self_signing_key, MID_SIGNING_KEY_SIZE);
+        /*
+         * NEVER save self_secret_signing_key.
+         *
+         * The Ed25519 signing secret key belongs to the NGC group identity
+         * and is owned by Toxcore. It must be re-obtained from Toxcore when
+         * the group is active again.
+         */
+        mid_buf_append_u16(&buf, g->self_nickname_len);
+        mid_buf_append(&buf, g->self_nickname, g->self_nickname_len);
+        mid_buf_append_u32(&buf, (uint32_t)g->count);
+
+        for (size_t j = 0; j < g->count; j++) {
+            MidPeerRecord *p = &g->records[j];
+            mid_buf_append(&buf, p->identity_key, MID_IDENTITY_KEY_SIZE);
+            mid_buf_append(&buf, p->signing_key, MID_SIGNING_KEY_SIZE);
+            mid_buf_append_u8(&buf, p->status);
+            mid_buf_append_u64(&buf, p->timestamp);
+            mid_buf_append_u16(&buf, p->nickname_len);
+            mid_buf_append(&buf, p->nickname, p->nickname_len);
+            mid_buf_append(&buf, p->signature, MID_SIG_SIZE);
+            mid_buf_append_u8(&buf, p->has_signature ? 1 : 0);
+            mid_buf_append_u32(&buf, (uint32_t)p->connection_status);
+            mid_buf_append_u32(&buf, (uint32_t)p->role);
+            mid_buf_append_u64(&buf, p->last_seen);
+        }
+    }
+
+    // 3. Encrypt payload if passphrase provided
+    uint8_t *final_payload = buf.data;
+    size_t final_payload_len = buf.len;
+    uint8_t *free_payload = NULL;
+
+    if (passphrase && passphrase_len > 0) {
+        size_t cipher_len = buf.len + TOX_PASS_ENCRYPTION_EXTRA_LENGTH;
+        free_payload = (uint8_t *)malloc(cipher_len);
+        if (!free_payload) { mid_buf_free(&buf); mid_unlock(s); return false; }
+
+        Tox_Err_Encryption err;
+        if (!tox_pass_encrypt(buf.data, buf.len, passphrase, passphrase_len, free_payload, &err)) {
+            printf("[MID] save: encryption failed (err=%d)\n", err);
+            free(free_payload); mid_buf_free(&buf); mid_unlock(s); return false;
+        }
+        final_payload = free_payload;
+        final_payload_len = cipher_len;
+    }
+
+    char *path_copy = mid_strdup(s->save_path);
+    mid_unlock(s); // <--- CRITICAL: Release lock before doing blocking Disk I/O
+
+    if (!path_copy) {
+        if (free_payload) free(free_payload);
+        mid_buf_free(&buf);
+        return false;
+    }
+
+    // 4. Write to Disk Atomically
+    size_t path_len = strlen(path_copy);
+    char *tmp_path = (char *)malloc(path_len + 6);
+    if (!tmp_path) {
+        free(path_copy);
+        if (free_payload) free(free_payload);
+        mid_buf_free(&buf);
+        return false;
+    }
+    snprintf(tmp_path, path_len + 6, "%s.tmp", path_copy);
+
+    FILE *f = fopen(tmp_path, "wb");
+    if (!f) {
+        free(tmp_path); free(path_copy);
+        if (free_payload) free(free_payload);
+        mid_buf_free(&buf);
+        return false;
+    }
+
+#ifndef _WIN32
+    /* 
+     * FIX: CodeQL TOCTOU Race Condition.
+     * Instead of closing the file and calling chmod() on the path string 
+     * (which allows an attacker to swap the path with a symlink in between),
+     * we use fchmod() on the open file descriptor. This atomically secures 
+     * the exact file we just created, completely bypassing path-based races.
+     */
+    if (fchmod(fileno(f), 0600) != 0) {
+        // Silently ignore permission errors, matching previous behavior
+    }
+#endif
+
+    fwrite(final_payload, 1, final_payload_len, f);
+    fclose(f);
+
+    if (free_payload) free(free_payload);
+    mid_buf_free(&buf);
+
+#ifdef _WIN32
+    /*
+     * Windows filesystem semantics differ from POSIX. Symlink-based TOCTOU 
+     * attacks via _chmod are not part of the standard Windows threat model 
+     * in this context, so _chmod remains the correct and standard approach here.
+     */
+    _chmod(tmp_path, _S_IREAD | _S_IWRITE);
+#endif
+
+#ifdef __MINGW32__
+    // HINT: rename() will refuse to overwrite existing files with WIN32 mingw
+    unlink(path_copy);
+#endif
+
+    bool ok = (rename(tmp_path, path_copy) == 0);
+    if (!ok) remove(tmp_path);
+
+    free(tmp_path);
+    free(path_copy);
+    return ok;
+}
+
+MidState *mid_new(const char *save_path, const uint8_t *passphrase, size_t passphrase_len) {
+    if (sodium_init() < 0) return NULL;
+
+    MidState *s = (MidState *)calloc(1, sizeof(MidState));
+    if (!s) return NULL;
+
+    s->mutex = (pthread_mutex_t *)calloc(1, sizeof(pthread_mutex_t));
+    if (!s->mutex) { free(s); return NULL; }
+    pthread_mutex_init(s->mutex, NULL);
+
+    if (save_path) s->save_path = mid_strdup(save_path);
+
+    if (s->save_path) {
+        mid_load_from_disk(s, s->save_path, passphrase, passphrase_len);
+    }
+
+    return s;
+}
+
+void mid_free(MidState *s) {
+    if (s == NULL) return;
+
+    for (size_t i = 0; i < s->group_count; i++) {
+        sodium_memzero(s->groups[i].self_secret_signing_key, sizeof(s->groups[i].self_secret_signing_key));
+        free(s->groups[i].records);
+    }
+    free(s->groups);
+
+    free(s->save_path);
+
+    if (s->mutex) {
+        pthread_mutex_destroy(s->mutex);
+        free(s->mutex);
+    }
+
+    free(s);
+}
+
+void mid_on_group_self_join(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_self_join_internal(s, tox, chat_id, nickname, nickname_len);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    /* Fire callback OUTSIDE the lock to avoid deadlock */
+    if (changed && cb) cb(chat_id, ud);
+}
+
+void mid_on_group_delete(MidState *s, Tox *tox, uint32_t group_number)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_delete_internal(s, chat_id);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+void mid_on_group_peer_join(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_peer_join_internal(s, tox, chat_id, peer_id);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+void mid_on_group_peer_exit(MidState *s, Tox *tox, uint32_t group_number, Tox_Group_Exit_Type exit_type)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_peer_exit_internal(s, tox, chat_id, exit_type);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+bool mid_on_group_moderation(MidState *s, Tox *tox, uint32_t group_number,
+                             uint32_t source_peer_id, uint32_t target_peer_id,
+                             Tox_Group_Mod_Event mod_type)
+{
+    if (!s || !tox) return false;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return false;
+
+    mid_lock(s);
+    bool changed = false;
+    bool we_were_kicked = mid_on_group_moderation_internal(s, tox, chat_id, source_peer_id, target_peer_id, mod_type, &changed);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+    return we_were_kicked;
+}
+
+void mid_on_group_peer_name(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_peer_name_internal(s, tox, chat_id, peer_id);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+bool mid_self_set_name(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len)
+{
+    if (!s || !tox) return false;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return false;
+
+    mid_lock(s);
+    bool changed = mid_self_set_name_internal(s, tox, chat_id, nickname, nickname_len);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    /* Fire callback OUTSIDE the lock to avoid deadlock */
+    if (changed && cb) cb(chat_id, ud);
+
+    return changed;
+}
+
+void mid_on_group_custom_packet(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data, size_t length)
+{
+    if (!s || !tox) return;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return;
+
+    mid_lock(s);
+    bool changed = mid_on_group_custom_packet_internal(s, tox, chat_id, peer_id, data, length);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+}
+
+bool mid_announce_leave(MidState *s, Tox *tox, uint32_t group_number)
+{
+    if (!s || !tox) return false;
+
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    Tox_Err_Group_State_Queries err;
+    if (!tox_group_get_chat_id(tox, group_number, chat_id, &err) || err != TOX_ERR_GROUP_STATE_QUERIES_OK) return false;
+
+    mid_lock(s);
+    bool changed = false;
+    bool sent = mid_announce_leave_internal(s, tox, chat_id, &changed);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+    return sent;
+}
+
+void mid_iterate(MidState *s, Tox *tox)
+{
+    if (!s || !tox) return;
+
+    mid_lock(s);
+
+    uint64_t now = mid_now_or_time(0);
+
+    /*
+     * PERFORMANCE THROTTLE:
+     * Do not run the heavy sync/cleanup loop on every 50ms tox_iterate() tick.
+     * Only run it every MID_SYNC_INTERVAL_SEC seconds.
+     */
+    if (now - s->last_sync_time < MID_SYNC_INTERVAL_SEC) {
+        mid_unlock(s);
+        return;
+    }
+
+    s->last_sync_time = now;
+
+    /* Collect changed groups to fire callbacks AFTER unlocking */
+    uint8_t changed_groups[MID_MAX_CHANGED_GROUPS_PER_ITERATE][TOX_GROUP_CHAT_ID_SIZE];
+    size_t num_changed = 0;
+
+    for (size_t i = 0; i < s->group_count; i++) {
+        MidGroupState *g = &s->groups[i];
+        bool changed = false;
+
+        // 1. Sync online state with Toxcore
+        if (mid_sync_online_state_group(g, tox, now)) {
+            changed = true;
+        }
+
+        // 2. Heartbeats (FIX 3: Uses lightweight heartbeat packet)
+        if (g->have_keys && g->self_active && g->announced) {
+            if (now >= g->last_announce && (now - g->last_announce >= MID_HEARTBEAT_SEC)) {
+                printf("[MID] poll: heartbeat triggered\n"); fflush(stdout);
+                if (mid_send_heartbeat_record(s, g, tox)) {
+                    g->last_announce = now;
+                    int idx = mid_find_identity(g, g->self_identity_key);
+                    if (idx >= 0) {
+                        g->records[idx].timestamp = now;
+                    }
+                    changed = true;
+                }
+            }
+        }
+
+        // 3. GRAVEYARD & STALE CLEANUP
+        uint64_t cutoff_tombstone = (now > MID_TOMBSTONE_TTL_SEC) ? (now - MID_TOMBSTONE_TTL_SEC) : 0;
+        uint64_t cutoff_stale = (now > MID_STALE_PEER_TTL_SEC) ? (now - MID_STALE_PEER_TTL_SEC) : 0;
+
+        size_t j = 0;
+        while (j < g->count) {
+            bool purge = false;
+            const MidPeerRecord *rec = &g->records[j];
+
+            // A. Purge expired LEFT tombstones (7 days)
+            if (rec->status == MID_STATUS_LEFT && rec->timestamp < cutoff_tombstone) {
+                purge = true;
+            }
+            // B. Purge stale offline ACTIVE peers (30 days)
+            // Must be ACTIVE, offline, and last_seen is older than the stale cutoff.
+            else if (rec->status == MID_STATUS_ACTIVE &&
+                     rec->connection_status == TOX_CONNECTION_NONE &&
+                     rec->last_seen > 0 &&
+                     rec->last_seen < cutoff_stale) {
+                purge = true;
+            }
+
+            if (purge) {
+                printf("[MID] iterate: purging stale/expired peer %zu\n", j); fflush(stdout);
+                if (rec->has_signature) {
+                    printf("[MID] iterate: XOR OUT purged peer. Old FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                    mid_xor_fingerprint(g->roster_fingerprint, rec->identity_key);
+                    printf("[MID] iterate: New FP[0..3]=%02X%02X%02X%02X\n", g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]); fflush(stdout);
+                }
+                // Shift array down to delete
+                for (size_t k = j; k < g->count - 1; k++) {
+                    g->records[k] = g->records[k+1];
+                }
+                g->count--;
+                changed = true;
+                continue; // Do not increment j, check the new record at this index
+            }
+            j++;
+        }
+
+        // 4. FIX 2: Multicast Roster Reply Timer execution
+        if (g->roster_reply_deadline != 0 && now >= g->roster_reply_deadline) {
+            printf("[MID] iterate: Roster reply timer fired! No one else suppressed us. Sending our roster. Our FP[0..3]=%02X%02X%02X%02X\n",
+                   g->roster_fingerprint[0], g->roster_fingerprint[1], g->roster_fingerprint[2], g->roster_fingerprint[3]);
+            fflush(stdout);
+            g->roster_reply_deadline = 0;
+            mid_send_roster_group(s, g, tox);
+            changed = true;
+        }
+
+        if (changed && num_changed < MID_MAX_CHANGED_GROUPS_PER_ITERATE) {
+            memcpy(changed_groups[num_changed++], g->chat_id, TOX_GROUP_CHAT_ID_SIZE);
+        }
+    }
+
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+
+    /*
+     * IMPORTANT: Unlock BEFORE firing callbacks.
+     * This prevents deadlocks if the user's callback calls mid_peer_list_get().
+     */
+    mid_unlock(s);
+
+    if (cb) {
+        for (size_t i = 0; i < num_changed; i++) {
+            cb(changed_groups[i], ud);
+        }
+    }
+}
+
+size_t mid_group_count(MidState *s)
+{
+    if (!s) return 0;
+
+    mid_lock(s);
+    size_t count = s->group_count;
+    mid_unlock(s);
+
+    return count;
+}
+
+int mid_find_peer(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (s == NULL || identity_key == NULL || chat_id == NULL) return -1;
+    if (mid_key_is_zero(identity_key)) return -1;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    int idx = -1;
+    if (g != NULL) {
+        idx = mid_find_identity(g, identity_key);
+    }
+    mid_unlock(s);
+
+    return idx;
+}
+
+bool mid_delete_peer_by_identity(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (!s || !chat_id) return false;
+
+    mid_lock(s);
+    bool changed = mid_delete_peer_by_identity_internal(s, chat_id, identity_key);
+    mid_peer_list_changed_cb cb = s->peer_list_changed_cb;
+    void *ud = s->peer_list_changed_user_data;
+    mid_unlock(s);
+
+    if (changed && cb) cb(chat_id, ud);
+    return changed;
+}
+
+size_t mid_peer_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t count = g ? g->count : 0;
+    mid_unlock(s);
+
+    return count;
+}
+
+size_t mid_signed_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t c = 0;
+    if (g) {
+        for (size_t i = 0; i < g->count; i++) {
+            if (g->records[i].has_signature) c++;
+        }
+    }
+    mid_unlock(s);
+
+    return c;
+}
+
+size_t mid_online_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t c = 0;
+    if (g) {
+        for (size_t i = 0; i < g->count; i++) {
+            if (g->records[i].connection_status != TOX_CONNECTION_NONE) c++;
+        }
+    }
+    mid_unlock(s);
+
+    return c;
+}
+
+size_t mid_offline_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t c = 0;
+    if (g) {
+        for (size_t i = 0; i < g->count; i++) {
+            if (g->records[i].connection_status == TOX_CONNECTION_NONE &&
+                g->records[i].status == MID_STATUS_ACTIVE) c++;
+        }
+    }
+    mid_unlock(s);
+
+    return c;
+}
+
+bool mid_peer_is_signed_left(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const uint8_t identity_key[MID_IDENTITY_KEY_SIZE])
+{
+    if (s == NULL || identity_key == NULL || chat_id == NULL) return false;
+    if (mid_key_is_zero(identity_key)) return false;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    bool res = false;
+    if (g != NULL) {
+        int idx = mid_find_identity(g, identity_key);
+        if (idx >= 0) {
+            const MidPeerRecord *rec = &g->records[idx];
+            res = rec->has_signature && rec->status == MID_STATUS_LEFT;
+        }
+    }
+    mid_unlock(s);
+
+    return res;
+}
+
+/******************************************************************************
+Network Stats
+******************************************************************************/
+
+void mid_get_network_stats(MidState *s, uint64_t *sent_bytes, uint64_t *recv_bytes)
+{
+    if (s == NULL) {
+        if (sent_bytes) *sent_bytes = 0;
+        if (recv_bytes) *recv_bytes = 0;
+        return;
+    }
+
+    /* Cast away const for locking; the mutex is logically mutable */
+    mid_lock(s);
+    if (sent_bytes) *sent_bytes = s->sent_bytes;
+    if (recv_bytes) *recv_bytes = s->recv_bytes;
+    mid_unlock(s);
+}
+
+/******************************************************************************
+Peer List Query API (for C / JNI clients)
+******************************************************************************/
+
+size_t mid_peer_list_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE])
+{
+    if (!s || !chat_id) return 0;
+
+    mid_lock(s);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    size_t count = g ? g->count : 0;
+    mid_unlock(s);
+
+    return count;
+}
+
+bool mid_peer_list_get(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], size_t index, MidPeerInfo *out)
+{
+    if (s == NULL || out == NULL || chat_id == NULL) return false;
+
+    mid_lock(s);
+
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+    bool success = false;
+
+    if (g != NULL && index < g->count) {
+        const MidPeerRecord *rec = &g->records[index];
+
+        memset(out, 0, sizeof(*out));
+
+        memcpy(out->identity_key, rec->identity_key, MID_IDENTITY_KEY_SIZE);
+        memcpy(out->signing_key, rec->signing_key, MID_SIGNING_KEY_SIZE);
+
+        out->status        = rec->status;
+        out->connection_status = (uint8_t)rec->connection_status;
+        out->role          = (uint8_t)rec->role;
+        out->has_signature = rec->has_signature ? 1 : 0;
+        out->reserved      = 0;
+        out->last_seen     = rec->last_seen;
+        out->nickname_len  = rec->nickname_len;
+
+        // Safe copy bounded strictly by MID_MAX_NICK_SIZE
+        if (rec->nickname_len > 0 && rec->nickname_len <= MID_MAX_NICK_SIZE) {
+            memcpy(out->nickname, rec->nickname, rec->nickname_len);
+        }
+
+        // The NUL-termination.
+        // Because the array in MidPeerInfo is (MID_MAX_NICK_SIZE + 1),
+        // the index [nickname_len] is ALWAYS a valid memory location.
+        // (Max index written to is MID_MAX_NICK_SIZE, which is the last byte).
+        out->nickname[out->nickname_len] = '\0';
+
+        success = true;
+    }
+
+    mid_unlock(s);
+
+    return success;
+}
+
+/******************************************************************************
+Peer List Changed Callback registration
+******************************************************************************/
+
+void mid_set_peer_list_changed_cb(MidState *s, mid_peer_list_changed_cb cb, void *user_data)
+{
+    if (!s) return;
+
+    mid_lock(s);
+    s->peer_list_changed_cb = cb;
+    s->peer_list_changed_user_data = user_data;
+    mid_unlock(s);
+}
+
+/******************************************************************************
+Peer table printing
+******************************************************************************/
+
+static void mid_hex_short(char *out, size_t out_size, const uint8_t *data, size_t data_len, size_t max_bytes)
+{
+    if (out == NULL || out_size == 0) return;
+    out[0] = '\0';
+    if (data == NULL || data_len == 0 || max_bytes == 0) return;
+    if (max_bytes > data_len) max_bytes = data_len;
+    if (out_size <= (max_bytes * 2)) max_bytes = (out_size - 1) / 2;
+
+    for (size_t i = 0; i < max_bytes; i++) {
+        snprintf(out + (i * 2), 3, "%02X", data[i]);
+    }
+    out[max_bytes * 2] = '\0';
+}
+
+static void mid_make_safe_nick(char *out, size_t out_size, const uint8_t *nick, uint16_t nick_len)
+{
+    if (out == NULL || out_size == 0) return;
+
+    size_t o = 0;
+    if (nick != NULL) {
+        for (uint16_t i = 0; i < nick_len && o + 1 < out_size; i++) {
+            uint8_t c = nick[i];
+            if (c >= 0x20 && c <= 0x7E) out[o] = (char)c;
+            else out[o] = '.';
+            o++;
+        }
+    }
+    out[o] = '\0';
+}
+
+void mid_print_peer_table(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const char *title)
+{
+    if (!s || !chat_id) return;
+
+    mid_lock(s);
+
+    time_t now = time(NULL);
+    const MidGroupState *g = mid_find_group_const(s, chat_id);
+
+    char chat_id_hex[9];
+    mid_hex_short(chat_id_hex, sizeof(chat_id_hex), chat_id, TOX_GROUP_CHAT_ID_SIZE, 4);
+
+    printf("\n");
+    printf("==========================================================================================\n");
+    printf("MIDDLEWARE PEER TABLE: %s (ChatID %s...)\n", title != NULL ? title : "unknown", chat_id_hex);
+
+    if (g == NULL) {
+        printf("(Group not found in middleware)\n");
+        printf("==========================================================================================\n\n");
+        fflush(stdout);
+        mid_unlock(s);
+        return;
+    }
+
+    size_t active_count = 0;
+    size_t online_count = 0;
+    size_t signed_count = 0;
+
+    for (size_t i = 0; i < g->count; i++) {
+        if (g->records[i].status == MID_STATUS_ACTIVE) active_count++;
+        if (g->records[i].connection_status != TOX_CONNECTION_NONE) online_count++;
+        if (g->records[i].has_signature) signed_count++;
+    }
+
+    printf("records=%zu active=%zu online=%zu signed=%zu sent=%llu recv=%llu\n",
+           g->count, active_count, online_count, signed_count,
+           (unsigned long long)s->sent_bytes, (unsigned long long)s->recv_bytes);
+
+    printf("+----+------+--------------+--------------+--------------+--------+------+--------+--------+----------+\n");
+    printf("| %2s | %-4s | %-12s | %-12s | %-12s | %-6s | %-4s | %-6s | %-6s | %-8s |\n",
+           "#", "Self", "Nickname", "Identity", "Signing", "Status", "Sig", "Conn", "Role", "Last seen");
+    printf("+----+------+--------------+--------------+--------------+--------+------+--------+--------+----------+\n");
+
+    for (size_t i = 0; i < g->count; i++) {
+        const MidPeerRecord *rec = &g->records[i];
+
+        char nick_buf[13];
+        char identity_buf[13];
+        char signing_buf[13];
+        char seen_buf[16];
+
+        mid_make_safe_nick(nick_buf, sizeof(nick_buf), rec->nickname, rec->nickname_len);
+        mid_hex_short(identity_buf, sizeof(identity_buf), rec->identity_key, MID_IDENTITY_KEY_SIZE, 6);
+        mid_hex_short(signing_buf, sizeof(signing_buf), rec->signing_key, MID_SIGNING_KEY_SIZE, 6);
+
+        bool is_self = false;
+        if (g->have_keys) {
+            is_self = mid_same_identity(rec->identity_key, g->self_identity_key);
+        }
+
+        const char *status_str = "?";
+        if (rec->status == MID_STATUS_ACTIVE) status_str = "ACTIVE";
+        else if (rec->status == MID_STATUS_LEFT) status_str = "LEFT";
+
+        const char *conn_str = "NONE";
+        if (rec->connection_status == TOX_CONNECTION_TCP) conn_str = "TCP";
+        else if (rec->connection_status == TOX_CONNECTION_UDP) conn_str = "UDP";
+
+        const char *role_str = "USER";
+        if (rec->role == TOX_GROUP_ROLE_FOUNDER) role_str = "FOUNDER";
+        else if (rec->role == TOX_GROUP_ROLE_MODERATOR) role_str = "MOD";
+        else if (rec->role == TOX_GROUP_ROLE_OBSERVER) role_str = "OBS";
+
+        if (rec->connection_status != TOX_CONNECTION_NONE) {
+            snprintf(seen_buf, sizeof(seen_buf), "now");
+        } else if (rec->last_seen == 0) {
+            snprintf(seen_buf, sizeof(seen_buf), "-");
+        } else if (rec->last_seen > (uint64_t)now) {
+            snprintf(seen_buf, sizeof(seen_buf), "future");
+        } else {
+            unsigned long age = (unsigned long)(now - (time_t)rec->last_seen);
+            snprintf(seen_buf, sizeof(seen_buf), "%lus", age);
+        }
+
+        printf("| %2zu | %-4s | %-12s | %-12s | %-12s | %-6s | %-4s | %-6s | %-6s | %-8s |\n",
+               i,
+               is_self ? "YES" : "no",
+               nick_buf,
+               identity_buf,
+               signing_buf,
+               status_str,
+               rec->has_signature ? "yes" : "no",
+               conn_str,
+               role_str,
+               seen_buf);
+    }
+
+    printf("+----+------+--------------+--------------+--------------+--------+------+--------+--------+----------+\n");
+    printf("\n");
+    fflush(stdout);
+
+    mid_unlock(s);
+}

--- a/ngc_ppeerlist/mid_roster.h
+++ b/ngc_ppeerlist/mid_roster.h
@@ -1,0 +1,375 @@
+/*
+mid_roster.h
+Minimal persistent group-roster middleware for Tox NGC.
+This header exposes a very simple API. All internal state, heartbeats,
+online-state synchronization, and roster requests are hidden inside
+the middleware. The client only needs to forward Toxcore events to
+the middleware hooks and call mid_iterate() in its main loop.
+*/
+
+#ifndef MID_ROSTER_H
+#define MID_ROSTER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+/*
+Opaque middleware state.
+A single MidState instance can manage multiple groups simultaneously.
+
+THREAD-SAFETY:
+All public functions in this header are thread-safe and may be called
+concurrently from any thread. Internally a single non-recursive
+pthread_mutex_t protects all mutable state (similar to tox_lock/tox_unlock
+in Toxcore). Callbacks are always fired WITHOUT the lock held, so it is
+safe to call any mid_* function from within a callback without deadlock.
+
+mid_new() and mid_free() are NOT thread-safe with respect to each other
+or to concurrent users. The caller must ensure mid_free() is only called
+after all other threads have stopped using the MidState.
+*/
+typedef struct MidState MidState;
+
+/* Hard limit for stored peers per group. */
+#define MID_MAX_PEERS_PER_GROUP 1024
+
+#define MID_PROTOCOL_VERSION    1
+
+/* NGC custom packet ID */
+#define MID_MAGIC_0  0x66      // was before: 0xA0
+#define MID_MAGIC_1  0x77      // was before: 0x91
+#define MID_MAGIC_2  0x92
+
+#define MID_MAGIC_BYTES_TOTAL 3
+/* Total header size: Magic bytes + Protocol Version (1 byte) + Message Type (1 byte) */
+#define MID_HEADER_SIZE (MID_MAGIC_BYTES_TOTAL + 2)
+
+/******************************************************************************
+Key-size constants (needed by MidPeerInfo below)
+******************************************************************************/
+
+#ifndef MID_IDENTITY_KEY_SIZE
+#define MID_IDENTITY_KEY_SIZE TOX_GROUP_PEER_PUBLIC_KEY_SIZE
+#endif
+
+#ifndef MID_SIGNING_KEY_SIZE
+#define MID_SIGNING_KEY_SIZE 32
+#endif
+
+#ifndef MID_MAX_NICK_SIZE
+#define MID_MAX_NICK_SIZE 128
+#endif
+
+/******************************************************************************
+Lifecycle
+******************************************************************************/
+
+/*
+Create a new middleware state.
+
+Parameters:
+  save_path      File path to load/save state. Pass NULL for a clean,
+                 in-memory only state.
+
+  passphrase     Optional passphrase to encrypt/decrypt the save file on disk.
+                 Pass NULL (with passphrase_len = 0) to save in plaintext
+                 (file permissions will be set to 0600).
+                 The passphrase can be any arbitrary length. It is fed
+                 directly to tox_pass_key_derive() internally.
+                 The passphrase is NOT stored in the middleware state.
+                 You must provide the same passphrase on every call to
+                 mid_save() to produce a readable encrypted file.
+
+  passphrase_len Length of the passphrase in bytes. Pass 0 if passphrase
+                 is NULL.
+
+Behavior on load:
+  If a save file exists at save_path:
+    - If the file is encrypted, the passphrase MUST be correct, otherwise
+      decryption fails and the file is ignored (clean state is started).
+    - If the file is unencrypted, it is loaded regardless of passphrase.
+    - If the file is corrupted or has an unsupported version, it is ignored.
+
+Returns:
+  A new MidState instance, or NULL on fatal error.
+*/
+MidState *mid_new(const char *save_path, const uint8_t *passphrase, size_t passphrase_len);
+
+/*
+Save the current state to disk. Thread-safe.
+
+The state is written atomically: data is written to a temporary file first,
+then renamed over the target path. This prevents corruption if the process
+is killed mid-write.
+
+Parameters:
+  s              The middleware state. Must not be NULL.
+
+  passphrase     Optional passphrase to encrypt the save file on disk.
+                 Pass NULL (with passphrase_len = 0) to save in plaintext.
+                 Must match the passphrase used when the file was originally
+                 encrypted if you intend to load it later with a passphrase.
+                 The passphrase is NOT stored. It is used only for this
+                 single save operation.
+
+  passphrase_len Length of the passphrase in bytes. Pass 0 if passphrase
+                 is NULL.
+
+Note:
+  The save_path used here is the one provided to mid_new(). There is no
+  separate configuration function. If save_path was NULL at creation,
+  this function returns false immediately.
+
+Returns:
+  true on success, false on failure.
+*/
+bool mid_save(MidState *s, const uint8_t *passphrase, size_t passphrase_len);
+
+void mid_free(MidState *s);
+
+/******************************************************************************
+Group Hooks
+******************************************************************************/
+
+/*
+Call this when the client successfully joins a group (or creates one).
+The middleware will fetch keys, announce the client, and request the roster.
+*/
+void mid_on_group_self_join(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len);
+
+/*
+Call this when the client leaves or deletes a group.
+The middleware will securely wipe keys and free the roster for this group.
+*/
+void mid_on_group_delete(MidState *s, Tox *tox, uint32_t group_number);
+
+/******************************************************************************
+Peer Event Hooks
+******************************************************************************/
+
+/*
+Call this when a new peer joins the group.
+The middleware will record them as online, refresh their name, and
+automatically re-sync the roster if we have already announced ourselves.
+*/
+void mid_on_group_peer_join(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id);
+
+/*
+ * Call this when a peer exits the group (via Toxcore's peer_exit callback).
+ * 
+ * NOTE: The `exit_type` parameter is intentionally ignored. 
+ * To maintain a stable, persistent roster that includes offline peers, 
+ * we do not delete peers simply because they disconnected or quit. 
+ * 
+ * Instead, this triggers a state-sync (`mid_sync_online_state_group`). 
+ * The middleware will query Toxcore to confirm the peer is gone and mark 
+ * them as offline (`TOX_CONNECTION_NONE`). 
+ * 
+ * If a peer actually intends to leave permanently, they should broadcast 
+ * a signed LEFT tombstone (MID_STATUS_LEFT) via custom packets before 
+ * disconnecting. The middleware will process that tombstone and keep the 
+ * peer in the roster for 7 days (MID_TOMBSTONE_TTL_SEC) to allow offline 
+ * peers to sync the departure.
+ */
+void mid_on_group_peer_exit(MidState *s, Tox *tox, uint32_t group_number, Tox_Group_Exit_Type exit_type);
+
+/*
+Call this when a peer changes their nickname.
+The middleware will update the unsigned local observation of their name.
+*/
+void mid_on_group_peer_name(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id);
+
+/******************************************************************************
+Moderation Hook
+******************************************************************************/
+
+/*
+Call this when a group moderation event is received.
+The middleware hides all kick-related roster logic internally:
+If we were the target of the kick, the middleware securely wipes the group
+state (keys and roster) and returns true. The client should then clear its
+own local group reference (group_number / group_connected).
+If another peer was kicked, the middleware deletes that peer from the
+roster and returns false.
+
+NOTE:
+The peer who INITIATES a kick does NOT receive the group_moderation event
+(see tox_group_mod_kick_peer / tox_callback_group_moderation in tox.h).
+Therefore the middleware cannot delete the kicked peer on the kicker's side
+from this hook. The kicker must explicitly call mid_delete_peer_by_identity()
+for the peer it kicked.
+
+Returns true if we ourselves were kicked.
+*/
+bool mid_on_group_moderation(MidState *s, Tox *tox, uint32_t group_number,
+                             uint32_t source_peer_id, uint32_t target_peer_id,
+                             Tox_Group_Mod_Event mod_type);
+
+/******************************************************************************
+Network Hook
+******************************************************************************/
+
+/*
+Call this when a group custom packet is received.
+The middleware will verify signatures, upsert records, and respond to
+roster requests automatically.
+*/
+void mid_on_group_custom_packet(MidState *s, Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data, size_t length);
+
+/******************************************************************************
+Main Loop Hook
+******************************************************************************/
+
+/*
+Call this in your main loop alongside tox_iterate().
+The middleware will handle periodic heartbeats and continuously sync
+the online state of all peers across all managed groups.
+*/
+void mid_iterate(MidState *s, Tox *tox);
+
+/******************************************************************************
+Queries
+******************************************************************************/
+
+size_t mid_group_count(MidState *s);
+size_t mid_peer_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+size_t mid_signed_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+size_t mid_online_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+size_t mid_offline_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+
+/*
+Find a peer by NGC identity public key in a specific group.
+Returns:
+>= 0   peer index in the middleware roster for that group
+-1     peer not found, or group not found
+*/
+int mid_find_peer(MidState *s,
+                  const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                  const uint8_t identity_key[TOX_GROUP_PEER_PUBLIC_KEY_SIZE]);
+
+/*
+Delete a peer from the middleware roster by identity key.
+This is needed for kick handling.
+The kicker does not receive a group_peer_exit event for the peer it kicked,
+so the client must explicitly delete the kicked peer.
+*/
+bool mid_delete_peer_by_identity(MidState *s,
+                                 const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                                 const uint8_t identity_key[TOX_GROUP_PEER_PUBLIC_KEY_SIZE]);
+
+/*
+Returns true if the middleware has a signed LEFT tombstone for this
+identity key in the given group.
+*/
+bool mid_peer_is_signed_left(MidState *s,
+                             const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                             const uint8_t identity_key[MID_IDENTITY_KEY_SIZE]);
+
+/*
+Call this IMMEDIATELY BEFORE calling tox_group_leave().
+This broadcasts a signed "LEFT" tombstone to the group.
+When other peers (including those who were offline and just synced)
+receive this signed record, they will permanently delete this peer
+from their persistent rosters.
+*/
+bool mid_announce_leave(MidState *s, Tox *tox, uint32_t group_number);
+
+
+bool mid_self_set_name(MidState *s, Tox *tox, uint32_t group_number, const uint8_t *nickname, size_t nickname_len);
+
+/******************************************************************************
+Peer List Query API (for C / JNI clients)
+Flat, fixed-size, index-based access. No dynamic allocation.
+Safe pattern:
+
+    size_t n = mid_peer_list_count(s, chat_id);
+    for (size_t i = 0; i < n; i++) {
+        MidPeerInfo info;
+        if (mid_peer_list_get(s, chat_id, i, &info)) {
+            // use info
+        }
+    }
+******************************************************************************/
+
+/*
+Flat representation of one peer in the roster.
+All fields are fixed-size. No pointers. NUL-terminated nickname.
+Suitable for direct mapping to JNI structs or flatbuffers.
+*/
+typedef struct {
+    uint8_t  identity_key[MID_IDENTITY_KEY_SIZE];   /*  NGC group identity key  */
+    uint8_t  signing_key[MID_SIGNING_KEY_SIZE];     /*  Ed25519 signing key    */
+    uint8_t  status;          /*  0 = ACTIVE, 1 = LEFT  */
+    uint8_t  connection_status; /* Tox_Connection: 0=NONE(offline), 1=TCP, 2=UDP */
+    uint8_t  role;            /* Tox_Group_Role: 0=FOUNDER, 1=MOD, 2=USER, 3=OBSERVER */
+    uint8_t  has_signature;   /*  1 if record is cryptographically signed  */
+    uint8_t  reserved;        /*  padding for alignment  */
+    uint64_t last_seen;       /*  unix timestamp, 0 if never seen  */
+    uint16_t nickname_len;    /*  length of nickname in bytes (without NUL)  */
+    /* CRUCIAL: +1 byte to safely hold the NUL terminator for JNI/C strings */
+    uint8_t nickname[MID_MAX_NICK_SIZE + 1];
+} MidPeerInfo;
+
+/*
+Return the number of peers in the middleware roster for a group.
+Returns 0 if the group is not found.
+*/
+size_t mid_peer_list_count(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE]);
+
+/*
+Fill `out` with the peer at `index` in the roster for the given group.
+Returns true on success.
+Returns false if s is NULL, out is NULL, group not found, or index >= count.
+The caller provides the MidPeerInfo storage. No memory is allocated.
+All fields are written; the struct is fully initialised on success.
+*/
+bool mid_peer_list_get(MidState *s,
+                       const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE],
+                       size_t index,
+                       MidPeerInfo *out);
+
+/******************************************************************************
+Peer List Changed Callback
+Register a callback to be notified whenever the peer roster for any group
+managed by this MidState has changed. The client should then call
+mid_peer_list_count() / mid_peer_list_get() to refresh its view.
+The callback receives the chat_id whose list changed, plus the
+user_data pointer.
+
+Thread-safety: the callback is invoked WITHOUT the middleware lock held.
+It is safe to call mid_peer_list_get() from within the callback.
+******************************************************************************/
+
+typedef void (*mid_peer_list_changed_cb)(const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], void *user_data);
+
+/*
+Register the peer-list-changed callback.
+Pass NULL for cb to unregister.
+*/
+void mid_set_peer_list_changed_cb(MidState *s,
+                                  mid_peer_list_changed_cb cb,
+                                  void *user_data);
+
+/******************************************************************************
+Network Stats
+******************************************************************************/
+
+/*
+Query the total bytes sent and received by the middleware custom packets.
+Pass NULL for either pointer if you only want to query one of them.
+Thread-safe.
+*/
+void mid_get_network_stats(MidState *s, uint64_t *sent_bytes, uint64_t *recv_bytes);
+
+/******************************************************************************
+Debug
+******************************************************************************/
+
+void mid_print_peer_table(MidState *s, const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], const char *title);
+
+#endif /* MID_ROSTER_H */

--- a/ngc_ppeerlist/tox_ngc_tcp_test.c
+++ b/ngc_ppeerlist/tox_ngc_tcp_test.c
@@ -1,0 +1,1728 @@
+/*
+
+tox_ngc_tcp_test.c
+
+Test client with hidden-state mid_roster middleware integration:
+3 Tox instances in one process
+UDP disabled, TCP-only
+Bootstrap to 3 external bootstrap nodes
+tox1 friends tox2 and tox3
+tox1 creates a private NGC group
+tox1 invites tox2 and tox3
+tox2/tox3 auto-accept the invite
+Middleware automatically announces presence, requests roster, and verifies signatures
+tox3 is simulated to disconnect, tox4 joins and receives the persistent roster
+tox3 reconnects and the group fully syncs
+
+Compile with:
+
+gcc -fsanitize=address -g -fno-omit-frame-pointer tox_ngc_tcp_test.c mid_roster.c -I. ../amalgamation/libtoxcore.a -lsodium -lopus -lx265 -lx264 -lavcodec -lvpx -lavutil
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdarg.h>
+#include <signal.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "../toxcore/tox.h"
+#include "mid_roster.h"
+
+#define NUM_CLIENTS 3
+#define BOOTSTRAP_NODE_COUNT 3
+
+static volatile sig_atomic_t running = 1;
+
+typedef struct {
+    const char *host;
+    uint16_t    port;
+    const char *public_key_hex;
+} Bootstrap_Node;
+
+static const Bootstrap_Node BOOTSTRAP_NODES[BOOTSTRAP_NODE_COUNT] = {
+    {
+        .host = "tox.novg.net",
+        .port = 33445,
+        .public_key_hex = "D527E5847F8330D628DAB1814F0A422F6DC9D0A300E6C357634EE2DA88C35463"
+    },
+    {
+        .host = "tox.initramfs.io",
+        .port = 33445,
+        .public_key_hex = "3F0A45A268367C1BEA652F258C85F4A66DA76BCAA667A49E770BCC4917AB6A25"
+    },
+    {
+        .host = "tox.kurnevsky.net",
+        .port = 33445,
+        .public_key_hex = "82EF82BA33445A1F91A7DB27189ECFC0C013E8E8A64D829A508B21C0250B0139"
+    },
+};
+
+typedef struct {
+    int          index;
+    const char  *name;
+    Tox         *tox;
+    MidState    *mid;  /* Opaque middleware state. Handles all groups internally. */
+
+    uint8_t      address[TOX_ADDRESS_SIZE];
+    bool         network_connected;
+    time_t       last_bootstrap;
+
+    uint32_t     group_number;
+    bool         group_connected;
+
+    uint32_t     friend_num[NUM_CLIENTS];
+    bool         friend_online[NUM_CLIENTS];
+    bool         invited[NUM_CLIENTS];
+} Client;
+
+static Client clients[NUM_CLIENTS];
+
+/* --- PHASE 2+ INTEGRATION --- */
+static int test_phase = 1;
+static bool tox3_exited_group = false;
+static Client tox4_client;
+static bool tox4_initialized = false;
+/* ---------------------------- */
+
+/* --- PHASE 7 INTEGRATION --- */
+#define PHASE7_TOMBSTONE_FLUSH_SEC 5
+#define PHASE7_SYNC_WAIT_SEC       10
+#define PHASE7_TIMEOUT_SEC         180
+
+static int      phase7_step = 0;
+static time_t   phase7_step_time = 0;
+static time_t   phase7_sync_since = 0;
+
+static bool     tox2_identity_known = false;
+static uint8_t  tox2_identity[TOX_GROUP_PEER_PUBLIC_KEY_SIZE];
+static uint32_t tox2_old_group_number = UINT32_MAX;
+static bool     tox2_tombstone_sent = false;
+static bool     tox2_group_left = false;
+/* ---------------------------- */
+
+/* --- PHASE 8 INTEGRATION --- */
+static uint8_t tox4_identity[TOX_GROUP_PEER_PUBLIC_KEY_SIZE];
+static bool tox4_identity_known = false;
+static bool tox4_kicked = false;
+static bool tox4_cleanup_done = false;
+static int phase8_step = 0;
+static time_t phase8_step_time = 0;
+static time_t phase8_sync_since = 0;
+static time_t phase8_last_kick_attempt = 0;
+/* ---------------------------- */
+
+/* --- PHASE 9 INTEGRATION --- */
+/*
+ * A string containing deliberately broken UTF-8 and invalid bytes.
+ * \xC0\xAF is an overlong encoding.
+ * \xFE\xFF are never valid in UTF-8.
+ * \x80\x81 are unexpected continuation bytes.
+ * This tests that the middleware treats nicknames as opaque binary
+ * and does not crash or corrupt memory when handling them.
+ */
+static const char tox5_broken_name[] = "tox5_\xC0\xAF\xFE\xFF\x80\x81";
+static Client tox5_client;
+static bool tox5_initialized = false;
+/* ---------------------------- */
+
+/******************************************************************************
+Logging helpers
+******************************************************************************/
+
+static void log_client(const Client *client, const char *fmt, ...)
+{
+    char timebuf[64];
+    time_t now = time(NULL);
+    struct tm *tm_buf = localtime(&now);
+    strftime(timebuf, sizeof(timebuf), "%H:%M:%S", tm_buf);
+
+    printf("[%s][%s] ", timebuf, client ? client->name : "?");
+
+    va_list args;
+    va_start(args, fmt);
+    vprintf(fmt, args);
+    va_end(args);
+
+    printf("\n");
+    fflush(stdout);
+}
+
+static void log_raw(const char *fmt, ...)
+{
+    char timebuf[64];
+    time_t now = time(NULL);
+    struct tm *tm_buf = localtime(&now);
+    strftime(timebuf, sizeof(timebuf), "%H:%M:%S", tm_buf);
+
+    printf("[%s][main] ", timebuf);
+
+    va_list args;
+    va_start(args, fmt);
+    vprintf(fmt, args);
+    va_end(args);
+
+    printf("\n");
+    fflush(stdout);
+}
+
+/******************************************************************************
+Hex key parsing & Bootstrap
+******************************************************************************/
+
+static int hex_digit_value(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+    return -1;
+}
+
+static bool parse_hex_public_key(const char *hex, uint8_t *public_key)
+{
+    if (hex == NULL || public_key == NULL) return false;
+
+    size_t len = strlen(hex);
+    if (len != TOX_PUBLIC_KEY_SIZE * 2) return false;
+
+    for (size_t i = 0; i < TOX_PUBLIC_KEY_SIZE; i++) {
+        int high = hex_digit_value(hex[i * 2]);
+        int low  = hex_digit_value(hex[i * 2 + 1]);
+
+        if (high < 0 || low < 0) return false;
+
+        public_key[i] = (uint8_t)((high << 4) | low);
+    }
+
+    return true;
+}
+
+static void bootstrap_client_to_network(Client *client)
+{
+    client->last_bootstrap = time(NULL);
+
+    log_client(client, "Bootstrapping to %d external bootstrap nodes", BOOTSTRAP_NODE_COUNT);
+
+    for (size_t i = 0; i < BOOTSTRAP_NODE_COUNT; i++) {
+        const Bootstrap_Node *node = &BOOTSTRAP_NODES[i];
+
+        uint8_t public_key[TOX_PUBLIC_KEY_SIZE];
+        if (!parse_hex_public_key(node->public_key_hex, public_key)) continue;
+
+        Tox_Err_Bootstrap tcp_err;
+        tox_add_tcp_relay(client->tox, node->host, node->port, public_key, &tcp_err);
+
+        Tox_Err_Bootstrap boot_err;
+        tox_bootstrap(client->tox, node->host, node->port, public_key, &boot_err);
+    }
+}
+
+/******************************************************************************
+Helper lookups
+******************************************************************************/
+
+static bool get_client_chat_id(Client *client, uint8_t *chat_id)
+{
+    if (client == NULL || client->tox == NULL || client->group_number == UINT32_MAX || chat_id == NULL) return false;
+    Tox_Err_Group_State_Queries err;
+    bool ok = tox_group_get_chat_id(client->tox, client->group_number, chat_id, &err);
+    return ok && err == TOX_ERR_GROUP_STATE_QUERIES_OK;
+}
+
+static bool has_tombstone(Client *c, const uint8_t *id) {
+    if (c->group_number == UINT32_MAX) return false;
+    uint8_t cid[TOX_GROUP_CHAT_ID_SIZE];
+    if (!get_client_chat_id(c, cid)) return false;
+    return mid_peer_is_signed_left(c->mid, cid, id);
+}
+
+static bool peer_absent(Client *c, const uint8_t *id) {
+    if (c->group_number == UINT32_MAX) return true;
+    uint8_t cid[TOX_GROUP_CHAT_ID_SIZE];
+    if (!get_client_chat_id(c, cid)) return false;
+    return mid_find_peer(c->mid, cid, id) == -1;
+}
+
+static int find_client_index_by_public_key(const uint8_t *public_key)
+{
+    for (int i = 0; i < NUM_CLIENTS; i++) {
+        if (memcmp(clients[i].address, public_key, TOX_PUBLIC_KEY_SIZE) == 0) return i;
+    }
+
+    if (tox4_initialized && memcmp(tox4_client.address, public_key, TOX_PUBLIC_KEY_SIZE) == 0) {
+        return 3;
+    }
+
+    if (tox5_initialized && memcmp(tox5_client.address, public_key, TOX_PUBLIC_KEY_SIZE) == 0) {
+        return 4;
+    }
+
+    return -1;
+}
+
+static int find_friend_index(const Client *client, uint32_t friend_number)
+{
+    for (int i = 0; i < NUM_CLIENTS; i++) {
+        if (client->friend_num[i] == friend_number) return i;
+    }
+
+    return -1;
+}
+
+static bool client_is_group_connected(Client *client)
+{
+    if (client->tox == NULL || client->group_number == UINT32_MAX) return false;
+
+    Tox_Err_Group_Is_Connected err;
+    int32_t status = tox_group_is_connected(client->tox, client->group_number, &err);
+
+    if (err != TOX_ERR_GROUP_IS_CONNECTED_OK) return false;
+
+    client->group_connected = (status == 1);
+    return client->group_connected;
+}
+
+/******************************************************************************
+Peer table printing using the public mid_peer_list API
+
+This replaces mid_print_peer_table() with a client-side implementation
+that uses only mid_peer_list_count() and mid_peer_list_get().
+This demonstrates how a real client or JNI wrapper would render the list.
+******************************************************************************/
+
+static void print_peer_table(const MidState *mid, const uint8_t *chat_id, const char *title)
+{
+    time_t now = time(NULL);
+    size_t count = mid_peer_list_count((MidState *)mid, chat_id);
+
+    uint64_t sent = 0;
+    uint64_t recv_bytes = 0;
+    mid_get_network_stats((MidState *)mid, &sent, &recv_bytes);
+
+    char chat_id_hex[9];
+    for(int i=0; i<4; i++) snprintf(chat_id_hex + i*2, 3, "%02X", chat_id[i]);
+    chat_id_hex[8] = '\0';
+
+    printf("\n");
+    printf("==========================================================================================\n");
+    printf("PEER TABLE: %s (ChatID %s...)\n", title != NULL ? title : "unknown", chat_id_hex);
+    printf("peers=%zu sent=%llu recv=%llu\n", count, (unsigned long long)sent, (unsigned long long)recv_bytes);
+    printf("+----+--------------+--------------+--------------+--------+------+--------+----------+-------+----------+\n");
+    printf("| %2s | %-12s | %-12s | %-12s | %-6s | %-4s | %-6s | %-8s | %-8s | %-8s |\n",
+           "#", "Nickname", "Identity", "Signing", "Status", "Sig", "Conn", "Role", "Last seen", "NickLen");
+    printf("+----+--------------+--------------+--------------+--------+------+--------+----------+-------+----------+\n");
+
+    for (size_t i = 0; i < count; i++) {
+        MidPeerInfo info;
+
+        if (!mid_peer_list_get((MidState *)mid, chat_id, i, &info)) {
+            printf("| %2zu | (failed to read peer)                                                                        |\n", i);
+            continue;
+        }
+
+        /*
+         * Format identity key (first 6 bytes as hex).
+         */
+        char identity_buf[13];
+        char signing_buf[13];
+        identity_buf[0] = '\0';
+        signing_buf[0] = '\0';
+
+        for (int j = 0; j < 6; j++) {
+            snprintf(identity_buf + (j * 2), 3, "%02X", info.identity_key[j]);
+            snprintf(signing_buf + (j * 2), 3, "%02X", info.signing_key[j]);
+        }
+        identity_buf[12] = '\0';
+        signing_buf[12] = '\0';
+
+        const char *conn_str = "NONE";
+        if (info.connection_status == TOX_CONNECTION_TCP) conn_str = "TCP";
+        else if (info.connection_status == TOX_CONNECTION_UDP) conn_str = "UDP";
+
+        const char *role_str = "USER";
+        if (info.role == TOX_GROUP_ROLE_FOUNDER) role_str = "FOUNDER";
+        else if (info.role == TOX_GROUP_ROLE_MODERATOR) role_str = "MOD";
+        else if (info.role == TOX_GROUP_ROLE_OBSERVER) role_str = "OBS";
+
+        /*
+         * Format last seen.
+         */
+        char seen_buf[16];
+        if (info.connection_status != TOX_CONNECTION_NONE) {
+            snprintf(seen_buf, sizeof(seen_buf), "now");
+        } else if (info.last_seen == 0) {
+            snprintf(seen_buf, sizeof(seen_buf), "-");
+        } else if (info.last_seen > (uint64_t)now) {
+            snprintf(seen_buf, sizeof(seen_buf), "future");
+        } else {
+            unsigned long age = (unsigned long)(now - (time_t)info.last_seen);
+            snprintf(seen_buf, sizeof(seen_buf), "%lus", age);
+        }
+
+        /*
+         * Format status.
+         */
+        const char *status_str = "?";
+        if (info.status == 0) status_str = "ACTIVE";
+        else if (info.status == 1) status_str = "LEFT";
+
+        /*
+         * Sanitize nickname for display (printable ASCII only).
+         */
+        char nick_buf[13];
+        size_t display_len = info.nickname_len;
+        if (display_len > 12) display_len = 12;
+        for (size_t j = 0; j < display_len; j++) {
+            uint8_t c = (uint8_t)info.nickname[j];
+            nick_buf[j] = (c >= 0x20 && c <= 0x7E) ? (char)c : '.';
+        }
+        nick_buf[display_len] = '\0';
+
+        printf("| %2zu | %-12s | %-12s | %-12s | %-6s | %-4s | %-6s | %-8s | %-8s | %-8u |\n",
+               i,
+               nick_buf,
+               identity_buf,
+               signing_buf,
+               status_str,
+               info.has_signature ? "yes" : "no",
+               conn_str,
+               role_str,
+               seen_buf,
+               (unsigned)info.nickname_len);
+    }
+
+    printf("+----+--------------+--------------+--------------+--------+------+--------+----------+-------+----------+\n");
+    printf("\n");
+
+    fflush(stdout);
+}
+
+static void print_client_peer_table(Client *c, const char *title) {
+    if (c->group_number == UINT32_MAX) return;
+    uint8_t cid[TOX_GROUP_CHAT_ID_SIZE];
+    if (get_client_chat_id(c, cid)) {
+        print_peer_table(c->mid, cid, title);
+    }
+}
+
+/******************************************************************************
+Group leave / delete helper
+
+Wraps tox_group_leave() + mid_on_group_delete() + local state reset so
+every leave/delete path goes through one place. This ensures the
+middleware state is always cleaned up when we leave or delete a group.
+******************************************************************************/
+
+static void client_leave_group(Client *client)
+{
+    if (client == NULL || client->group_number == UINT32_MAX) {
+        return;
+    }
+
+    uint32_t gn = client->group_number;
+
+    log_client(client, "Leaving group %u", gn);
+
+    Tox_Err_Group_Leave lerr;
+    tox_group_leave(client->tox, gn, NULL, 0, &lerr);
+
+    /*
+     * Always clean up middleware state regardless of whether
+     * tox_group_leave succeeded. The group may already be gone
+     * from Toxcore's perspective (e.g. after a kick).
+     */
+    mid_on_group_delete(client->mid, client->tox, gn);
+
+    client->group_number = UINT32_MAX;
+    client->group_connected = false;
+
+    log_client(client, "Group %u left and middleware state removed", gn);
+}
+
+/******************************************************************************
+Peer-list-changed callback (demonstrates the new mid API)
+
+This is called by the middleware whenever the roster for a group changes.
+In a real client you would call mid_peer_list_count() and mid_peer_list_get()
+here to refresh your UI list.
+******************************************************************************/
+
+static void peer_list_changed_cb(const uint8_t *chat_id, void *user_data)
+{
+    Client *client = user_data;
+    if (client == NULL) return;
+
+    size_t count = mid_peer_list_count(client->mid, chat_id);
+
+    char chat_id_hex[9];
+    for(int i=0; i<4; i++) snprintf(chat_id_hex + i*2, 3, "%02X", chat_id[i]);
+    chat_id_hex[8] = '\0';
+
+    log_client(client,
+               "Peer list changed for chat_id %s... (%zu peers in middleware roster)",
+               chat_id_hex,
+               count);
+
+    /*
+     * Example: iterate the full peer list using the flat getter API.
+     * This is the same pattern a JNI wrapper would use.
+     */
+    for (size_t i = 0; i < count; i++) {
+        MidPeerInfo info;
+        if (mid_peer_list_get(client->mid, chat_id, i, &info)) {
+            /*
+             * In a real client, you would push each MidPeerInfo into
+             * your UI model here. For this test we just log a summary.
+             */
+            log_client(client,
+                       "  peer[%zu]: status=%u conn=%u signed=%u nick_len=%u",
+                       i,
+                       info.status,
+                       info.connection_status,
+                       info.has_signature,
+                       info.nickname_len);
+        }
+    }
+}
+
+/******************************************************************************
+Group invite logic for tox1
+******************************************************************************/
+
+static void invite_if_ready(Client *client, int friend_index)
+{
+    if (client->index != 0) return;
+    if (friend_index <= 0 || friend_index >= NUM_CLIENTS) return;
+    if (client->group_number == UINT32_MAX) return;
+    if (!client->friend_online[friend_index]) return;
+    if (client->friend_num[friend_index] == UINT32_MAX) return;
+    if (client->invited[friend_index]) return;
+    if (!client_is_group_connected(client)) return;
+
+    Tox_Err_Group_Invite_Friend invite_err;
+    bool ok = tox_group_invite_friend(client->tox, client->group_number, client->friend_num[friend_index], &invite_err);
+
+    if (ok && invite_err == TOX_ERR_GROUP_INVITE_FRIEND_OK) {
+        client->invited[friend_index] = true;
+        log_client(client, "Invited %s to NGC group %u", clients[friend_index].name, client->group_number);
+    }
+}
+
+/******************************************************************************
+Tox callbacks (Using the simplified middleware API)
+******************************************************************************/
+
+static void self_connection_status_cb(Tox *tox, Tox_Connection connection_status, void *user_data)
+{
+    Client *client = user_data;
+
+    bool connected = (connection_status != TOX_CONNECTION_NONE);
+
+    if (client->network_connected != connected) {
+        log_client(client, "Tox network connection status: %s",
+                   connected ? (connection_status == TOX_CONNECTION_TCP ? "TCP" : "UDP") : "NONE");
+    }
+
+    client->network_connected = connected;
+}
+
+static void friend_request_cb(Tox *tox, const uint8_t *public_key, const uint8_t *message, size_t length, void *user_data)
+{
+    Client *client = user_data;
+
+    int from_index = find_client_index_by_public_key(public_key);
+    const char *from_name = (from_index >= 0) ? (from_index == 3 ? "tox4" : (from_index == 4 ? "tox5" : clients[from_index].name)) : "unknown";
+
+    Tox_Err_Friend_Add err;
+    uint32_t friend_number = tox_friend_add_norequest(tox, public_key, &err);
+
+    if (err == TOX_ERR_FRIEND_ADD_OK && friend_number != UINT32_MAX) {
+        if (from_index >= 0 && from_index < NUM_CLIENTS) {
+            client->friend_num[from_index] = friend_number;
+        }
+
+        log_client(client, "Accepted friend request from %s as friend number %u", from_name, friend_number);
+    }
+}
+
+static void friend_connection_status_cb(Tox *tox, uint32_t friend_number, Tox_Connection connection_status, void *user_data)
+{
+    Client *client = user_data;
+
+    int friend_index = find_friend_index(client, friend_number);
+    if (friend_index < 0) return;
+
+    bool online = (connection_status != TOX_CONNECTION_NONE);
+
+    if (client->friend_online[friend_index] != online) {
+        log_client(client, "Friend %s is now %s", clients[friend_index].name, online ? "ONLINE" : "OFFLINE");
+    }
+
+    client->friend_online[friend_index] = online;
+
+    if (client->index == 0) invite_if_ready(client, friend_index);
+}
+
+static void group_invite_cb(Tox *tox, uint32_t friend_number, const uint8_t *invite_data, size_t invite_data_length, const uint8_t *group_name, size_t group_name_length, void *user_data)
+{
+    Client *client = user_data;
+
+    int inviter_index = find_friend_index(client, friend_number);
+    const char *inviter_name = (inviter_index >= 0) ? clients[inviter_index].name : "unknown";
+
+    Tox_Err_Group_Invite_Accept err;
+    uint32_t group_number = tox_group_invite_accept(tox, friend_number, invite_data, invite_data_length, (const uint8_t *)client->name, strlen(client->name), NULL, 0, &err);
+
+    if (err == TOX_ERR_GROUP_INVITE_ACCEPT_OK && group_number != UINT32_MAX) {
+        client->group_number = group_number;
+        client->group_connected = false;
+
+        log_client(client, "Accepted group invite from %s, local group number: %u", inviter_name, group_number);
+    }
+}
+
+static void group_moderation_cb(Tox *tox,
+                                uint32_t group_number,
+                                uint32_t source_peer_id,
+                                uint32_t target_peer_id,
+                                Tox_Group_Mod_Event mod_type,
+                                void *user_data)
+{
+    Client *client = user_data;
+
+    if (client == NULL) {
+        return;
+    }
+
+    if (client->group_number != group_number) {
+        return;
+    }
+
+    log_client(client,
+               "Group moderation event: type=%d source_peer=%u target_peer=%u",
+               (int)mod_type,
+               source_peer_id,
+               target_peer_id);
+
+    /* --- MIDDLEWARE INTEGRATION --- */
+    bool we_were_kicked = mid_on_group_moderation(client->mid,
+                                                  tox,
+                                                  group_number,
+                                                  source_peer_id,
+                                                  target_peer_id,
+                                                  mod_type);
+    /* ------------------------------ */
+
+    if (we_were_kicked) {
+        log_client(client,
+                   "I was kicked from group %u; clearing local group reference",
+                   group_number);
+        client->group_number = UINT32_MAX;
+        client->group_connected = false;
+    }
+}
+
+static void group_self_join_cb(Tox *tox, uint32_t group_number, void *user_data)
+{
+    Client *client = user_data;
+
+    if (client->group_number == UINT32_MAX) client->group_number = group_number;
+
+    client->group_connected = true;
+
+    log_client(client, "Self joined NGC group %u (Callback fired!)", group_number);
+
+    /* --- MIDDLEWARE INTEGRATION --- */
+    mid_on_group_self_join(client->mid, tox, group_number, (const uint8_t *)client->name, strlen(client->name));
+    /* ------------------------------ */
+
+    if (client->index == 0) {
+        for (int i = 1; i < NUM_CLIENTS; i++) invite_if_ready(client, i);
+    }
+}
+
+static void group_peer_join_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, void *user_data)
+{
+    Client *client = user_data;
+
+    log_client(client, "Peer %u joined NGC group %u", peer_id, group_number);
+
+    /* --- MIDDLEWARE INTEGRATION --- */
+    mid_on_group_peer_join(client->mid, tox, group_number, peer_id);
+    /* ------------------------------ */
+}
+
+static void group_peer_exit_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Group_Exit_Type exit_type, const uint8_t *name, size_t name_length, const uint8_t *part_message, size_t part_message_length, void *user_data)
+{
+    Client *client = user_data;
+
+    log_client(client, "Peer %u exited NGC group %u (reason: %d)", peer_id, group_number, (int)exit_type);
+
+    /* --- MIDDLEWARE INTEGRATION --- */
+    mid_on_group_peer_exit(client->mid, tox, group_number, exit_type);
+    /* ------------------------------ */
+
+    /* --- PHASE 2 INTEGRATION --- */
+    if (test_phase >= 2 && !tox3_exited_group) {
+        tox3_exited_group = true;
+        log_raw("Phase 2: Detected peer exit, assuming tox3 is offline.");
+    }
+    /* --------------------------- */
+}
+
+static void group_custom_packet_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *data, size_t length, void *user_data)
+{
+    Client *client = user_data;
+
+    log_client(client, "Received group custom packet: %zu bytes from peer %u", length, peer_id);
+
+    /* --- MIDDLEWARE INTEGRATION --- */
+    mid_on_group_custom_packet(client->mid, tox, group_number, peer_id, data, length);
+    /* ------------------------------ */
+}
+
+static void group_peer_name_cb(Tox *tox, uint32_t group_number, uint32_t peer_id, const uint8_t *name, size_t length, void *user_data)
+{
+    Client *client = user_data;
+
+    log_client(client, "Peer %u changed name to: '%.*s'", peer_id, (int)length, (const char *)name);
+
+    /* --- MIDDLEWARE INTEGRATION --- */
+    mid_on_group_peer_name(client->mid, tox, group_number, peer_id);
+    /* ------------------------------ */
+}
+
+static void group_connection_status_cb(Tox *tox, uint32_t group_number, int32_t status, void *user_data)
+{
+    Client *client = user_data;
+
+    if (client->group_number == UINT32_MAX) {
+        client->group_number = group_number;
+    }
+
+    if (status == 3) {
+        client->group_connected = true;
+        log_client(client, "Group %u is now connected (raw status=%d)", group_number, (int)status);
+
+        if (client->index == 0) {
+            for (int i = 1; i < NUM_CLIENTS; i++) {
+                invite_if_ready(client, i);
+            }
+        }
+    } else if (status == 2) {
+        client->group_connected = false;
+        log_client(client, "Group %u is connecting (raw status=%d)", group_number, (int)status);
+    } else {
+        client->group_connected = false;
+        log_client(client, "Group %u is disconnected (raw status=%d)", group_number, (int)status);
+    }
+}
+
+static void group_join_fail_cb(Tox *tox, uint32_t group_number, Tox_Group_Join_Fail fail_type, void *user_data)
+{
+    Client *client = user_data;
+
+    log_client(client, "Join failed for group %u, reason: %d", group_number, (int)fail_type);
+}
+
+/******************************************************************************
+Tox instance creation
+******************************************************************************/
+
+static void create_tox_instance(Client *client)
+{
+    Tox_Err_Options_New options_err;
+    struct Tox_Options *options = tox_options_new(&options_err);
+
+    if (options_err != TOX_ERR_OPTIONS_NEW_OK || options == NULL) exit(1);
+
+    tox_options_set_ipv6_enabled(options, false);
+    tox_options_set_udp_enabled(options, false);
+    tox_options_set_local_discovery_enabled(options, false);
+    tox_options_set_dht_announcements_enabled(options, false);
+    tox_options_set_hole_punching_enabled(options, false);
+
+    tox_options_set_start_port(options, 0);
+    tox_options_set_end_port(options, 0);
+    tox_options_set_tcp_port(options, 0);
+
+    Tox_Err_New new_err;
+    client->tox = tox_new(options, &new_err);
+
+    tox_options_free(options);
+
+    if (client->tox == NULL) exit(1);
+
+    tox_self_get_address(client->tox, client->address);
+
+    /* Initialize the opaque middleware state for this client */
+    client->mid = mid_new("mid.save", NULL, 0);
+
+    /* Register the peer-list-changed callback for this client */
+    mid_set_peer_list_changed_cb(client->mid, peer_list_changed_cb, client);
+}
+
+static void register_callbacks(Tox *tox)
+{
+    tox_callback_self_connection_status(tox, self_connection_status_cb);
+    tox_callback_friend_request(tox, friend_request_cb);
+    tox_callback_friend_connection_status(tox, friend_connection_status_cb);
+
+    tox_callback_group_invite(tox, group_invite_cb);
+    tox_callback_group_self_join(tox, group_self_join_cb);
+    tox_callback_group_peer_join(tox, group_peer_join_cb);
+    tox_callback_group_peer_exit(tox, group_peer_exit_cb);
+    tox_callback_group_connection_status(tox, group_connection_status_cb);
+    tox_callback_group_join_fail(tox, group_join_fail_cb);
+    tox_callback_group_peer_name(tox, group_peer_name_cb);
+    tox_callback_group_custom_packet(tox, group_custom_packet_cb);
+    tox_callback_group_moderation(tox, group_moderation_cb);
+}
+
+/* Convert a hex string to raw bytes */
+static int hex_to_bytes(const char *hex, uint8_t *bytes, size_t byte_len)
+{
+    for (size_t i = 0; i < byte_len; i++) {
+        unsigned int val;
+        if (sscanf(hex + (i * 2), "%2x", &val) != 1) {
+            return -1;
+        }
+        bytes[i] = (uint8_t)val;
+    }
+    return 0;
+}
+
+/******************************************************************************
+Main
+******************************************************************************/
+
+static void signal_handler(int signum) { running = 0; }
+
+int main(void)
+{
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+
+    memset(clients, 0, sizeof(clients));
+    memset(&tox4_client, 0, sizeof(tox4_client));
+    memset(&tox5_client, 0, sizeof(tox5_client));
+
+    clients[0].index = 0; clients[0].name = "tox1";
+    clients[1].index = 1; clients[1].name = "tox2";
+    clients[2].index = 2; clients[2].name = "tox3";
+
+    for (int i = 0; i < NUM_CLIENTS; i++) {
+        clients[i].group_number = UINT32_MAX;
+        clients[i].network_connected = false;
+        clients[i].last_bootstrap = 0;
+
+        for (int j = 0; j < NUM_CLIENTS; j++) {
+            clients[i].friend_num[j] = UINT32_MAX;
+            clients[i].friend_online[j] = false;
+            clients[i].invited[j] = false;
+        }
+    }
+
+    log_raw("Creating %d Tox instances in TCP-only mode", NUM_CLIENTS);
+
+    for (int i = 0; i < NUM_CLIENTS; i++) {
+        create_tox_instance(&clients[i]);
+        register_callbacks(clients[i].tox);
+    }
+
+    log_raw("Bootstrapping all Tox instances to external bootstrap nodes");
+
+    for (int i = 0; i < NUM_CLIENTS; i++) {
+        bootstrap_client_to_network(&clients[i]);
+    }
+
+    log_raw("Waiting for all clients to connect to the Tox network...");
+
+    time_t wait_start = time(NULL);
+    bool all_net_connected = false;
+
+    while (!all_net_connected && (time(NULL) - wait_start < 120)) {
+        all_net_connected = true;
+
+        for (int i = 0; i < NUM_CLIENTS; i++) {
+            tox_iterate(clients[i].tox, &clients[i]);
+
+            if (!clients[i].network_connected) {
+                all_net_connected = false;
+            }
+        }
+
+        for (int i = 0; i < NUM_CLIENTS; i++) {
+            if (!clients[i].network_connected) {
+                time_t now = time(NULL);
+                if (clients[i].last_bootstrap == 0 || now - clients[i].last_bootstrap >= 10) {
+                    bootstrap_client_to_network(&clients[i]);
+                }
+            }
+        }
+
+        if (!all_net_connected) {
+            usleep(50000);
+        }
+    }
+
+    if (!all_net_connected) {
+        log_raw("Failed to connect all clients to the network within timeout. Exiting.");
+        goto cleanup;
+    }
+
+    log_raw("All clients connected to the network. Proceeding with friend requests.");
+
+    Tox_Err_Friend_Add friend_err;
+
+    uint32_t friend2 = tox_friend_add(clients[0].tox, clients[1].address, (const uint8_t *)"hello", 5, &friend_err);
+    if (friend_err == TOX_ERR_FRIEND_ADD_OK) {
+        clients[0].friend_num[1] = friend2;
+        log_client(&clients[0], "Sent friend request to tox2 (friend num %u)", friend2);
+    }
+
+    uint32_t friend3 = tox_friend_add(clients[0].tox, clients[2].address, (const uint8_t *)"hello", 5, &friend_err);
+    if (friend_err == TOX_ERR_FRIEND_ADD_OK) {
+        clients[0].friend_num[2] = friend3;
+        log_client(&clients[0], "Sent friend request to tox3 (friend num %u)", friend3);
+    }
+
+#if 0
+#define GROUP_CHAT_ID "154b3973bd0e66304fd6179a8a54759073649e09e6e368f0334fc6ed666ab762"
+    uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE];
+    if (hex_to_bytes(GROUP_CHAT_ID, chat_id, TOX_GROUP_CHAT_ID_SIZE) != 0) {
+        fprintf(stderr, "[ERROR] Invalid group chat ID hex\n");
+        return -1;
+    }
+
+    const char *nick = "tox1 ______ u";
+
+    Tox_Err_Group_Join err;
+    uint32_t group_number = tox_group_join(clients[0].tox, chat_id,
+                                           (const uint8_t *)nick, strlen(nick),
+                                           NULL, 0,   /* no password */
+                                           &err);
+
+    if (err == TOX_ERR_GROUP_JOIN_OK) {
+#else
+    const char *group_name = "TCP-NGC-Test";
+
+    Tox_Err_Group_New group_err;
+    uint32_t group_number = tox_group_new(clients[0].tox, TOX_GROUP_PRIVACY_STATE_PRIVATE, (const uint8_t *)group_name, strlen(group_name), (const uint8_t *)clients[0].name, strlen(clients[0].name), &group_err);
+
+    if (group_err == TOX_ERR_GROUP_NEW_OK) {
+#endif
+        clients[0].group_number = group_number;
+        clients[0].group_connected = true;
+
+        /*
+         * For the group founder, group_self_join_cb may not fire.
+         * So we manually trigger the middleware self-join hook.
+         */
+        mid_on_group_self_join(clients[0].mid, clients[0].tox, group_number, (const uint8_t *)clients[0].name, strlen(clients[0].name));
+    }
+
+    time_t start_time = time(NULL);
+    time_t all_connected_since = 0;
+    time_t last_peer_table_print = 0;
+    time_t phase_start_time = 0;
+
+    while (running) {
+        uint32_t min_interval = 50;
+
+        for (int i = 0; i < NUM_CLIENTS; i++) {
+            uint32_t interval = tox_iteration_interval(clients[i].tox);
+            if (interval < min_interval) min_interval = interval;
+        }
+
+        if (min_interval == 0) min_interval = 1;
+        if (min_interval > 100) min_interval = 100;
+
+        usleep((useconds_t)min_interval * 1000);
+
+        for (int i = 0; i < NUM_CLIENTS; i++) {
+            /* --- PHASE 2+ INTEGRATION --- */
+            if (test_phase >= 2 && test_phase < 6 && i == 2) {
+                continue; /* Stop iterating tox3 to simulate disconnect */
+            }
+            /* ---------------------------- */
+
+            tox_iterate(clients[i].tox, &clients[i]);
+
+            /* --- MIDDLEWARE INTEGRATION --- */
+            mid_iterate(clients[i].mid, clients[i].tox);
+            /* ------------------------------ */
+        }
+
+        /* --- PHASE 3+ INTEGRATION --- */
+        if (test_phase >= 3 && tox4_initialized) {
+            tox_iterate(tox4_client.tox, &tox4_client);
+            mid_iterate(tox4_client.mid, tox4_client.tox);
+
+            if (!tox4_client.network_connected) {
+                time_t now = time(NULL);
+                if (tox4_client.last_bootstrap == 0 || now - tox4_client.last_bootstrap >= 10) {
+                    bootstrap_client_to_network(&tox4_client);
+                }
+            }
+        }
+        /* ---------------------------- */
+
+        /* --- PHASE 9+ INTEGRATION --- */
+        if (test_phase >= 9 && tox5_initialized) {
+            tox_iterate(tox5_client.tox, &tox5_client);
+            mid_iterate(tox5_client.mid, tox5_client.tox);
+
+            if (!tox5_client.network_connected) {
+                time_t now = time(NULL);
+                if (tox5_client.last_bootstrap == 0 || now - tox5_client.last_bootstrap >= 10) {
+                    bootstrap_client_to_network(&tox5_client);
+                }
+            }
+        }
+        /* ---------------------------- */
+
+        time_t table_now = time(NULL);
+
+        if (table_now - last_peer_table_print >= 10) {
+            for (int i = 0; i < NUM_CLIENTS; i++) {
+                print_client_peer_table(&clients[i], clients[i].name);
+            }
+            print_client_peer_table(&tox4_client, tox4_client.name);
+            print_client_peer_table(&tox5_client, tox5_client.name);
+            last_peer_table_print = table_now;
+        }
+
+        for (int i = 0; i < NUM_CLIENTS; i++) {
+            if (test_phase >= 2 && i == 2) continue;
+
+            if (!clients[i].network_connected) {
+                time_t now = time(NULL);
+                if (clients[i].last_bootstrap == 0 || now - clients[i].last_bootstrap >= 30) {
+                    bootstrap_client_to_network(&clients[i]);
+                }
+            }
+        }
+
+        /* --- PHASE STATE MACHINE --- */
+
+        if (test_phase == 1) {
+            bool synced = true;
+
+            for (int i = 0; i < NUM_CLIENTS; i++) {
+                uint8_t cid[TOX_GROUP_CHAT_ID_SIZE];
+                if (!get_client_chat_id(&clients[i], cid) ||
+                    mid_signed_count(clients[i].mid, cid) < NUM_CLIENTS) {
+                    synced = false;
+                    break;
+                }
+            }
+
+            if (synced) {
+                if (all_connected_since == 0) {
+                    all_connected_since = time(NULL);
+                    log_raw("Phase 1: All clients are connected to the NGC group and middleware is fully synced");
+                } else if (time(NULL) - all_connected_since >= 10) {
+                    log_raw("Phase 1: All clients stayed connected and synced for 10 seconds, success!");
+
+                    test_phase = 2;
+                    phase_start_time = time(NULL);
+
+                    log_raw("Phase 2: Stopping tox3 iteration to simulate disconnect.");
+
+                    all_connected_since = 0;
+                }
+            } else {
+                all_connected_since = 0;
+            }
+        }
+
+        if (test_phase == 2) {
+            if (tox3_exited_group) {
+                log_raw("Phase 2: tox3 is offline. Spawning tox4...");
+
+                test_phase = 3;
+                phase_start_time = time(NULL);
+            } else if (time(NULL) - phase_start_time >= 120) {
+                log_raw("Phase 2: Timeout waiting for tox3 to exit. Forcing Phase 3.");
+
+                test_phase = 3;
+                phase_start_time = time(NULL);
+            }
+        }
+
+        if (test_phase == 3) {
+            if (!tox4_initialized) {
+                tox4_initialized = true;
+
+                tox4_client.index = 3;
+                tox4_client.name = "tox4";
+                tox4_client.group_number = UINT32_MAX;
+                tox4_client.network_connected = false;
+                tox4_client.last_bootstrap = 0;
+                tox4_client.group_connected = false;
+
+                for (int j = 0; j < NUM_CLIENTS; j++) {
+                    tox4_client.friend_num[j] = UINT32_MAX;
+                    tox4_client.friend_online[j] = false;
+                    tox4_client.invited[j] = false;
+                }
+
+                create_tox_instance(&tox4_client);
+                register_callbacks(tox4_client.tox);
+                bootstrap_client_to_network(&tox4_client);
+
+                log_raw("Phase 3: tox4 created and bootstrapping.");
+            }
+
+            if (tox4_client.network_connected) {
+                log_raw("Phase 3: tox4 connected to network. Proceeding to friend request.");
+
+                test_phase = 4;
+                phase_start_time = time(NULL);
+            }
+        }
+
+        if (test_phase == 4) {
+            static bool friend_request_sent = false;
+            static uint32_t tox4_friend_num = UINT32_MAX;
+            static bool tox4_online = false;
+            static bool invited_tox4 = false;
+
+            if (!friend_request_sent) {
+                friend_request_sent = true;
+
+                Tox_Err_Friend_Add err;
+                tox4_friend_num = tox_friend_add(clients[0].tox, tox4_client.address, (const uint8_t *)"hello", 5, &err);
+
+                if (err == TOX_ERR_FRIEND_ADD_OK) {
+                    log_raw("Phase 4: tox1 sent friend request to tox4 (friend num %u)", tox4_friend_num);
+                } else {
+                    log_raw("Phase 4: Failed to add tox4 as friend, error: %d", err);
+                }
+            }
+
+            Tox_Err_Friend_Query err;
+            Tox_Connection status = tox_friend_get_connection_status(clients[0].tox, tox4_friend_num, &err);
+
+            if (status != TOX_CONNECTION_NONE && !tox4_online) {
+                tox4_online = true;
+                log_raw("Phase 4: tox4 is now ONLINE as a friend.");
+            }
+
+            if (tox4_online && !invited_tox4) {
+                if (client_is_group_connected(&clients[0])) {
+                    invited_tox4 = true;
+
+                    Tox_Err_Group_Invite_Friend err;
+                    bool ok = tox_group_invite_friend(clients[0].tox, clients[0].group_number, tox4_friend_num, &err);
+
+                    if (ok) {
+                        log_raw("Phase 4: tox1 invited tox4 to the NGC group.");
+
+                        test_phase = 5;
+                        phase_start_time = time(NULL);
+                        all_connected_since = 0;
+                    } else {
+                        log_raw("Phase 4: Failed to invite tox4, error: %d", err);
+                    }
+                }
+            }
+        }
+
+        if (test_phase == 5) {
+            if (tox4_client.group_number != UINT32_MAX && tox4_client.mid != NULL) {
+                uint8_t cid[TOX_GROUP_CHAT_ID_SIZE];
+                if (get_client_chat_id(&tox4_client, cid)) {
+                    size_t count = mid_peer_count(tox4_client.mid, cid);
+                    size_t signed_count = mid_signed_count(tox4_client.mid, cid);
+
+                    if (count >= 3 && signed_count >= 3) {
+                        if (all_connected_since == 0) {
+                            all_connected_since = time(NULL);
+                            log_raw("Phase 5: tox4 joined and middleware is syncing... (peers=%zu, signed=%zu)", count, signed_count);
+                        } else if (time(NULL) - all_connected_since >= 15) {
+                            log_raw("Phase 5: tox4 successfully received the persistent roster including offline tox3! Success!");
+
+                            print_client_peer_table(&tox4_client, "tox4 FINAL");
+
+                            test_phase = 6;
+                            phase_start_time = time(NULL);
+                            all_connected_since = 0;
+
+                            log_raw("Phase 6: Resuming tox3 iteration to simulate reconnect...");
+                        }
+                    } else {
+                        all_connected_since = 0;
+                    }
+                }
+            }
+
+            if (test_phase == 5 && time(NULL) - phase_start_time >= 120) {
+                log_raw("Phase 5: Timeout waiting for tox4 to sync.");
+
+                print_client_peer_table(&tox4_client, "tox4 TIMEOUT");
+
+                test_phase = 6;
+            }
+        }
+
+        if (test_phase == 6) {
+            bool all_synced_phase6 = true;
+
+            for (int i = 0; i < NUM_CLIENTS; i++) {
+                if (clients[i].mid == NULL || clients[i].group_number == UINT32_MAX) {
+                    all_synced_phase6 = false;
+                    break;
+                }
+
+                uint8_t cid[TOX_GROUP_CHAT_ID_SIZE];
+                if (!get_client_chat_id(&clients[i], cid)) {
+                    all_synced_phase6 = false;
+                    break;
+                }
+
+                if (mid_peer_count(clients[i].mid, cid) < 4) {
+                    all_synced_phase6 = false;
+                    break;
+                }
+
+                if (mid_signed_count(clients[i].mid, cid) < 4) {
+                    all_synced_phase6 = false;
+                    break;
+                }
+
+                if (mid_online_count(clients[i].mid, cid) < 4) {
+                    all_synced_phase6 = false;
+                    break;
+                }
+            }
+
+            if (all_synced_phase6) {
+                if (all_connected_since == 0) {
+                    all_connected_since = time(NULL);
+                    log_raw("Phase 6: tox3 is back online. Waiting for all clients to fully sync...");
+                } else if (time(NULL) - all_connected_since >= 10) {
+                    log_raw("Phase 6: All clients fully synced with tox3 back online! Success!");
+
+                    for (int i = 0; i < NUM_CLIENTS; i++) {
+                        print_client_peer_table(&clients[i], clients[i].name);
+                    }
+
+                    print_client_peer_table(&tox4_client, tox4_client.name);
+
+                    test_phase = 7;
+                    phase7_step = 0;
+                    phase7_step_time = time(NULL);
+                    phase7_sync_since = 0;
+
+                    log_raw("Phase 7: tox2 will now gracefully leave the group.");
+                }
+            } else {
+                all_connected_since = 0;
+            }
+        }
+
+        /* --- PHASE 7: tox2 gracefully leaves --- */
+        if (test_phase == 7) {
+            /*
+             * Step 0:
+             * Capture tox2's group identity key before leaving.
+             */
+            if (phase7_step == 0) {
+                if (clients[1].group_number != UINT32_MAX) {
+                    Tox_Err_Group_Self_Query qerr;
+
+                    if (tox_group_self_get_public_key(clients[1].tox,
+                                                      clients[1].group_number,
+                                                      tox2_identity,
+                                                      &qerr) &&
+                        qerr == TOX_ERR_GROUP_SELF_QUERY_OK) {
+                        tox2_identity_known = true;
+                        tox2_old_group_number = clients[1].group_number;
+
+                        phase7_step = 1;
+                        phase7_step_time = time(NULL);
+
+                        log_raw("Phase 7: captured tox2 group identity, will send LEFT tombstone");
+                    }
+                } else {
+                    log_raw("Phase 7: tox2 has no group number, cannot start graceful leave");
+                    test_phase = 8;
+                }
+            }
+            /*
+             * Step 1:
+             * tox2 broadcasts its signed LEFT tombstone.
+             */
+            else if (phase7_step == 1) {
+                bool ok = mid_announce_leave(clients[1].mid,
+                                             clients[1].tox,
+                                             clients[1].group_number);
+
+                if (ok) {
+                    log_raw("Phase 7: tox2 sent signed LEFT tombstone");
+                } else {
+                    log_raw("Phase 7: WARNING: tox2 failed to send signed LEFT tombstone");
+                }
+
+                tox2_tombstone_sent = true;
+
+                phase7_step = 2;
+                phase7_step_time = time(NULL);
+            }
+            /*
+             * Step 2:
+             * Wait a few seconds while all clients keep iterating, so the
+             * tombstone has time to be transmitted and processed.
+             */
+            else if (phase7_step == 2) {
+                if (time(NULL) - phase7_step_time >= PHASE7_TOMBSTONE_FLUSH_SEC) {
+                    log_raw("Phase 7: tombstone flush wait done, calling tox_group_leave() for tox2");
+
+                    phase7_step = 3;
+                    phase7_step_time = time(NULL);
+                }
+            }
+            /*
+             * Step 3:
+             * tox2 calls tox_group_leave() via the unified helper.
+             * This ensures mid_on_group_delete() is always called.
+             */
+            else if (phase7_step == 3) {
+                if (time(NULL) - phase7_step_time >= 1) {
+                    client_leave_group(&clients[1]);
+
+                    log_raw("Phase 7: tox2 left the Tox group");
+
+                    tox2_group_left = true;
+
+                    phase7_step = 4;
+                    phase7_step_time = time(NULL);
+                    phase7_sync_since = 0;
+                }
+            }
+            /*
+             * Step 4:
+             * Wait until tox1, tox3, and tox4 all have the signed LEFT tombstone.
+             */
+            else if (phase7_step == 4) {
+                bool t1_has_tombstone = has_tombstone(&clients[0], tox2_identity);
+                bool t3_has_tombstone = has_tombstone(&clients[2], tox2_identity);
+                bool t4_has_tombstone = has_tombstone(&tox4_client, tox2_identity);
+
+                if (t1_has_tombstone && t3_has_tombstone && t4_has_tombstone) {
+                    if (phase7_sync_since == 0) {
+                        phase7_sync_since = time(NULL);
+                        log_raw("Phase 7: tox2 LEFT tombstone seen on tox1, tox3, and tox4; waiting to confirm stable");
+                    } else if (time(NULL) - phase7_sync_since >= PHASE7_SYNC_WAIT_SEC) {
+                        log_raw("Phase 7: tox2 LEFT tombstone fully synced! Success!");
+
+                        print_client_peer_table(&clients[0], "tox1 after tox2 left");
+                        print_client_peer_table(&clients[2], "tox3 after tox2 left");
+                        print_client_peer_table(&tox4_client, "tox4 after tox2 left");
+
+                        /*
+                         * Phase 8:
+                         * Kick tox4 from the group and verify that the middleware handles it.
+                         */
+                        test_phase = 8;
+                        phase8_step = 0;
+                        phase8_step_time = time(NULL);
+                        phase8_sync_since = 0;
+                        phase8_last_kick_attempt = 0;
+
+                        tox4_identity_known = false;
+                        tox4_kicked = false;
+                        tox4_cleanup_done = false;
+
+                        log_raw("Phase 8: will now kick tox4 from the group");
+                    }
+                } else {
+                    phase7_sync_since = 0;
+
+                    if (time(NULL) - phase7_step_time >= PHASE7_TIMEOUT_SEC) {
+                        log_raw("Phase 7: timeout waiting for tox2 tombstone sync");
+
+                        print_client_peer_table(&clients[0], "tox1 timeout");
+                        print_client_peer_table(&clients[2], "tox3 timeout");
+                        print_client_peer_table(&tox4_client, "tox4 timeout");
+
+                        test_phase = 8;
+                    }
+                }
+            }
+        }
+
+        /* --- PHASE 8: kick tox4 --- */
+        if (test_phase == 8) {
+            /*
+             * Step 0:
+             * Capture tox4's group identity key before kicking it.
+             */
+            if (phase8_step == 0) {
+                if (tox4_initialized && tox4_client.group_number != UINT32_MAX) {
+                    Tox_Err_Group_Self_Query qerr;
+
+                    if (tox_group_self_get_public_key(tox4_client.tox,
+                                                      tox4_client.group_number,
+                                                      tox4_identity,
+                                                      &qerr) &&
+                        qerr == TOX_ERR_GROUP_SELF_QUERY_OK) {
+                        tox4_identity_known = true;
+
+                        phase8_step = 1;
+                        phase8_step_time = time(NULL);
+                        phase8_last_kick_attempt = 0;
+
+                        log_raw("Phase 8: captured tox4 identity, preparing to kick");
+                    } else if (time(NULL) - phase8_step_time >= 30) {
+                        log_raw("Phase 8: timeout capturing tox4 identity");
+                        test_phase = 9;
+                    }
+                } else {
+                    if (time(NULL) - phase8_step_time >= 30) {
+                        log_raw("Phase 8: tox4 is not in a group, skipping kick phase");
+                        test_phase = 9;
+                    }
+                }
+            }
+            /*
+             * Step 1:
+             * tox1 kicks tox4.
+             */
+            else if (phase8_step == 1) {
+                if (time(NULL) - phase8_last_kick_attempt >= 5) {
+                    phase8_last_kick_attempt = time(NULL);
+
+                    Tox_Err_Group_Peer_Query perr;
+                    uint32_t tox4_peer_id =
+                        tox_group_peer_by_public_key(clients[0].tox,
+                                                     clients[0].group_number,
+                                                     tox4_identity,
+                                                     &perr);
+
+                    if (perr == TOX_ERR_GROUP_PEER_QUERY_OK) {
+                        Tox_Err_Group_Mod_Kick_Peer kerr;
+
+                        bool ok = tox_group_mod_kick_peer(clients[0].tox,
+                                                          clients[0].group_number,
+                                                          tox4_peer_id,
+                                                          &kerr);
+
+                        if (ok && kerr == TOX_ERR_GROUP_MOD_KICK_PEER_OK) {
+                            tox4_kicked = true;
+
+                            log_raw("Phase 8: tox1 kicked tox4");
+
+                            /*
+                             * IMPORTANT:
+                             *
+                             * The peer that INITIATES the kick does NOT receive the
+                             * group_moderation event (see tox.h). Therefore the
+                             * middleware cannot auto-delete the kicked peer on the
+                             * kicker's side via mid_on_group_moderation().
+                             *
+                             * As the kicker, tox1 must explicitly delete tox4 from
+                             * its own middleware roster.
+                             */
+                            uint8_t cid0[TOX_GROUP_CHAT_ID_SIZE];
+                            if (get_client_chat_id(&clients[0], cid0)) {
+                                mid_delete_peer_by_identity(clients[0].mid,
+                                                            cid0,
+                                                            tox4_identity);
+
+                                log_raw("Phase 8: tox1 deleted tox4 from its own middleware roster");
+                            }
+
+                            phase8_step = 2;
+                            phase8_step_time = time(NULL);
+                            phase8_sync_since = 0;
+                        } else {
+                            log_raw("Phase 8: tox_group_mod_kick_peer failed, retrying");
+                        }
+                    } else {
+                        log_raw("Phase 8: tox4 peer id not found on tox1, retrying");
+                    }
+                }
+
+                if (time(NULL) - phase8_step_time >= 120) {
+                    log_raw("Phase 8: timeout while trying to kick tox4");
+                    test_phase = 9;
+                }
+            }
+            /*
+             * Step 2:
+             * Wait until tox4 is removed from the middleware roster of tox1 and tox3.
+             *
+             * This expects your middleware to treat TOX_GROUP_EXIT_TYPE_KICK as a
+             * permanent removal from the roster.
+             */
+            else if (phase8_step == 2) {
+                bool absent_on_tox1 = peer_absent(&clients[0], tox4_identity);
+                bool absent_on_tox3 = peer_absent(&clients[2], tox4_identity);
+
+                if (absent_on_tox1 && absent_on_tox3) {
+                    if (phase8_sync_since == 0) {
+                        phase8_sync_since = time(NULL);
+                    } else if (time(NULL) - phase8_sync_since >= 10) {
+                        log_raw("Phase 8: tox4 removed from remaining peers' middleware");
+
+                        phase8_step = 3;
+                        phase8_step_time = time(NULL);
+                        phase8_sync_since = 0;
+                    }
+                } else {
+                    phase8_sync_since = 0;
+
+                    if (time(NULL) - phase8_step_time >= 120) {
+                        log_raw("Phase 8: timeout waiting for tox4 removal from remaining peers");
+
+                        print_client_peer_table(&clients[0], "tox1 timeout after kick");
+                        print_client_peer_table(&clients[2], "tox3 timeout after kick");
+
+                        test_phase = 9;
+                    }
+                }
+            }
+            /*
+             * Step 3:
+             * Wait until tox4 itself is no longer connected to the group.
+             */
+            else if (phase8_step == 3) {
+                bool tox4_gone = false;
+
+                if (tox4_client.group_number == UINT32_MAX) {
+                    tox4_gone = true;
+                } else {
+                    Tox_Err_Group_Is_Connected ierr;
+                    int32_t st = tox_group_is_connected(tox4_client.tox,
+                                                        tox4_client.group_number,
+                                                        &ierr);
+
+                    tox4_gone = (ierr != TOX_ERR_GROUP_IS_CONNECTED_OK || st != 1);
+                }
+
+                if (tox4_gone) {
+                    if (phase8_sync_since == 0) {
+                        phase8_sync_since = time(NULL);
+                    } else if (time(NULL) - phase8_sync_since >= 10) {
+                        log_raw("Phase 8: tox4 is no longer connected to the group");
+
+                        phase8_step = 4;
+                    }
+                } else {
+                    phase8_sync_since = 0;
+
+                    if (time(NULL) - phase8_step_time >= 120) {
+                        log_raw("Phase 8: timeout waiting for tox4 to disconnect");
+                        test_phase = 9;
+                    }
+                }
+            }
+            /*
+             * Step 4:
+             * Clean up tox4 middleware state and print final tables.
+             */
+            else if (phase8_step == 4) {
+                if (!tox4_cleanup_done) {
+                    if (tox4_client.group_number != UINT32_MAX) {
+                        print_client_peer_table(&tox4_client, "tox4 after kick before cleanup");
+
+                        /*
+                         * tox4 is no longer part of the group.
+                         *
+                         * Toxcore may already have removed the group internally.
+                         * We clean the middleware state for that group via the
+                         * unified leave helper.
+                         */
+                        client_leave_group(&tox4_client);
+
+                        tox4_cleanup_done = true;
+
+                        log_raw("Phase 8: tox4 middleware group deleted after kick");
+                    }
+                }
+
+                print_client_peer_table(&clients[0], "tox1 after kicking tox4");
+                print_client_peer_table(&clients[2], "tox3 after kicking tox4");
+
+                log_raw("Phase 8: kick test complete");
+
+                test_phase = 9;
+            }
+        }
+        /* ---------------------------- */
+
+        /* --- PHASE 9: tox5 with broken UTF-8 name --- */
+        if (test_phase == 9) {
+            if (!tox5_initialized) {
+                tox5_initialized = true;
+
+                tox5_client.index = 4;
+                tox5_client.name = tox5_broken_name;
+                tox5_client.group_number = UINT32_MAX;
+                tox5_client.network_connected = false;
+                tox5_client.last_bootstrap = 0;
+                tox5_client.group_connected = false;
+
+                for (int j = 0; j < NUM_CLIENTS; j++) {
+                    tox5_client.friend_num[j] = UINT32_MAX;
+                    tox5_client.friend_online[j] = false;
+                    tox5_client.invited[j] = false;
+                }
+
+                create_tox_instance(&tox5_client);
+                register_callbacks(tox5_client.tox);
+                bootstrap_client_to_network(&tox5_client);
+
+                log_raw("Phase 9: tox5 created with broken UTF-8 name and bootstrapping.");
+            }
+
+            if (tox5_initialized && tox5_client.network_connected) {
+                static bool tox5_friend_req_sent = false;
+                static uint32_t tox5_friend_num = UINT32_MAX;
+                static bool tox5_online = false;
+                static bool invited_tox5 = false;
+                static time_t phase9_sync_since = 0;
+
+                if (!tox5_friend_req_sent) {
+                    tox5_friend_req_sent = true;
+
+                    Tox_Err_Friend_Add err;
+                    tox5_friend_num = tox_friend_add(clients[0].tox, tox5_client.address, (const uint8_t *)"hello", 5, &err);
+
+                    if (err == TOX_ERR_FRIEND_ADD_OK) {
+                        log_raw("Phase 9: tox1 sent friend request to tox5 (friend num %u)", tox5_friend_num);
+                    } else {
+                        log_raw("Phase 9: Failed to add tox5 as friend, error: %d", err);
+                    }
+                }
+
+                Tox_Err_Friend_Query err;
+                Tox_Connection status = tox_friend_get_connection_status(clients[0].tox, tox5_friend_num, &err);
+
+                if (status != TOX_CONNECTION_NONE && !tox5_online) {
+                    tox5_online = true;
+                    log_raw("Phase 9: tox5 is now ONLINE as a friend.");
+                }
+
+                if (tox5_online && !invited_tox5) {
+                    if (client_is_group_connected(&clients[0])) {
+                        invited_tox5 = true;
+
+                        Tox_Err_Group_Invite_Friend err;
+                        bool ok = tox_group_invite_friend(clients[0].tox, clients[0].group_number, tox5_friend_num, &err);
+
+                        if (ok) {
+                            log_raw("Phase 9: tox1 invited tox5 to the NGC group.");
+                        } else {
+                            log_raw("Phase 9: Failed to invite tox5, error: %d", err);
+                        }
+                    }
+                }
+
+                if (tox5_client.group_number != UINT32_MAX && tox5_client.mid != NULL) {
+                    uint8_t cid[TOX_GROUP_CHAT_ID_SIZE];
+                    if (get_client_chat_id(&tox5_client, cid)) {
+                        size_t count = mid_peer_count(tox5_client.mid, cid);
+
+                        if (count >= 2) {
+                            if (phase9_sync_since == 0) {
+                                phase9_sync_since = time(NULL);
+                                log_raw("Phase 9: tox5 joined and middleware is syncing... (peers=%zu)", count);
+                            } else if (time(NULL) - phase9_sync_since >= 15) {
+                                log_raw("Phase 9: tox5 synced successfully with broken UTF-8 name! Success!");
+
+                                print_client_peer_table(&tox5_client, "tox5 FINAL");
+                                print_client_peer_table(&clients[0], "tox1 after tox5 joined");
+
+                                test_phase = 10;
+                            }
+                        } else {
+                            phase9_sync_since = 0;
+                        }
+                    }
+                }
+            }
+        }
+        /* ---------------------------- */
+
+        if (test_phase == 10) {
+            log_raw("Test completed successfully.");
+            break;
+        }
+
+        if (time(NULL) - start_time >= 900) {
+            log_raw("Global timeout reached (900 seconds), exiting");
+            break;
+        }
+    }
+
+cleanup:
+    log_raw("Cleaning up");
+
+    /*
+     * Leave any groups we are still in before freeing middleware.
+     * This ensures mid_on_group_delete() is called for every group
+     * so no middleware state leaks, even on early exit / signal.
+     */
+    for (int i = 0; i < NUM_CLIENTS; i++) {
+        if (clients[i].group_number != UINT32_MAX) {
+            client_leave_group(&clients[i]);
+        }
+    }
+
+    if (tox4_initialized && tox4_client.group_number != UINT32_MAX) {
+        client_leave_group(&tox4_client);
+    }
+
+    if (tox5_initialized && tox5_client.group_number != UINT32_MAX) {
+        client_leave_group(&tox5_client);
+    }
+
+    for (int i = 0; i < NUM_CLIENTS; i++) {
+        if (clients[i].mid != NULL) {
+           if (!mid_save(clients[i].mid, NULL, 0)) {
+                fprintf(stderr, "Warning: Failed to save middleware state to disk!\n");
+            }
+            mid_free(clients[i].mid);
+            clients[i].mid = NULL;
+        }
+
+        if (clients[i].tox != NULL) {
+            tox_kill(clients[i].tox);
+            clients[i].tox = NULL;
+        }
+    }
+
+    if (tox4_initialized) {
+        if (tox4_client.mid != NULL) {
+            mid_free(tox4_client.mid);
+            tox4_client.mid = NULL;
+        }
+
+        if (tox4_client.tox != NULL) {
+            tox_kill(tox4_client.tox);
+            tox4_client.tox = NULL;
+        }
+    }
+
+    if (tox5_initialized) {
+        if (tox5_client.mid != NULL) {
+            mid_free(tox5_client.mid);
+            tox5_client.mid = NULL;
+        }
+
+        if (tox5_client.tox != NULL) {
+            tox_kill(tox5_client.tox);
+            tox5_client.tox = NULL;
+        }
+    }
+
+    return 0;
+}

--- a/ngc_ppeerlist/unit_test/.gitignore
+++ b/ngc_ppeerlist/unit_test/.gitignore
@@ -1,0 +1,9 @@
+*
+!.gitignore
+
+#########
+
+!Makefile
+!test_framework.h 
+!tox_mocks.c
+!test_*.c

--- a/ngc_ppeerlist/unit_test/Makefile
+++ b/ngc_ppeerlist/unit_test/Makefile
@@ -1,0 +1,67 @@
+CC = gcc
+CFLAGS = -I. -I../.. -I../../toxcore -I../ -Wall -Wextra -Wno-unused-parameter -Wno-unused-but-set-variable -g -O1
+LDFLAGS = -lsodium -lpthread -ldl
+
+MID_SRC = ../mid_roster.c
+MOCK_SRC = tox_mocks.c
+
+# Automatically find every test_*.c file in this directory.
+TEST_SRCS := $(sort $(wildcard test_*.c))
+
+# Binary name = source file name without .c
+# Example: test_midroster_unit.c -> test_midroster_unit
+TEST_BINS := $(TEST_SRCS:.c=)
+
+GRAND_TMP = .test_grand_total.tmp
+GRAND_LABEL ?= Normal
+SAN_FLAGS ?=
+
+.PHONY: all asan ubsan tsan clean run_all_bins build
+
+all:
+	@$(MAKE) --no-print-directory clean
+	@$(MAKE) --no-print-directory build SAN_FLAGS=""
+	@$(MAKE) --no-print-directory run_all_bins GRAND_LABEL="Normal"
+
+asan:
+	@$(MAKE) --no-print-directory clean
+	@$(MAKE) --no-print-directory build SAN_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
+	@$(MAKE) --no-print-directory run_all_bins GRAND_LABEL="ASan"
+
+ubsan:
+	@$(MAKE) --no-print-directory clean
+	@$(MAKE) --no-print-directory build SAN_FLAGS="-fsanitize=undefined -fno-omit-frame-pointer"
+	@$(MAKE) --no-print-directory run_all_bins GRAND_LABEL="UBSan"
+
+tsan:
+	@$(MAKE) --no-print-directory clean
+	@$(MAKE) --no-print-directory build SAN_FLAGS="-fsanitize=thread -fno-omit-frame-pointer"
+	@$(MAKE) --no-print-directory run_all_bins GRAND_LABEL="TSan"
+
+build: $(TEST_BINS)
+
+# Automatic rule:
+#   test_foo.c -> test_foo
+#
+# Every test is linked with:
+#   - the middleware source
+#   - the shared mock file
+#
+# If a test defines its own mock functions, those will override the weak
+# mock functions in tox_mocks.c.
+$(TEST_BINS): %: %.c $(MID_SRC) $(MOCK_SRC)
+	$(CC) $(CFLAGS) $(SAN_FLAGS) -o $@ $< $(MID_SRC) $(MOCK_SRC) $(LDFLAGS) $(SAN_FLAGS)
+
+run_all_bins:
+	@rm -f $(GRAND_TMP)
+	@touch $(GRAND_TMP)
+	@for bin in $(TEST_BINS); do \
+		echo ""; \
+		echo "==== Running $$bin ===="; \
+		TEST_GRAND_FILE=$(GRAND_TMP) ./$$bin || true; \
+	done
+	@echo ""
+	@awk -v label="$(GRAND_LABEL)" '{ total += $$1; passed += $$2; failed += $$3; suites += $$4; suites_failed += $$5 } END { printf "============================================================\n"; printf "  GRAND TOTAL (%s)\n", label; printf "============================================================\n"; printf "    Individual tests:  %d total, %d passed, %d failed\n", total, passed, failed; printf "    Suites:            %d run, %d failed\n", suites, suites_failed; printf "============================================================\n"; printf "  RESULT: %s\n", ((failed == 0 && suites_failed == 0) ? "PASS" : "FAIL"); exit ((failed == 0 && suites_failed == 0) ? 0 : 1) }' $(GRAND_TMP)
+
+clean:
+	rm -f $(TEST_BINS) $(GRAND_TMP)

--- a/ngc_ppeerlist/unit_test/test_framework.h
+++ b/ngc_ppeerlist/unit_test/test_framework.h
@@ -1,0 +1,261 @@
+#ifndef TEST_FRAMEWORK_H
+#define TEST_FRAMEWORK_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <errno.h>
+
+#define C_RESET "\033[0m"
+#define C_BOLD  "\033[1m"
+#define C_RED   "\033[31m"
+#define C_GREEN "\033[32m"
+#define C_CYAN  "\033[36m"
+
+static int _tests_run    = 0;
+static int _tests_passed = 0;
+static int _tests_failed = 0;
+
+static int  _suites_run      = 0;
+static int  _suites_failed   = 0;
+static int  _suite_fail_base = 0;
+static bool _suite_active    = false;
+
+static inline void _tf_close_active_suite(void)
+{
+    if (_suite_active) {
+        if (_tests_failed > _suite_fail_base) {
+            _suites_failed++;
+        }
+        _suite_active = false;
+    }
+}
+
+#define T_ASSERT_TRUE(expr, msg) \
+    do { if (!(expr)) { \
+        printf(C_RED "      assertion failed: %s\n" C_RESET, (msg)); \
+        printf("        at %s:%d: %s\n", __func__, __LINE__, #expr); \
+        return false; \
+    } } while (0)
+
+#define T_ASSERT_FALSE(expr, msg) T_ASSERT_TRUE(!(expr), msg)
+
+#define T_ASSERT_INT_EQ(a, b, msg) \
+    do { long long _a=(long long)(a), _b=(long long)(b); if (_a!=_b) { \
+        printf(C_RED "      assertion failed: %s\n" C_RESET, (msg)); \
+        printf("        at %s:%d: got %lld, want %lld\n", __func__, __LINE__, _a, _b); \
+        return false; \
+    } } while (0)
+
+#define T_ASSERT_INT_GT(a, b, msg) \
+    do { \
+        long long _va = (long long)(a), _vb = (long long)(b); \
+        if (_va <= _vb) { \
+            printf(C_RED "    FAIL  %s:%d  %s  (got %lld, want > %lld)\n" C_RESET, \
+                   __func__, __LINE__, (msg), _va, _vb); \
+            return false; \
+        } \
+    } while (0)
+
+#define T_ASSERT_PTR_NOT_NULL(p, msg) \
+    do { if ((p)==NULL) { \
+        printf(C_RED "      assertion failed: %s\n" C_RESET, (msg)); \
+        printf("        at %s:%d: pointer is NULL\n", __func__, __LINE__); \
+        return false; \
+    } } while (0)
+
+static char *_tf_read_all(int fd, size_t *out_len)
+{
+    size_t cap = 8192, len = 0;
+    char *buf = (char *)malloc(cap);
+    if (!buf) { close(fd); *out_len = 0; return NULL; }
+
+    for (;;) {
+        if (len + 4096 > cap) {
+            cap *= 2;
+            char *nb = (char *)realloc(buf, cap);
+            if (!nb) break;
+            buf = nb;
+        }
+
+        ssize_t r = read(fd, buf + len, 4096);
+        if (r < 0) { if (errno == EINTR) continue; break; }
+        if (r == 0) break;
+        len += (size_t)r;
+    }
+
+    close(fd);
+    *out_len = len;
+    return buf;
+}
+
+static void _tf_print_indented(const char *buf, size_t len)
+{
+    size_t i = 0;
+
+    while (i < len) {
+        fputs("        ", stdout);
+
+        while (i < len && buf[i] != '\n') {
+            fputc(buf[i], stdout);
+            i++;
+        }
+
+        fputc('\n', stdout);
+
+        if (i < len && buf[i] == '\n') {
+            i++;
+        }
+    }
+}
+
+typedef bool (*_tf_test_fn)(void);
+
+static void _tf_run_isolated(const char *name, _tf_test_fn fn)
+{
+    _tests_run++;
+
+    fflush(stdout);
+    fflush(stderr);
+
+    int pipefd[2];
+
+    if (pipe(pipefd) != 0) {
+        printf("    %-50s", name);
+
+        if (fn()) {
+            _tests_passed++;
+            printf(C_GREEN "PASS\n" C_RESET);
+        } else {
+            _tests_failed++;
+            printf(C_RED "FAIL\n" C_RESET);
+        }
+
+        return;
+    }
+
+    pid_t pid = fork();
+
+    if (pid == -1) {
+        printf("    %-50s" C_RED "FAIL (fork error)\n" C_RESET, name);
+        _tests_failed++;
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return;
+    }
+
+    if (pid == 0) {
+        close(pipefd[0]);
+
+        dup2(pipefd[1], STDOUT_FILENO);
+        dup2(pipefd[1], STDERR_FILENO);
+
+        close(pipefd[1]);
+
+        bool ok = fn();
+        _exit(ok ? 0 : 1);
+    }
+
+    close(pipefd[1]);
+
+    size_t out_len = 0;
+    char *out = _tf_read_all(pipefd[0], &out_len);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        _tests_passed++;
+        printf("    %-50s" C_GREEN "PASS\n" C_RESET, name);
+
+        /*
+         * HINT: this prints the stdout of the test also in case of PASS
+         * if (out && out_len > 0) {
+         *     _tf_print_indented(out, out_len);
+         * }
+         */
+    } else {
+        _tests_failed++;
+
+        if (WIFSIGNALED(status)) {
+            int sig = WTERMSIG(status);
+            const char *why =
+                (sig == SIGABRT) ? "SIGABRT" :
+                (sig == SIGSEGV) ? "SIGSEGV" :
+                "crashed";
+
+            printf("    %-50s" C_RED "FAIL (%s, signal %d)\n" C_RESET,
+                   name, why, sig);
+        } else {
+            printf("    %-50s" C_RED "FAIL (exit %d)\n" C_RESET,
+                   name, WEXITSTATUS(status));
+        }
+
+        if (out && out_len > 0) {
+            _tf_print_indented(out, out_len);
+        }
+    }
+
+    free(out);
+}
+
+#define RUN_TEST(fn) _tf_run_isolated(#fn, fn)
+
+#define TEST_SUITE(name) \
+    do { \
+        _tf_close_active_suite(); \
+        printf(C_CYAN "  [%s]\n" C_RESET, (name)); \
+        _suites_run++; \
+        _suite_fail_base = _tests_failed; \
+        _suite_active = true; \
+    } while (0)
+
+#define SUITE_END() \
+    do { \
+        _tf_close_active_suite(); \
+        printf("\n"); \
+    } while (0)
+
+static inline int test_summary(const char *label)
+{
+    _tf_close_active_suite();
+
+    printf(C_BOLD "  ───────────────────────────────────────────\n" C_RESET);
+
+    if (_tests_failed == 0) {
+        printf(C_GREEN C_BOLD "  ✓  %s:  %d / %d passed\n" C_RESET,
+               label, _tests_passed, _tests_run);
+    } else {
+        printf(C_RED C_BOLD "  ✗  %s:  %d / %d passed,  %d FAILED\n" C_RESET,
+               label, _tests_passed, _tests_run, _tests_failed);
+    }
+
+    printf(C_BOLD "  ───────────────────────────────────────────\n" C_RESET);
+
+    printf("  Total:   %d\n", _tests_run);
+    printf("  Passed:  %d\n", _tests_passed);
+    printf("  Failed:  %d\n", _tests_failed);
+
+    const char *grand_file = getenv("TEST_GRAND_FILE");
+    if (grand_file && grand_file[0] != '\0') {
+        FILE *f = fopen(grand_file, "a");
+        if (f) {
+            fprintf(f, "%d %d %d %d %d\n",
+                    _tests_run,
+                    _tests_passed,
+                    _tests_failed,
+                    _suites_run,
+                    _suites_failed);
+            fclose(f);
+        }
+    }
+
+    return (_tests_failed > 0 || _suites_failed > 0) ? 1 : 0;
+}
+
+#endif

--- a/ngc_ppeerlist/unit_test/test_midroster_adversarial.c
+++ b/ngc_ppeerlist/unit_test/test_midroster_adversarial.c
@@ -1,0 +1,86 @@
+#include "test_framework.h"
+#include "../../toxcore/tox.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include "../mid_roster.h"
+
+extern Tox *create_dummy_tox(void);
+
+#define MID_MSG_PRESENCE     1
+#define MID_MSG_ROSTER_REQUEST 2
+
+bool test_custom_packet_null_and_zero(void) {
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    mid_on_group_self_join(s, tox, 1, (uint8_t*)"test", 4);
+    
+    mid_on_group_custom_packet(s, tox, 1, 1, NULL, 0);
+    mid_on_group_custom_packet(s, tox, 1, 1, NULL, 100);
+    mid_on_group_custom_packet(s, tox, 1, 1, (uint8_t*)"", 0);
+    mid_free(s);
+    return true;
+}
+
+bool test_custom_packet_malformed(void) {
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    mid_on_group_self_join(s, tox, 1, (uint8_t*)"test", 4);
+    
+    uint8_t bad_magic[5] = {0x00, 0x00, 0x00, 0x00, MID_MSG_PRESENCE};
+    mid_on_group_custom_packet(s, tox, 1, 1, bad_magic, sizeof(bad_magic));
+    
+    uint8_t short_pkt[4] = {MID_MAGIC_0, MID_MAGIC_1, MID_MAGIC_2, MID_PROTOCOL_VERSION};
+    mid_on_group_custom_packet(s, tox, 1, 1, short_pkt, sizeof(short_pkt));
+    
+    uint8_t small_presence[66] = {0};
+    small_presence[0] = MID_MAGIC_0;
+    small_presence[1] = MID_MAGIC_1;
+    small_presence[2] = MID_MAGIC_2;
+    small_presence[3] = MID_PROTOCOL_VERSION;
+    small_presence[4] = MID_MSG_PRESENCE;
+    mid_on_group_custom_packet(s, tox, 1, 1, small_presence, sizeof(small_presence));
+    
+    uint8_t huge_pkt[1200] = {MID_MAGIC_0, MID_MAGIC_1, MID_MAGIC_2, MID_PROTOCOL_VERSION, MID_MSG_PRESENCE};
+    mid_on_group_custom_packet(s, tox, 1, 1, huge_pkt, sizeof(huge_pkt));
+    
+    mid_free(s);
+    return true;
+}
+
+bool test_corrupt_signature(void) {
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    mid_on_group_self_join(s, tox, 1, (uint8_t*)"test", 4);
+    
+    uint8_t pkt[5 + 64 + 75] = {0};
+    pkt[0] = MID_MAGIC_0;
+    pkt[1] = MID_MAGIC_1;
+    pkt[2] = MID_MAGIC_2;
+    pkt[3] = MID_PROTOCOL_VERSION;
+    pkt[4] = MID_MSG_PRESENCE;
+    
+    uint8_t *body = pkt + 5 + 64;
+    body[0] = 0;
+    body[9] = 0;
+    body[10] = 0;
+    memset(body + 11, 0xCC, 32);
+    memset(body + 11 + 32, 0xCC, 32);
+    
+    mid_on_group_custom_packet(s, tox, 1, 1, pkt, sizeof(pkt));
+    
+    mid_free(s);
+    return true;
+}
+
+int main(void) {
+    TEST_SUITE("midroster adversarial / security tests");
+
+    RUN_TEST(test_custom_packet_null_and_zero);
+    RUN_TEST(test_custom_packet_malformed);
+    RUN_TEST(test_corrupt_signature);
+
+    SUITE_END();
+    return test_summary("midroster_adversarial");
+}

--- a/ngc_ppeerlist/unit_test/test_midroster_boundaries.c
+++ b/ngc_ppeerlist/unit_test/test_midroster_boundaries.c
@@ -1,0 +1,110 @@
+#include "test_framework.h"
+#include "../../toxcore/tox.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include "../mid_roster.h"
+
+extern Tox *create_dummy_tox(void);
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+static const uint8_t dummy_chat_id_1[TOX_GROUP_CHAT_ID_SIZE] = {1};
+static const uint8_t dummy_chat_id_99[TOX_GROUP_CHAT_ID_SIZE] = {99};
+
+bool test_new_and_free(void) {
+    MidState *s = mid_new(NULL, NULL, 0);
+    T_ASSERT_PTR_NOT_NULL(s, "mid_new failed");
+    mid_free(s);
+    mid_free(NULL); // Must not crash
+    return true;
+}
+
+bool test_null_inputs(void) {
+    T_ASSERT_INT_EQ(mid_group_count(NULL), 0, "group_count on NULL");
+    T_ASSERT_INT_EQ(mid_peer_count(NULL, dummy_chat_id_1), 0, "peer_count on NULL");
+    T_ASSERT_INT_EQ(mid_signed_count(NULL, dummy_chat_id_1), 0, "signed_count on NULL");
+    T_ASSERT_INT_EQ(mid_online_count(NULL, dummy_chat_id_1), 0, "online_count on NULL");
+    T_ASSERT_INT_EQ(mid_find_peer(NULL, dummy_chat_id_1, NULL), -1, "find_peer on NULL");
+    T_ASSERT_FALSE(mid_delete_peer_by_identity(NULL, dummy_chat_id_1, NULL), "delete_peer on NULL");
+    T_ASSERT_FALSE(mid_peer_is_signed_left(NULL, dummy_chat_id_1, NULL), "is_signed_left on NULL");
+    T_ASSERT_FALSE(mid_announce_leave(NULL, NULL, 1), "announce_leave on NULL");
+
+    MidPeerInfo info;
+    T_ASSERT_FALSE(mid_peer_list_get(NULL, dummy_chat_id_1, 0, &info), "peer_list_get on NULL state");
+    
+    mid_iterate(NULL, NULL); // Must not crash
+    mid_on_group_self_join(NULL, NULL, 1, NULL, 0);
+    mid_on_group_delete(NULL, NULL, 1);
+    return true;
+}
+
+bool test_extreme_values(void) {
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    
+    mid_on_group_self_join(s, tox, UINT32_MAX, (uint8_t*)"test", 4);
+    T_ASSERT_INT_EQ(mid_group_count(s), 1, "group added");
+    mid_on_group_delete(s, tox, UINT32_MAX);
+    T_ASSERT_INT_EQ(mid_group_count(s), 0, "group deleted");
+
+    mid_on_group_self_join(s, tox, 1, (uint8_t*)"test", 4);
+    mid_on_group_peer_join(s, tox, 1, UINT32_MAX);
+    mid_on_group_peer_name(s, tox, 1, UINT32_MAX);
+    mid_on_group_peer_exit(s, tox, 1, TOX_GROUP_EXIT_TYPE_QUIT);
+    mid_iterate(s, tox);
+    
+    mid_free(s);
+    return true;
+}
+
+bool test_empty_nickname(void) {
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    mid_on_group_self_join(s, tox, 1, NULL, 0);
+    mid_on_group_self_join(s, tox, 2, (uint8_t*)"", 0);
+    
+    T_ASSERT_INT_EQ(mid_group_count(s), 2, "groups created with empty nicks");
+    mid_free(s);
+    return true;
+}
+
+static int cb_called = 0;
+static void test_peer_list_changed_cb(const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], void *user_data) {
+    (void)chat_id;
+    (void)user_data;
+    cb_called++;
+}
+
+bool test_callback_and_print(void) {
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    
+    cb_called = 0;
+    mid_set_peer_list_changed_cb(s, test_peer_list_changed_cb, NULL);
+    mid_on_group_self_join(s, tox, 1, (uint8_t*)"test", 4);
+    
+    T_ASSERT_INT_GT(cb_called, 0, "callback should be triggered on self join");
+    
+    mid_print_peer_table(s, dummy_chat_id_1, "test title");
+    mid_print_peer_table(s, dummy_chat_id_99, "missing group");
+    
+    mid_free(s);
+    return true;
+}
+
+int main(void) {
+    TEST_SUITE("midroster boundary and invariant tests");
+
+    RUN_TEST(test_new_and_free);
+    RUN_TEST(test_null_inputs);
+    RUN_TEST(test_extreme_values);
+    RUN_TEST(test_empty_nickname);
+    RUN_TEST(test_callback_and_print);
+
+    SUITE_END();
+    return test_summary("midroster_boundaries");
+}

--- a/ngc_ppeerlist/unit_test/test_midroster_limits.c
+++ b/ngc_ppeerlist/unit_test/test_midroster_limits.c
@@ -1,0 +1,97 @@
+#include "test_framework.h"
+#include "../../toxcore/tox.h"
+#include "../mid_roster.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+extern Tox *create_dummy_tox(void);
+extern void mock_set_churn(int on);
+
+static const uint8_t chat_id_1[TOX_GROUP_CHAT_ID_SIZE] = {1};
+static const uint8_t chat_id_2[TOX_GROUP_CHAT_ID_SIZE] = {2};
+static const uint8_t chat_id_3[TOX_GROUP_CHAT_ID_SIZE] = {3};
+static const uint8_t chat_id_4[TOX_GROUP_CHAT_ID_SIZE] = {4};
+
+/*
+ * Test that the middleware enforces the MID_MAX_PEERS_PER_GROUP limit
+ * across multiple groups, and gracefully drops peers beyond the limit
+ * without crashing, leaking, or corrupting memory.
+ */
+static bool test_peer_limit_multiple_groups(void)
+{
+    /* Ensure each peer_id gets a distinct identity key so the roster actually grows */
+    mock_set_churn(1);
+
+    MidState *s = mid_new(NULL, NULL, 0);
+    T_ASSERT_PTR_NOT_NULL(s, "mid_new()");
+
+    Tox *tox = create_dummy_tox();
+    T_ASSERT_PTR_NOT_NULL(tox, "create_dummy_tox()");
+
+    const uint8_t *chat_ids[4] = {chat_id_1, chat_id_2, chat_id_3, chat_id_4};
+
+    /* Create 3 groups */
+    mid_on_group_self_join(s, tox, 1, (const uint8_t *)"g1", 2);
+    mid_on_group_self_join(s, tox, 2, (const uint8_t *)"g2", 2);
+    mid_on_group_self_join(s, tox, 3, (const uint8_t *)"g3", 2);
+
+    T_ASSERT_INT_EQ(mid_group_count(s), 3, "3 groups created");
+
+    /* 
+     * The limit is defined as MID_MAX_PEERS_PER_GROUP.
+     * We will attempt to add 8500 peers to each group.
+     * The self peer is already in the group, so the roster can accept 4095 more.
+     */
+    size_t limit = MID_MAX_PEERS_PER_GROUP;
+    uint32_t target_peers = 8500;
+
+    for (int g = 0; g < 3; g++) {
+        for (uint32_t i = 1; i <= target_peers; i++) {
+            /* Make peer_id unique per group */
+            uint32_t peer_id = ((g + 1) * 100000) + i;
+            mid_on_group_peer_join(s, tox, g + 1, peer_id);
+        }
+        
+        /* The count should be exactly the limit. */
+        size_t count = mid_peer_count(s, chat_ids[g]);
+        T_ASSERT_INT_EQ(count, limit, "peer count capped at limit");
+    }
+
+    T_ASSERT_INT_EQ(mid_group_count(s), 3, "still 3 groups");
+
+    /* Verify counts are stable */
+    T_ASSERT_INT_EQ(mid_peer_count(s, chat_ids[0]), limit, "group 1 count stable");
+    T_ASSERT_INT_EQ(mid_peer_count(s, chat_ids[1]), limit, "group 2 count stable");
+    T_ASSERT_INT_EQ(mid_peer_count(s, chat_ids[2]), limit, "group 3 count stable");
+
+    /* Verify we can still add a 4th group and it also respects the limit */
+    mid_on_group_self_join(s, tox, 4, (const uint8_t *)"g4", 2);
+    T_ASSERT_INT_EQ(mid_group_count(s), 4, "4th group added successfully");
+
+    for (uint32_t i = 1; i <= target_peers; i++) {
+        mid_on_group_peer_join(s, tox, 4, 400000 + i);
+    }
+    T_ASSERT_INT_EQ(mid_peer_count(s, chat_ids[3]), limit, "group 4 peer count capped at limit");
+
+    mid_free(s);
+    mock_set_churn(0);
+    return true;
+}
+
+int main(void)
+{
+    TEST_SUITE("midroster limits / stress tests");
+
+    RUN_TEST(test_peer_limit_multiple_groups);
+
+    SUITE_END();
+
+    return test_summary("midroster_limits");
+}

--- a/ngc_ppeerlist/unit_test/test_midroster_peer_limit.c
+++ b/ngc_ppeerlist/unit_test/test_midroster_peer_limit.c
@@ -1,0 +1,199 @@
+#include "test_framework.h"
+#include "../../toxcore/tox.h"
+#include "../mid_roster.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+extern Tox *create_dummy_tox(void);
+extern void mock_set_churn(int on);
+
+/*
+How many peer joins to attempt per group.
+
+This should be comfortably larger than your MID_MAX_PEERS_PER_GROUP
+limit in mid_roster.c.
+
+If your limit is very large, increase this value, for example:
+
+    make CFLAGS+="-DLIMIT_MAX_ATTEMPT=100000"
+*/
+#ifndef LIMIT_MAX_ATTEMPT
+#define LIMIT_MAX_ATTEMPT 20000
+#endif
+
+#ifndef LIMIT_CHUNK
+#define LIMIT_CHUNK 1000
+#endif
+
+#define LIMIT_GROUPS 3
+
+
+/*
+Keep inserting peers until the roster count stops growing.
+
+Returns true if a cap was detected.
+Stores the capped peer count in *out_count.
+*/
+static bool group_hits_cap(MidState *s,
+                           Tox *tox,
+                           uint32_t group_number,
+                           const uint8_t *chat_id,
+                           size_t *out_count)
+{
+    size_t prev = 0;
+    uint32_t peer_id = 0;
+    bool capped = false;
+
+    while (peer_id < LIMIT_MAX_ATTEMPT) {
+        uint32_t end = peer_id + LIMIT_CHUNK;
+
+        if (end > LIMIT_MAX_ATTEMPT) {
+            end = LIMIT_MAX_ATTEMPT;
+        }
+
+        for (; peer_id < end; peer_id++) {
+            mid_on_group_peer_join(s, tox, group_number, peer_id);
+        }
+
+        size_t cur = mid_peer_count(s, chat_id);
+
+        /*
+        If a full chunk of new peer joins did not increase the count,
+        the peer limit has been reached.
+        */
+        if (cur == prev) {
+            capped = true;
+            break;
+        }
+
+        prev = cur;
+    }
+
+    /*
+    If the limit was reached exactly at LIMIT_MAX_ATTEMPT, the loop above
+    may not have observed a stable chunk yet. Try one more chunk.
+    */
+    if (!capped) {
+        size_t before = mid_peer_count(s, chat_id);
+
+        for (uint32_t i = 0; i < LIMIT_CHUNK; i++) {
+            mid_on_group_peer_join(s, tox, group_number, peer_id + i);
+        }
+
+        size_t after = mid_peer_count(s, chat_id);
+
+        if (after == before) {
+            capped = true;
+        }
+
+        prev = after;
+    }
+
+    if (out_count != NULL) {
+        *out_count = prev;
+    }
+
+    return capped;
+}
+
+static bool test_peer_limit_is_enforced(void)
+{
+    /*
+    Churn mode gives every peer_id a distinct identity key.
+    Without this, all peers would have the same key and the roster
+    would not grow.
+    */
+    mock_set_churn(1);
+
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    T_ASSERT_PTR_NOT_NULL(s, "mid_new");
+    T_ASSERT_PTR_NOT_NULL(tox, "create_dummy_tox");
+
+    uint32_t group_numbers[LIMIT_GROUPS] = {
+        9101,
+        9102,
+        9103
+    };
+
+/* chat_ids must match what tox_group_get_chat_id() produces for these group_numbers:
+     *   byte[0] = group_number & 0xFF
+     *   byte[1] = (group_number >> 8) & 0xFF
+     */
+    uint8_t chat_ids[LIMIT_GROUPS][TOX_GROUP_CHAT_ID_SIZE];
+    for (size_t i = 0; i < LIMIT_GROUPS; i++) {
+        memset(chat_ids[i], 0, TOX_GROUP_CHAT_ID_SIZE);
+        chat_ids[i][0] = (uint8_t)(group_numbers[i] & 0xFF);
+        chat_ids[i][1] = (uint8_t)((group_numbers[i] >> 8) & 0xFF);
+        chat_ids[i][2] = (uint8_t)((group_numbers[i] >> 16) & 0xFF);
+        chat_ids[i][3] = (uint8_t)((group_numbers[i] >> 24) & 0xFF);
+    }
+
+    /*
+    Create groups.
+    */
+    for (size_t i = 0; i < LIMIT_GROUPS; i++) {
+        mid_on_group_self_join(s, tox, group_numbers[i],
+                               (const uint8_t *)"limit", 5);
+    }
+
+    T_ASSERT_INT_EQ(mid_group_count(s), LIMIT_GROUPS,
+                    "all test groups must be created");
+
+    /*
+    Try to store far too many peers in each group.
+    */
+    for (size_t i = 0; i < LIMIT_GROUPS; i++) {
+        size_t stored = 0;
+
+        bool capped = group_hits_cap(s, tox, group_numbers[i], chat_ids[i], &stored);
+
+        T_ASSERT_TRUE(capped,
+                      "peer limit must be enforced");
+
+        T_ASSERT_TRUE(stored > 0,
+                      "some peers must be stored before the limit is reached");
+
+        /*
+        Attempt even more peers after the cap was detected.
+        These must be rejected without crashing and without growing the roster.
+        */
+        uint32_t extra_base = LIMIT_MAX_ATTEMPT + LIMIT_CHUNK + 5000;
+
+        for (uint32_t p = 0; p < 256; p++) {
+            mid_on_group_peer_join(s, tox, group_numbers[i], extra_base + p);
+        }
+
+        T_ASSERT_INT_EQ(mid_peer_count(s, chat_ids[i]),
+                        stored,
+                        "peer count must remain capped");
+
+        T_ASSERT_INT_EQ(mid_peer_list_count(s, chat_ids[i]),
+                        stored,
+                        "peer list count must remain capped");
+    }
+
+    mid_free(s);
+
+    mock_set_churn(0);
+
+    return true;
+}
+
+int main(void)
+{
+    TEST_SUITE("midroster peer limit tests");
+
+    RUN_TEST(test_peer_limit_is_enforced);
+
+    SUITE_END();
+
+    return test_summary("midroster_peer_limit");
+}

--- a/ngc_ppeerlist/unit_test/test_midroster_threading.c
+++ b/ngc_ppeerlist/unit_test/test_midroster_threading.c
@@ -1,0 +1,263 @@
+#include "test_framework.h"
+#include "../../toxcore/tox.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdatomic.h>
+#include "../mid_roster.h"
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+extern Tox *create_dummy_tox(void);
+extern void mock_set_churn(int on);
+
+#define MID_MSG_ROSTER_REQUEST 2
+
+static _Atomic bool running = true;
+static MidState *global_s;
+static Tox *global_tox;
+
+/* ── static chat_ids used across threads (for query functions) ── */
+static const uint8_t chat_id_1[TOX_GROUP_CHAT_ID_SIZE] = {1};
+static const uint8_t chat_id_42[TOX_GROUP_CHAT_ID_SIZE] = {42};
+static const uint8_t chat_id_9999[TOX_GROUP_CHAT_ID_SIZE] = {0x99, 0x99};
+
+/* ── group numbers used for the new group_number API ──────────── */
+#define GROUP_1    1
+#define GROUP_42   42
+#define GROUP_9999 0x9999
+
+/* ── helpers ──────────────────────────────────────────────────── */
+static void key_from_peer(uint32_t id, uint8_t *out) {
+    memset(out, 0, 32);
+    out[0] = 0x10;
+    out[1] = (uint8_t)(id & 0xFF);
+    out[2] = (uint8_t)((id >> 8) & 0xFF);
+    out[3] = (uint8_t)((id >> 16) & 0xFF);
+}
+
+/* ════════════════════════════════════════════════════════════════
+ * TEST 2 — full API churn
+ * Each peer_id now has a DISTINCT identity key (mock churn mode),
+ * so joins grow the roster, deletes/kicks shrink it, and array
+ * shifts race against readers.
+ * ════════════════════════════════════════════════════════════════ */
+
+/* mid_iterate */
+void *thread_iterate(void *arg) {
+    (void)arg;
+    while (running) {
+        mid_iterate(global_s, global_tox);
+    }
+    return NULL;
+}
+
+/* mid_on_group_self_join + mid_on_group_delete on private groups */
+void *thread_group_lifecycle(void *arg) {
+    (void)arg;
+    uint32_t group = 100;
+    while (running) {
+        mid_on_group_self_join(global_s, global_tox, group, (uint8_t*)"stress", 6);
+        mid_on_group_delete(global_s, global_tox, group);
+        group++;
+        if (group > 200) group = 100;
+    }
+    return NULL;
+}
+
+/* mid_on_group_peer_join + mid_on_group_peer_name — grows roster */
+void *thread_peer_join(void *arg) {
+    (void)arg;
+    uint32_t id = 0;
+    while (running) {
+        uint32_t peer_id = 1000 + (id % 64);
+        mid_on_group_peer_join(global_s, global_tox, GROUP_1, peer_id);
+        mid_on_group_peer_name(global_s, global_tox, GROUP_1, peer_id);
+        id++;
+    }
+    return NULL;
+}
+
+/* mid_delete_peer_by_identity — shrinks roster (array shift) */
+void *thread_delete(void *arg) {
+    (void)arg;
+    uint32_t id = 0;
+    uint8_t key[32];
+    while (running) {
+        key_from_peer(1000 + (id % 64), key);
+        mid_delete_peer_by_identity(global_s, chat_id_1, key);
+        id++;
+    }
+    return NULL;
+}
+
+/* mid_on_group_moderation (KICK) — also shrinks roster */
+void *thread_moderation(void *arg) {
+    (void)arg;
+    uint32_t id = 0;
+    while (running) {
+        uint32_t target = 1000 + (id % 64);
+        mid_on_group_moderation(global_s, global_tox, GROUP_1, 0, target,
+                                TOX_GROUP_MOD_EVENT_KICK);
+        id++;
+    }
+    return NULL;
+}
+
+/* mid_on_group_peer_exit — triggers mid_sync_online_state_group */
+void *thread_peer_exit(void *arg) {
+    (void)arg;
+    while (running) {
+        mid_on_group_peer_exit(global_s, global_tox, GROUP_1, TOX_GROUP_EXIT_TYPE_QUIT);
+    }
+    return NULL;
+}
+
+/* mid_on_group_custom_packet */
+/* mid_on_group_custom_packet */
+void *thread_custom_packet(void *arg) {
+    (void)arg;
+    uint8_t roster_req[5] = {
+        MID_MAGIC_0,
+        MID_MAGIC_1,
+        MID_MAGIC_2,
+        MID_PROTOCOL_VERSION,
+        MID_MSG_ROSTER_REQUEST
+    };
+    uint8_t garbage[64];
+    memset(garbage, 0xFF, sizeof(garbage));
+    while (running) {
+        mid_on_group_custom_packet(global_s, global_tox, GROUP_1, 1, roster_req, sizeof(roster_req));
+        mid_on_group_custom_packet(global_s, global_tox, GROUP_1, 1, garbage, sizeof(garbage));
+        mid_on_group_custom_packet(global_s, global_tox, GROUP_1, 1, NULL, 0);
+    }
+    return NULL;
+}
+
+/* query functions */
+void *thread_queries(void *arg) {
+    (void)arg;
+    uint32_t id = 0;
+    uint8_t key[32];
+    while (running) {
+        key_from_peer(1000 + (id % 64), key);
+        mid_group_count(global_s);
+        mid_peer_count(global_s, chat_id_1);
+        mid_signed_count(global_s, chat_id_1);
+        mid_online_count(global_s, chat_id_1);
+        mid_find_peer(global_s, chat_id_1, key);
+        mid_peer_is_signed_left(global_s, chat_id_1, key);
+        mid_peer_count(global_s, chat_id_9999);
+        id++;
+    }
+    return NULL;
+}
+
+/* mid_peer_list_count + mid_peer_list_get */
+void *thread_peer_list(void *arg) {
+    (void)arg;
+    while (running) {
+        size_t count = mid_peer_list_count(global_s, chat_id_1);
+        for (size_t i = 0; i < count; i++) {
+            MidPeerInfo info;
+            mid_peer_list_get(global_s, chat_id_1, i, &info);
+        }
+        MidPeerInfo info;
+        mid_peer_list_get(global_s, chat_id_1, 99999, &info);
+        mid_peer_list_get(global_s, chat_id_1, 0, NULL);
+    }
+    return NULL;
+}
+
+/* mid_announce_leave */
+void *thread_announce_leave(void *arg) {
+    (void)arg;
+    while (running) {
+        mid_announce_leave(global_s, global_tox, GROUP_1);
+        mid_announce_leave(global_s, global_tox, GROUP_9999);
+    }
+    return NULL;
+}
+
+/* mid_set_peer_list_changed_cb + mid_print_peer_table */
+static void noop_cb(const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], void *user_data) {
+    (void)chat_id;
+    (void)user_data;
+}
+
+void *thread_callback_print(void *arg) {
+    (void)arg;
+    int toggle = 0;
+    while (running) {
+        mid_set_peer_list_changed_cb(global_s, (toggle & 1) ? noop_cb : NULL, NULL);
+        mid_print_peer_table(global_s, chat_id_1, "stress");
+        toggle++;
+    }
+    return NULL;
+}
+
+/* mid_new + mid_free on independent instances */
+void *thread_independent_lifecycle(void *arg) {
+    (void)arg;
+    while (running) {
+        MidState *local_s = mid_new(NULL, NULL, 0);
+        if (local_s) {
+            mid_on_group_self_join(local_s, global_tox, GROUP_42, (uint8_t*)"local", 5);
+            mid_iterate(local_s, global_tox);
+            mid_peer_count(local_s, chat_id_42);
+            mid_on_group_delete(local_s, global_tox, GROUP_42);
+            mid_free(local_s);
+        }
+    }
+    return NULL;
+}
+
+bool test_all_api_concurrent(void) {
+    mock_set_churn(1);   /* distinct identity per peer_id */
+
+    global_s = mid_new(NULL, NULL, 0);
+    global_tox = create_dummy_tox();
+
+    mid_on_group_self_join(global_s, global_tox, GROUP_1, (uint8_t*)"test", 4);
+
+    #define NUM_THREADS 11
+    pthread_t threads[NUM_THREADS];
+
+    pthread_create(&threads[0],  NULL, thread_iterate,              NULL);
+    pthread_create(&threads[1],  NULL, thread_group_lifecycle,      NULL);
+    pthread_create(&threads[2],  NULL, thread_peer_join,            NULL);
+    pthread_create(&threads[3],  NULL, thread_delete,               NULL);
+    pthread_create(&threads[4],  NULL, thread_moderation,           NULL);
+    pthread_create(&threads[5],  NULL, thread_peer_exit,            NULL);
+    pthread_create(&threads[6],  NULL, thread_custom_packet,        NULL);
+    pthread_create(&threads[7],  NULL, thread_queries,              NULL);
+    pthread_create(&threads[8],  NULL, thread_peer_list,            NULL);
+    pthread_create(&threads[9],  NULL, thread_announce_leave,       NULL);
+    pthread_create(&threads[10], NULL, thread_independent_lifecycle, NULL);
+
+    sleep(3);
+
+    running = false;
+
+    for (int i = 0; i < NUM_THREADS; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    mid_free(global_s);
+    mock_set_churn(0);
+    return true;
+}
+
+int main(void) {
+    TEST_SUITE("midroster threading / TSan tests (full API coverage)");
+
+    RUN_TEST(test_all_api_concurrent);
+
+    SUITE_END();
+    return test_summary("midroster_threading");
+}

--- a/ngc_ppeerlist/unit_test/test_midroster_unit.c
+++ b/ngc_ppeerlist/unit_test/test_midroster_unit.c
@@ -1,0 +1,1279 @@
+#include "test_framework.h"
+#include "../../toxcore/tox.h"
+#include "../mid_roster.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sodium.h>
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+#define MID_PROTOCOL_VERSION   1
+#define MID_MSG_PRESENCE       1
+#define MID_MSG_ROSTER_REQUEST 2
+
+#define MID_STATUS_ACTIVE      0
+#define MID_STATUS_LEFT        1
+
+#define SELF_SEED_ID           0x77777777u
+
+#define TEST_BODY_MAX          (1 + 8 + 2 + MID_MAX_NICK_SIZE + 32 + 32)
+
+/* ------------------------------------------------------------------ */
+/* Group numbers and Chat ID constants                                */
+/* ------------------------------------------------------------------ */
+
+#define GROUP_1    1
+#define GROUP_2    2
+#define GROUP_9999 9999
+
+static const uint8_t cid1[TOX_GROUP_CHAT_ID_SIZE] = {1};
+static const uint8_t cid2[TOX_GROUP_CHAT_ID_SIZE] = {2};
+static const uint8_t cid9999[TOX_GROUP_CHAT_ID_SIZE] = {0x0F, 0x27}; /* 9999 in LE */
+
+/* ------------------------------------------------------------------ */
+/* Mock state                                                         */
+/* ------------------------------------------------------------------ */
+
+static bool mock_only_self_present = false;
+static bool mock_long_peer_name    = false;
+static int  mock_send_count        = 0;
+
+/* ------------------------------------------------------------------ */
+/* Deterministic valid Ed25519 keys                                   */
+/* ------------------------------------------------------------------ */
+
+static void test_seed_from_u32(uint32_t v, uint8_t seed[32])
+{
+    memset(seed, 0, 32);
+    seed[0] = 0x5A;
+    seed[1] = (uint8_t)(v >> 24);
+    seed[2] = (uint8_t)(v >> 16);
+    seed[3] = (uint8_t)(v >> 8);
+    seed[4] = (uint8_t)(v);
+    seed[5] = 0x43;
+}
+
+/* 
+ * Updated to generate both the Curve25519 identity key and the 
+ * Ed25519 signing key, satisfying mid_valid_key_binding().
+ */
+static void test_keypair_from_id(uint32_t id, uint8_t id_pk[32], uint8_t sig_pk[32], uint8_t sig_sk[64])
+{
+    uint8_t seed[32];
+    uint8_t tmp_pk[32];
+    uint8_t tmp_sk[64];
+
+    test_seed_from_u32(id, seed);
+    crypto_sign_seed_keypair(tmp_pk, tmp_sk, seed);
+
+    if (sig_pk != NULL) {
+        memcpy(sig_pk, tmp_pk, 32);
+    }
+    if (sig_sk != NULL) {
+        memcpy(sig_sk, tmp_sk, 64);
+    }
+    if (id_pk != NULL) {
+        /* Derive Curve25519 identity key from Ed25519 signing key */
+        if (crypto_sign_ed25519_pk_to_curve25519(id_pk, tmp_pk) != 0) {
+            memcpy(id_pk, tmp_pk, 32); /* Fallback, should never happen */
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Tox mocks                                                          */
+/* ------------------------------------------------------------------ */
+
+typedef struct DummyTox {
+    int dummy;
+} DummyTox;
+
+Tox *create_dummy_tox(void)
+{
+    static DummyTox t;
+    return (Tox *)&t;
+}
+
+
+
+bool tox_group_self_get_public_key(const Tox *tox,
+                                   uint32_t group_number,
+                                   uint8_t *public_key,
+                                   Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    }
+    if (public_key == NULL) {
+        return false;
+    }
+
+    uint8_t sig_pk[32], sig_sk[64];
+    test_keypair_from_id(SELF_SEED_ID, public_key, sig_pk, sig_sk);
+    return true;
+}
+
+bool tox_group_self_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    }
+    if (public_key == NULL) {
+        return false;
+    }
+
+    uint8_t id_pk[32], sig_sk[64];
+    test_keypair_from_id(SELF_SEED_ID, id_pk, public_key, sig_sk);
+    return true;
+}
+
+bool tox_group_self_get_signing_secret_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *secret_key,
+                                           Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    }
+    if (secret_key == NULL) {
+        return false;
+    }
+
+    uint8_t id_pk[32], sig_pk[32];
+    test_keypair_from_id(SELF_SEED_ID, id_pk, sig_pk, secret_key);
+    return true;
+}
+
+bool tox_group_peer_get_public_key(const Tox *tox,
+                                   uint32_t group_number,
+                                   uint32_t peer_id,
+                                   uint8_t *public_key,
+                                   Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    }
+    if (public_key == NULL) {
+        return false;
+    }
+
+    uint8_t sig_pk[32], sig_sk[64];
+    test_keypair_from_id(peer_id, public_key, sig_pk, sig_sk);
+    return true;
+}
+
+bool tox_group_peer_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint32_t peer_id,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    }
+    if (public_key == NULL) {
+        return false;
+    }
+
+    uint8_t id_pk[32], sig_sk[64];
+    test_keypair_from_id(peer_id, id_pk, public_key, sig_sk);
+    return true;
+}
+
+
+
+
+
+uint32_t tox_group_by_chat_id(const Tox *tox, const uint8_t *chat_id, Tox_Err_Group_State_Queries *error)
+{
+    (void)tox;
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_STATE_QUERIES_OK;
+    }
+    if (chat_id == NULL) {
+        return UINT32_MAX;
+    }
+    /* Reconstruct the group_number from the first 4 bytes (little-endian) */
+    return (uint32_t)chat_id[0] |
+           ((uint32_t)chat_id[1] << 8) |
+           ((uint32_t)chat_id[2] << 16) |
+           ((uint32_t)chat_id[3] << 24);
+}
+
+bool tox_group_get_chat_id(const Tox *tox, uint32_t group_number, uint8_t *chat_id, Tox_Err_Group_State_Queries *error)
+{
+    (void)tox;
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_STATE_QUERIES_OK;
+    }
+    if (chat_id != NULL) {
+        memset(chat_id, 0, TOX_GROUP_CHAT_ID_SIZE);
+        chat_id[0] = (uint8_t)(group_number & 0xFF);
+        chat_id[1] = (uint8_t)((group_number >> 8) & 0xFF);
+        chat_id[2] = (uint8_t)((group_number >> 16) & 0xFF);
+        chat_id[3] = (uint8_t)((group_number >> 24) & 0xFF);
+    }
+    return true;
+}
+
+
+
+
+uint32_t tox_group_self_get_peer_id(const Tox *tox,
+                                    uint32_t group_number,
+                                    Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    }
+    return 0;
+}
+
+/*
+ * Connection / role mocks.
+ *
+ * These were missing, so the weak defaults returned TOX_CONNECTION_NONE and
+ * every peer looked offline. Returning TCP makes self-join and peer-join mark
+ * records online, which is what the assertions expect.
+ */
+Tox_Connection tox_group_peer_get_connection_status(const Tox *tox,
+                                                    uint32_t group_number,
+                                                    uint32_t peer_id,
+                                                    Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    (void)peer_id;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    }
+    return TOX_CONNECTION_TCP;
+}
+
+Tox_Group_Role tox_group_peer_get_role(const Tox *tox,
+                                       uint32_t group_number,
+                                       uint32_t peer_id,
+                                       Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    (void)peer_id;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    }
+    return TOX_GROUP_ROLE_USER;
+}
+
+Tox_Group_Role tox_group_self_get_role(const Tox *tox,
+                                       uint32_t group_number,
+                                       Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    }
+    return TOX_GROUP_ROLE_FOUNDER;
+}
+
+size_t tox_group_peer_get_name_size(const Tox *tox,
+                                    uint32_t group_number,
+                                    uint32_t peer_id,
+                                    Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    (void)peer_id;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    }
+
+    if (mock_long_peer_name) {
+        return (size_t)MID_MAX_NICK_SIZE + 50;
+    }
+    return 4;
+}
+
+bool tox_group_peer_get_name(const Tox *tox,
+                             uint32_t group_number,
+                             uint32_t peer_id,
+                             uint8_t *name,
+                             Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    }
+    if (name == NULL) {
+        return false;
+    }
+
+    if (mock_long_peer_name) {
+        memset(name, 'A', (size_t)MID_MAX_NICK_SIZE + 50);
+        return true;
+    }
+
+    name[0] = 'p';
+    name[1] = (uint8_t)((peer_id >> 8) & 0xFF);
+    name[2] = (uint8_t)(peer_id & 0xFF);
+    name[3] = '!';
+    return true;
+}
+
+uint32_t tox_group_peer_by_public_key(const Tox *tox,
+                                      uint32_t group_number,
+                                      const uint8_t *public_key,
+                                      Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+
+    if (public_key == NULL) {
+        if (error != NULL) {
+            *error = (Tox_Err_Group_Peer_Query)9999;
+        }
+        return UINT32_MAX;
+    }
+
+    if (mock_only_self_present) {
+        uint8_t self_pk[32];
+        test_keypair_from_id(SELF_SEED_ID, self_pk, NULL, NULL);
+
+        if (memcmp(public_key, self_pk, 32) == 0) {
+            if (error != NULL) {
+                *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+            }
+            return 1;
+        }
+
+        if (error != NULL) {
+            *error = (Tox_Err_Group_Peer_Query)9999;
+        }
+        return UINT32_MAX;
+    }
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    }
+    return 1;
+}
+
+bool tox_group_send_custom_packet(const Tox *tox,
+                                  uint32_t group_number,
+                                  bool lossless,
+                                  const uint8_t *data,
+                                  size_t length,
+                                  Tox_Err_Group_Send_Custom_Packet *error)
+{
+    (void)tox;
+    (void)group_number;
+    (void)lossless;
+
+    if (error != NULL) {
+        *error = TOX_ERR_GROUP_SEND_CUSTOM_PACKET_OK;
+    }
+
+    if (data == NULL || length == 0 || length > 1200) {
+        return false;
+    }
+
+    mock_send_count++;
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Packet helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+static void put_u16_be(uint8_t *p, uint16_t v)
+{
+    p[0] = (uint8_t)(v >> 8);
+    p[1] = (uint8_t)(v & 0xFF);
+}
+
+static void put_u64_be(uint8_t *p, uint64_t v)
+{
+    p[0] = (uint8_t)(v >> 56);
+    p[1] = (uint8_t)(v >> 48);
+    p[2] = (uint8_t)(v >> 40);
+    p[3] = (uint8_t)(v >> 32);
+    p[4] = (uint8_t)(v >> 24);
+    p[5] = (uint8_t)(v >> 16);
+    p[6] = (uint8_t)(v >> 8);
+    p[7] = (uint8_t)(v & 0xFF);
+}
+
+static bool make_presence_packet(uint8_t *out,
+                                 size_t cap,
+                                 size_t *out_len,
+                                 uint32_t signer_id,
+                                 uint8_t status,
+                                 uint64_t timestamp,
+                                 const uint8_t *nick,
+                                 uint16_t nick_len)
+{
+    if (out == NULL || out_len == NULL) {
+        return false;
+    }
+    if (nick_len > MID_MAX_NICK_SIZE) {
+        return false;
+    }
+    if (nick_len > 0 && nick == NULL) {
+        return false;
+    }
+
+    uint8_t id_pk[32];
+    uint8_t sig_pk[32];
+    uint8_t sig_sk[64];
+    test_keypair_from_id(signer_id, id_pk, sig_pk, sig_sk);
+
+    size_t body_len = 1 + 8 + 2 + nick_len + 32 + 32;
+    size_t packet_len = 5 + 64 + body_len;
+
+    if (cap < packet_len || body_len > TEST_BODY_MAX) {
+        return false;
+    }
+
+    uint8_t body[TEST_BODY_MAX];
+    size_t o = 0;
+
+    body[o++] = status;
+    put_u64_be(body + o, timestamp);
+    o += 8;
+    put_u16_be(body + o, nick_len);
+    o += 2;
+
+    if (nick_len > 0) {
+        memcpy(body + o, nick, nick_len);
+        o += nick_len;
+    }
+
+    memcpy(body + o, id_pk, 32);  // Identity key (Curve25519)
+    o += 32;
+    memcpy(body + o, sig_pk, 32); // Signing key (Ed25519)
+    o += 32;
+
+    uint8_t sig[64];
+    unsigned long long sig_len = 0;
+
+    if (crypto_sign_detached(sig, &sig_len, body, body_len, sig_sk) != 0) {
+        return false;
+    }
+    if (sig_len != 64) {
+        return false;
+    }
+
+    size_t p = 0;
+    out[p++] = MID_MAGIC_0;
+    out[p++] = MID_MAGIC_1;
+    out[p++] = MID_MAGIC_2;
+    out[p++] = MID_PROTOCOL_VERSION;
+    out[p++] = MID_MSG_PRESENCE;
+
+    memcpy(out + p, sig, 64);
+    p += 64;
+
+    memcpy(out + p, body, body_len);
+    p += body_len;
+
+    *out_len = p;
+    return true;
+}
+
+static bool get_peer_info_by_key(MidState *s,
+                                 const uint8_t *chat_id,
+                                 const uint8_t key[32],
+                                 MidPeerInfo *out)
+{
+    int idx = mid_find_peer(s, chat_id, key);
+    if (idx < 0) {
+        return false;
+    }
+    return mid_peer_list_get(s, chat_id, (size_t)idx, out);
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+static bool test_null_and_invalid_api(void)
+{
+    uint8_t zero_key[32] = {0};
+    MidPeerInfo info;
+
+    mid_free(NULL);
+
+    T_ASSERT_INT_EQ(mid_group_count(NULL), 0, "mid_group_count(NULL)");
+    T_ASSERT_INT_EQ(mid_peer_count(NULL, cid1), 0, "mid_peer_count(NULL)");
+    T_ASSERT_INT_EQ(mid_signed_count(NULL, cid1), 0, "mid_signed_count(NULL)");
+    T_ASSERT_INT_EQ(mid_online_count(NULL, cid1), 0, "mid_online_count(NULL)");
+    T_ASSERT_INT_EQ(mid_peer_list_count(NULL, cid1), 0, "mid_peer_list_count(NULL)");
+
+    T_ASSERT_INT_EQ(mid_find_peer(NULL, cid1, zero_key), -1, "mid_find_peer(NULL)");
+    T_ASSERT_FALSE(mid_delete_peer_by_identity(NULL, cid1, zero_key), "mid_delete_peer_by_identity(NULL)");
+    T_ASSERT_FALSE(mid_peer_is_signed_left(NULL, cid1, zero_key), "mid_peer_is_signed_left(NULL)");
+    T_ASSERT_FALSE(mid_announce_leave(NULL, NULL, GROUP_1), "mid_announce_leave(NULL)");
+    T_ASSERT_FALSE(mid_on_group_moderation(NULL, NULL, GROUP_1, 0, 0, TOX_GROUP_MOD_EVENT_KICK),
+                   "mid_on_group_moderation(NULL)");
+    T_ASSERT_FALSE(mid_peer_list_get(NULL, cid1, 0, &info), "mid_peer_list_get(NULL)");
+
+    /* These must simply not crash. */
+    mid_on_group_self_join(NULL, NULL, GROUP_1, NULL, 0);
+    mid_on_group_delete(NULL, NULL, GROUP_1);
+    mid_on_group_peer_join(NULL, NULL, GROUP_1, 1);
+    mid_on_group_peer_exit(NULL, NULL, GROUP_1, TOX_GROUP_EXIT_TYPE_QUIT);
+    mid_on_group_peer_name(NULL, NULL, GROUP_1, 1);
+    mid_on_group_custom_packet(NULL, NULL, GROUP_1, 1, NULL, 0);
+    mid_iterate(NULL, NULL);
+    mid_print_peer_table(NULL, cid1, "null");
+
+    return true;
+}
+
+static bool test_new_free_and_empty_queries(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    T_ASSERT_PTR_NOT_NULL(s, "mid_new()");
+
+    Tox *tox = create_dummy_tox();
+    T_ASSERT_PTR_NOT_NULL(tox, "create_dummy_tox()");
+
+    T_ASSERT_INT_EQ(mid_group_count(s), 0, "empty group count");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 0, "empty peer count");
+    T_ASSERT_INT_EQ(mid_signed_count(s, cid1), 0, "empty signed count");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 0, "empty online count");
+    T_ASSERT_INT_EQ(mid_peer_list_count(s, cid1), 0, "empty peer list count");
+
+    mid_iterate(s, tox);
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_self_join_creates_signed_self(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"alice", 5);
+
+    T_ASSERT_INT_EQ(mid_group_count(s), 1, "group count after self join");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "peer count after self join");
+    T_ASSERT_INT_EQ(mid_signed_count(s, cid1), 1, "signed count after self join");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 1, "online count after self join");
+
+    uint8_t self_pk[32];
+    test_keypair_from_id(SELF_SEED_ID, self_pk, NULL, NULL);
+
+    int idx = mid_find_peer(s, cid1, self_pk);
+    T_ASSERT_INT_EQ(idx, 0, "self peer index");
+
+    MidPeerInfo info;
+    T_ASSERT_TRUE(mid_peer_list_get(s, cid1, 0, &info), "get self peer info");
+
+    T_ASSERT_TRUE(memcmp(info.identity_key, self_pk, 32) == 0, "self identity key");
+    T_ASSERT_INT_EQ(info.status, MID_STATUS_ACTIVE, "self status");
+    T_ASSERT_TRUE(info.connection_status != TOX_CONNECTION_NONE, "self online");
+    T_ASSERT_INT_EQ(info.has_signature, 1, "self signed");
+    T_ASSERT_INT_EQ(info.nickname_len, 5, "self nickname length");
+    T_ASSERT_TRUE(memcmp(info.nickname, "alice", 5) == 0, "self nickname");
+    T_ASSERT_INT_EQ(info.nickname[5], 0, "self nickname NUL terminator");
+
+    T_ASSERT_FALSE(mid_peer_is_signed_left(s, cid1, self_pk), "self should not be LEFT");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_self_join_idempotent(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"alice", 5);
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"alice", 5);
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"alice", 5);
+
+    T_ASSERT_INT_EQ(mid_group_count(s), 1, "group count remains 1");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "self is not duplicated");
+    T_ASSERT_INT_EQ(mid_signed_count(s, cid1), 1, "signed count remains 1");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 1, "online count remains 1");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_self_join_long_nickname_truncated(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    uint8_t nick[200];
+    memset(nick, 'N', sizeof(nick));
+
+    mid_on_group_self_join(s, tox, GROUP_1, nick, sizeof(nick));
+
+    T_ASSERT_INT_EQ(mid_peer_list_count(s, cid1), 1, "peer list count");
+
+    MidPeerInfo info;
+    T_ASSERT_TRUE(mid_peer_list_get(s, cid1, 0, &info), "get self peer info");
+
+    T_ASSERT_INT_EQ(info.nickname_len, MID_MAX_NICK_SIZE, "nickname truncated to max");
+
+    bool all_match = true;
+    for (uint16_t i = 0; i < MID_MAX_NICK_SIZE; i++) {
+        if (info.nickname[i] != 'N') {
+            all_match = false;
+            break;
+        }
+    }
+    T_ASSERT_TRUE(all_match, "truncated nickname bytes");
+    T_ASSERT_INT_EQ(info.nickname[MID_MAX_NICK_SIZE], 0, "truncated nickname NUL terminator");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_multiple_groups_and_delete(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"g1", 2);
+    mid_on_group_self_join(s, tox, GROUP_2, (const uint8_t *)"g2", 2);
+
+    T_ASSERT_INT_EQ(mid_group_count(s), 2, "two groups");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "group 1 self");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid2), 1, "group 2 self");
+
+    mid_on_group_delete(s, tox, GROUP_1);
+
+    T_ASSERT_INT_EQ(mid_group_count(s), 1, "one group after delete");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 0, "deleted group has no peers");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid2), 1, "remaining group still has self");
+
+    mid_on_group_delete(s, tox, GROUP_9999);
+    T_ASSERT_INT_EQ(mid_group_count(s), 1, "deleting unknown group does nothing");
+
+    mid_on_group_delete(s, tox, GROUP_2);
+    T_ASSERT_INT_EQ(mid_group_count(s), 0, "all groups deleted");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_peer_join_counts_and_list(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    uint32_t peer_id = 1001;
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+    mid_on_group_peer_join(s, tox, GROUP_1, peer_id);
+
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 2, "self + joined peer");
+    T_ASSERT_INT_EQ(mid_signed_count(s, cid1), 1, "only self signed");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 2, "self + peer online");
+
+    uint8_t peer_pk[32];
+    test_keypair_from_id(peer_id, peer_pk, NULL, NULL);
+
+    MidPeerInfo info;
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, peer_pk, &info), "find joined peer");
+
+    T_ASSERT_TRUE(memcmp(info.identity_key, peer_pk, 32) == 0, "peer identity key");
+    T_ASSERT_INT_EQ(info.status, MID_STATUS_ACTIVE, "peer status");
+    T_ASSERT_TRUE(info.connection_status != TOX_CONNECTION_NONE, "peer online");
+    T_ASSERT_INT_EQ(info.has_signature, 0, "peer not signed yet");
+    T_ASSERT_INT_EQ(info.nickname_len, 4, "peer nickname from mock");
+
+    /* Duplicate join must not duplicate the record. */
+    mid_on_group_peer_join(s, tox, GROUP_1, peer_id);
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 2, "duplicate join does not duplicate");
+
+    T_ASSERT_TRUE(mid_delete_peer_by_identity(s, cid1, peer_pk), "delete peer");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "peer deleted");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 1, "only self online after delete");
+    T_ASSERT_INT_EQ(mid_find_peer(s, cid1, peer_pk), -1, "peer not found after delete");
+
+    T_ASSERT_FALSE(mid_delete_peer_by_identity(s, cid1, peer_pk), "delete again fails");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_peer_name_truncation(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    uint32_t peer_id = 1002;
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    mock_long_peer_name = true;
+    mid_on_group_peer_join(s, tox, GROUP_1, peer_id);
+    mock_long_peer_name = false;
+
+    uint8_t peer_pk[32];
+    test_keypair_from_id(peer_id, peer_pk, NULL, NULL);
+
+    MidPeerInfo info;
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, peer_pk, &info), "find peer");
+    T_ASSERT_INT_EQ(info.nickname_len, MID_MAX_NICK_SIZE, "peer nickname truncated");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_peer_exit_marks_offline(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    uint32_t peer_id = 1003;
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+    mid_on_group_peer_join(s, tox, GROUP_1, peer_id);
+
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 2, "both online before exit");
+
+    mock_only_self_present = true;
+    mid_on_group_peer_exit(s, tox, GROUP_1, TOX_GROUP_EXIT_TYPE_QUIT);
+    mock_only_self_present = false;
+
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 1, "peer offline after exit sync");
+
+    uint8_t peer_pk[32];
+    test_keypair_from_id(peer_id, peer_pk, NULL, NULL);
+
+    MidPeerInfo peer_info;
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, peer_pk, &peer_info), "find peer");
+    T_ASSERT_INT_EQ(peer_info.status, MID_STATUS_ACTIVE, "peer remains ACTIVE");
+    T_ASSERT_TRUE(peer_info.connection_status == TOX_CONNECTION_NONE, "peer is offline");
+
+    uint8_t self_pk[32];
+    test_keypair_from_id(SELF_SEED_ID, self_pk, NULL, NULL);
+
+    MidPeerInfo self_info;
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, self_pk, &self_info), "find self");
+    T_ASSERT_TRUE(self_info.connection_status != TOX_CONNECTION_NONE, "self remains online");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_valid_presence_packet_and_old_timestamp(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    uint32_t peer_id = 2001;
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    uint8_t pkt[512];
+    size_t len = 0;
+
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_ACTIVE,
+                                       1000,
+                                       (const uint8_t *)"alice", 5),
+                  "build valid presence packet");
+
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    uint8_t peer_pk[32];
+    test_keypair_from_id(peer_id, peer_pk, NULL, NULL);
+
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 2, "presence packet inserted peer");
+    T_ASSERT_INT_EQ(mid_signed_count(s, cid1), 2, "peer is signed");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 2, "peer is online");
+
+    MidPeerInfo info;
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, peer_pk, &info), "find peer");
+    T_ASSERT_INT_EQ(info.has_signature, 1, "peer has signature");
+    T_ASSERT_TRUE(info.connection_status != TOX_CONNECTION_NONE, "peer online");
+    T_ASSERT_INT_EQ(info.status, MID_STATUS_ACTIVE, "peer ACTIVE");
+    T_ASSERT_INT_EQ(info.nickname_len, 5, "packet nickname length");
+    T_ASSERT_TRUE(memcmp(info.nickname, "alice", 5) == 0, "packet nickname");
+
+    /* Older signed timestamp must not replace newer nickname. */
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_ACTIVE,
+                                       500,
+                                       (const uint8_t *)"old", 3),
+                  "build old presence packet");
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, peer_pk, &info), "find peer after old packet");
+    T_ASSERT_INT_EQ(info.nickname_len, 5, "old packet did not replace nickname length");
+    T_ASSERT_TRUE(memcmp(info.nickname, "alice", 5) == 0, "old packet did not replace nickname");
+
+    /* Equal signed timestamp must not replace either. */
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_ACTIVE,
+                                       1000,
+                                       (const uint8_t *)"new", 3),
+                  "build equal-timestamp presence packet");
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, peer_pk, &info), "find peer after equal packet");
+    T_ASSERT_INT_EQ(info.nickname_len, 5, "equal timestamp did not replace nickname length");
+    T_ASSERT_TRUE(memcmp(info.nickname, "alice", 5) == 0, "equal timestamp did not replace nickname");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_left_tombstone(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    uint32_t peer_id = 2100;
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    uint8_t pkt[512];
+    size_t len = 0;
+
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_ACTIVE,
+                                       1000,
+                                       (const uint8_t *)"bob", 3),
+                  "build ACTIVE packet");
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    uint8_t peer_pk[32];
+    test_keypair_from_id(peer_id, peer_pk, NULL, NULL);
+
+    T_ASSERT_FALSE(mid_peer_is_signed_left(s, cid1, peer_pk), "not LEFT yet");
+
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_LEFT,
+                                       2000,
+                                       NULL, 0),
+                  "build LEFT tombstone packet");
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    T_ASSERT_TRUE(mid_peer_is_signed_left(s, cid1, peer_pk), "signed LEFT tombstone stored");
+
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 2, "tombstone remains in roster");
+    T_ASSERT_INT_EQ(mid_signed_count(s, cid1), 2, "tombstone remains signed");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 1, "LEFT peer is offline");
+
+    MidPeerInfo info;
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, peer_pk, &info), "find tombstoned peer");
+    T_ASSERT_INT_EQ(info.status, MID_STATUS_LEFT, "peer status LEFT");
+    T_ASSERT_TRUE(info.connection_status == TOX_CONNECTION_NONE, "peer offline");
+    T_ASSERT_INT_EQ(info.has_signature, 1, "tombstone signed");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_old_left_does_not_overwrite(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    uint32_t peer_id = 2101;
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    uint8_t pkt[512];
+    size_t len = 0;
+
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_ACTIVE,
+                                       5000,
+                                       (const uint8_t *)"live", 4),
+                  "build ACTIVE packet");
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_LEFT,
+                                       4000,
+                                       NULL, 0),
+                  "build old LEFT packet");
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    uint8_t peer_pk[32];
+    test_keypair_from_id(peer_id, peer_pk, NULL, NULL);
+
+    T_ASSERT_FALSE(mid_peer_is_signed_left(s, cid1, peer_pk), "old LEFT must not tombstone");
+
+    MidPeerInfo info;
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, peer_pk, &info), "find peer");
+    T_ASSERT_INT_EQ(info.status, MID_STATUS_ACTIVE, "peer still ACTIVE");
+    T_ASSERT_TRUE(info.connection_status != TOX_CONNECTION_NONE, "peer still online");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_newer_active_resurrects_after_left(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    uint32_t peer_id = 2300;
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    uint8_t pkt[512];
+    size_t len = 0;
+
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_LEFT,
+                                       1000,
+                                       NULL, 0),
+                  "build LEFT packet for unknown peer");
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    uint8_t peer_pk[32];
+    test_keypair_from_id(peer_id, peer_pk, NULL, NULL);
+
+    T_ASSERT_TRUE(mid_peer_is_signed_left(s, cid1, peer_pk), "unknown LEFT tombstone stored");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 2, "tombstone inserted");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 1, "tombstone offline");
+
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_ACTIVE,
+                                       2000,
+                                       (const uint8_t *)"back", 4),
+                  "build newer ACTIVE packet");
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    T_ASSERT_FALSE(mid_peer_is_signed_left(s, cid1, peer_pk), "newer ACTIVE removes LEFT state");
+
+    MidPeerInfo info;
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, peer_pk, &info), "find resurrected peer");
+    T_ASSERT_INT_EQ(info.status, MID_STATUS_ACTIVE, "peer ACTIVE again");
+    T_ASSERT_TRUE(info.connection_status != TOX_CONNECTION_NONE, "peer online again");
+    T_ASSERT_INT_EQ(info.nickname_len, 4, "new nickname applied");
+    T_ASSERT_TRUE(memcmp(info.nickname, "back", 4) == 0, "new nickname bytes");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_corrupt_signature_and_malformed_packets(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    uint32_t peer_id = 2200;
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    uint8_t pkt[512];
+    size_t len = 0;
+
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       peer_id,
+                                       MID_STATUS_ACTIVE,
+                                       1000,
+                                       (const uint8_t *)"x", 1),
+                  "build valid packet");
+
+    /* Corrupt one byte inside the signature. */
+    pkt[10] ^= 0xFF;
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, pkt, len);
+
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "corrupt signature rejected");
+
+    uint8_t bad_magic[5] = {0x00, 0x00, 0x00, 0x00, MID_MSG_PRESENCE};
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, bad_magic, sizeof(bad_magic));
+
+    uint8_t short_pkt[4] = {MID_MAGIC_0, MID_MAGIC_1, MID_MAGIC_2, MID_PROTOCOL_VERSION};
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, short_pkt, sizeof(short_pkt));
+
+    uint8_t unknown_type[5] = {MID_MAGIC_0, MID_MAGIC_1, MID_MAGIC_2, MID_PROTOCOL_VERSION, 0x7F};
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, unknown_type, sizeof(unknown_type));
+
+    mid_on_group_custom_packet(s, tox, GROUP_1, peer_id, NULL, 0);
+
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "malformed packets rejected");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_self_packet_ignored(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    uint8_t pkt[512];
+    size_t len = 0;
+
+    T_ASSERT_TRUE(make_presence_packet(pkt, sizeof(pkt), &len,
+                                       SELF_SEED_ID,
+                                       MID_STATUS_ACTIVE,
+                                       9999,
+                                       (const uint8_t *)"evil", 4),
+                  "build self-signed packet");
+
+    mid_on_group_custom_packet(s, tox, GROUP_1, 3000, pkt, len);
+
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "self packet from network ignored");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_announce_leave(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    uint8_t self_pk[32];
+    test_keypair_from_id(SELF_SEED_ID, self_pk, NULL, NULL);
+
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 1, "self online before leave");
+    T_ASSERT_FALSE(mid_peer_is_signed_left(s, cid1, self_pk), "not LEFT before leave");
+
+    T_ASSERT_TRUE(mid_announce_leave(s, tox, GROUP_1), "announce leave succeeds");
+
+    T_ASSERT_TRUE(mid_peer_is_signed_left(s, cid1, self_pk), "self LEFT tombstone stored");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "self tombstone remains");
+    T_ASSERT_INT_EQ(mid_signed_count(s, cid1), 1, "self tombstone signed");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 0, "self offline after leave");
+
+    MidPeerInfo info;
+    T_ASSERT_TRUE(get_peer_info_by_key(s, cid1, self_pk, &info), "find self tombstone");
+    T_ASSERT_INT_EQ(info.status, MID_STATUS_LEFT, "self status LEFT");
+    T_ASSERT_TRUE(info.connection_status == TOX_CONNECTION_NONE, "self offline");
+    T_ASSERT_INT_EQ(info.has_signature, 1, "self tombstone signed");
+
+    T_ASSERT_FALSE(mid_announce_leave(s, tox, GROUP_9999), "announce leave unknown group fails");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_moderation_self_kicked(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+    T_ASSERT_INT_EQ(mid_group_count(s), 1, "group exists before kick");
+
+    bool we_were_kicked =
+        mid_on_group_moderation(s, tox, GROUP_1, 9, 0, TOX_GROUP_MOD_EVENT_KICK);
+
+    T_ASSERT_TRUE(we_were_kicked, "self kick detected");
+    T_ASSERT_INT_EQ(mid_group_count(s), 0, "group state deleted after self kick");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_moderation_other_peer_kicked(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+    uint32_t peer_id = 4000;
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+    mid_on_group_peer_join(s, tox, GROUP_1, peer_id);
+
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 2, "peer exists before kick");
+
+    bool we_were_kicked =
+        mid_on_group_moderation(s, tox, GROUP_1, 0, peer_id, TOX_GROUP_MOD_EVENT_KICK);
+
+    T_ASSERT_FALSE(we_were_kicked, "other peer kick detected");
+    T_ASSERT_INT_EQ(mid_group_count(s), 1, "group remains");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "kicked peer deleted");
+
+    uint8_t peer_pk[32];
+    test_keypair_from_id(peer_id, peer_pk, NULL, NULL);
+    T_ASSERT_INT_EQ(mid_find_peer(s, cid1, peer_pk), -1, "kicked peer not found");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_roster_request_cooldown(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    uint8_t req[5] = {
+        MID_MAGIC_0,
+        MID_MAGIC_1,
+        MID_MAGIC_2,
+        MID_PROTOCOL_VERSION,
+        MID_MSG_ROSTER_REQUEST
+    };
+
+    /*
+     * Roster replies use multicast suppression: a request only schedules a
+     * delayed reply (1..5 s). Nothing is sent synchronously.
+     */
+    mock_send_count = 0;
+    mid_on_group_custom_packet(s, tox, GROUP_1, 1, req, sizeof(req));
+    T_ASSERT_INT_EQ(mock_send_count, 0, "roster request does not reply immediately");
+
+    /*
+     * Wait past the maximum randomized delay, then run the iterate loop so
+     * the scheduled roster reply is flushed out.
+     */
+    sleep(6);
+    mid_iterate(s, tox);
+    T_ASSERT_TRUE(mock_send_count > 0, "scheduled roster reply is eventually sent");
+
+    /*
+     * A second request immediately after must again be delayed, not sent
+     * synchronously.
+     */
+    mock_send_count = 0;
+    mid_on_group_custom_packet(s, tox, GROUP_1, 1, req, sizeof(req));
+    T_ASSERT_INT_EQ(mock_send_count, 0, "second roster request is also delayed");
+
+    mid_free(s);
+    return true;
+}
+
+static void counting_cb(const uint8_t chat_id[TOX_GROUP_CHAT_ID_SIZE], void *user_data)
+{
+    (void)chat_id;
+    if (user_data != NULL) {
+        (*(int *)user_data)++;
+    }
+}
+
+static bool test_callback_fires(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    int count = 0;
+    mid_set_peer_list_changed_cb(s, counting_cb, &count);
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"cb", 2);
+    T_ASSERT_INT_EQ(count, 1, "callback fired once for self join");
+
+    mid_set_peer_list_changed_cb(s, NULL, NULL);
+    mid_on_group_peer_join(s, tox, GROUP_1, 6000);
+    T_ASSERT_INT_EQ(count, 1, "callback not fired after unregister");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_iterate_no_crash(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+
+    mid_iterate(s, tox);
+    mid_iterate(s, tox);
+
+    T_ASSERT_INT_EQ(mid_group_count(s), 1, "group remains after iterate");
+    T_ASSERT_INT_EQ(mid_peer_count(s, cid1), 1, "peer remains after iterate");
+    T_ASSERT_INT_EQ(mid_online_count(s, cid1), 1, "self remains online after iterate");
+
+    mid_free(s);
+    return true;
+}
+
+static bool test_print_peer_table_no_crash(void)
+{
+    MidState *s = mid_new(NULL, NULL, 0);
+    Tox *tox = create_dummy_tox();
+
+    mid_on_group_self_join(s, tox, GROUP_1, (const uint8_t *)"self", 4);
+    mid_on_group_peer_join(s, tox, GROUP_1, 7000);
+
+    mid_print_peer_table(s, cid1, "unit");
+    mid_print_peer_table(s, cid9999, "invalid");
+
+    mid_free(s);
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    if (sodium_init() < 0) {
+        return 1;
+    }
+
+    TEST_SUITE("midroster unit / roster logic tests");
+
+    RUN_TEST(test_null_and_invalid_api);
+    RUN_TEST(test_new_free_and_empty_queries);
+    RUN_TEST(test_self_join_creates_signed_self);
+    RUN_TEST(test_self_join_idempotent);
+    RUN_TEST(test_self_join_long_nickname_truncated);
+    RUN_TEST(test_multiple_groups_and_delete);
+    RUN_TEST(test_peer_join_counts_and_list);
+    RUN_TEST(test_peer_name_truncation);
+    RUN_TEST(test_peer_exit_marks_offline);
+    RUN_TEST(test_valid_presence_packet_and_old_timestamp);
+    RUN_TEST(test_left_tombstone);
+    RUN_TEST(test_old_left_does_not_overwrite);
+    RUN_TEST(test_newer_active_resurrects_after_left);
+    RUN_TEST(test_corrupt_signature_and_malformed_packets);
+    RUN_TEST(test_self_packet_ignored);
+    RUN_TEST(test_announce_leave);
+    RUN_TEST(test_moderation_self_kicked);
+    RUN_TEST(test_moderation_other_peer_kicked);
+    RUN_TEST(test_roster_request_cooldown);
+    RUN_TEST(test_callback_fires);
+    RUN_TEST(test_iterate_no_crash);
+    RUN_TEST(test_print_peer_table_no_crash);
+
+    SUITE_END();
+
+    return test_summary("midroster_unit");
+}

--- a/ngc_ppeerlist/unit_test/tox_mocks.c
+++ b/ngc_ppeerlist/unit_test/tox_mocks.c
@@ -1,0 +1,399 @@
+#include "../../toxcore/tox.h"
+#include "../../toxencryptsave/toxencryptsave.h"
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <sodium.h>
+
+#ifndef TOX_GROUP_CHAT_ID_SIZE
+#define TOX_GROUP_CHAT_ID_SIZE 32
+#endif
+
+/* When set to 1, each peer_id gets a DISTINCT identity key so the
+ * middleware roster actually grows/shrinks under the threading test. */
+static volatile int g_mock_churn = 1;
+void mock_set_churn(int on) { g_mock_churn = on; }
+
+/* ── deterministic valid Ed25519 keypair for "self" ───────────── */
+
+/* ── deterministic valid keypair for "self" ───────────── */
+static void mock_self_keys(uint8_t id_pk[32], uint8_t sig_pk[32], uint8_t sig_sk[64])
+{
+    uint8_t seed[32];
+    memset(seed, 0, 32);
+    seed[0] = 0x5A;
+    seed[1] = 0x01;
+    seed[2] = 0x02;
+    seed[3] = 0x03;
+    seed[4] = 0x04;
+    seed[5] = 0x43;
+    
+    /* 1. Generate Ed25519 signing keypair */
+    crypto_sign_seed_keypair(sig_pk, sig_sk, seed);
+    
+    /* 2. Derive Curve25519 identity key from Ed25519 signing key */
+    if (crypto_sign_ed25519_pk_to_curve25519(id_pk, sig_pk) != 0) {
+        memcpy(id_pk, sig_pk, 32); /* Fallback, should never happen with valid keys */
+    }
+}
+
+/* ── deterministic valid keypair for churned peers ────── */
+static void mock_churn_peer_keys(uint32_t peer_id, uint8_t id_pk[32], uint8_t sig_pk[32])
+{
+    uint8_t seed[32];
+    uint8_t sk[64];
+    
+    memset(seed, 0, 32);
+    seed[0] = (uint8_t)(peer_id >> 24);
+    seed[1] = (uint8_t)(peer_id >> 16);
+    seed[2] = (uint8_t)(peer_id >> 8);
+    seed[3] = (uint8_t)(peer_id);
+    
+    /* 1. Generate Ed25519 signing keypair */
+    crypto_sign_seed_keypair(sig_pk, sk, seed);
+    
+    /* 2. Derive Curve25519 identity key from Ed25519 signing key */
+    if (crypto_sign_ed25519_pk_to_curve25519(id_pk, sig_pk) != 0) {
+        memcpy(id_pk, sig_pk, 32); /* Fallback, should never happen with valid keys */
+    }
+}
+
+/* ── churn identity (unchanged) ─────────────────────────────────── */
+
+static inline uint64_t churn_splitmix64(uint64_t *state)
+{
+    uint64_t z = (*state += 0x9E3779B97F4A7C15ULL);
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+static inline void churn_put_le64(uint8_t *p, uint64_t v)
+{
+    p[0] = (uint8_t)(v);
+    p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16);
+    p[3] = (uint8_t)(v >> 24);
+    p[4] = (uint8_t)(v >> 32);
+    p[5] = (uint8_t)(v >> 40);
+    p[6] = (uint8_t)(v >> 48);
+    p[7] = (uint8_t)(v >> 56);
+}
+
+
+/******************************************************************************
+Group Chat ID / Group Number mocks
+FIX: encode group_number into chat_id so each group_number gets a unique chat_id.
+******************************************************************************/
+
+__attribute__((weak))
+uint32_t tox_group_by_chat_id(const Tox *tox, const uint8_t *chat_id, Tox_Err_Group_State_Queries *error)
+{
+    (void)tox;
+    if (error) *error = TOX_ERR_GROUP_STATE_QUERIES_OK;
+    if (chat_id == NULL) return UINT32_MAX;
+    return (uint32_t)chat_id[0] |
+           ((uint32_t)chat_id[1] << 8) |
+           ((uint32_t)chat_id[2] << 16) |
+           ((uint32_t)chat_id[3] << 24);
+}
+
+__attribute__((weak))
+bool tox_group_get_chat_id(const Tox *tox, uint32_t group_number, uint8_t *chat_id, Tox_Err_Group_State_Queries *error)
+{
+    (void)tox;
+    if (error) *error = TOX_ERR_GROUP_STATE_QUERIES_OK;
+    if (chat_id != NULL) {
+        memset(chat_id, 0, TOX_GROUP_CHAT_ID_SIZE);
+        chat_id[0] = (uint8_t)(group_number & 0xFF);
+        chat_id[1] = (uint8_t)((group_number >> 8) & 0xFF);
+        chat_id[2] = (uint8_t)((group_number >> 16) & 0xFF);
+        chat_id[3] = (uint8_t)((group_number >> 24) & 0xFF);
+    }
+    return true;
+}
+
+
+/******************************************************************************
+Self Key mocks
+******************************************************************************/
+
+__attribute__((weak))
+bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key, Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    if (public_key == NULL) return false;
+    
+    uint8_t sig_pk[32], sig_sk[64];
+    mock_self_keys(public_key, sig_pk, sig_sk); // Returns Curve25519 identity key
+    return true;
+}
+
+__attribute__((weak))
+bool tox_group_self_get_signing_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key, Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    if (public_key == NULL) return false;
+    
+    uint8_t id_pk[32], sig_sk[64];
+    mock_self_keys(id_pk, public_key, sig_sk); // Returns Ed25519 signing key
+    return true;
+}
+
+__attribute__((weak))
+bool tox_group_self_get_signing_secret_key(const Tox *tox, uint32_t group_number, uint8_t *secret_key, Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    if (secret_key == NULL) return false;
+    
+    uint8_t id_pk[32], sig_pk[32];
+    mock_self_keys(id_pk, sig_pk, secret_key); // Returns Ed25519 secret key
+    return true;
+}
+
+/******************************************************************************
+Peer Key mocks
+******************************************************************************/
+
+__attribute__((weak))
+bool tox_group_peer_get_public_key(const Tox *tox, uint32_t group_number, uint32_t peer_id, uint8_t *public_key, Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    if (public_key == NULL) return false;
+    
+    if (g_mock_churn) {
+        uint8_t sig_pk[32];
+        mock_churn_peer_keys(peer_id, public_key, sig_pk); // Returns Curve25519 identity key
+    } else {
+        memset(public_key, 0xCC, 32);
+    }
+    return true;
+}
+
+__attribute__((weak))
+bool tox_group_peer_get_signing_public_key(const Tox *tox, uint32_t group_number, uint32_t peer_id, uint8_t *public_key, Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    if (public_key == NULL) return false;
+    
+    if (g_mock_churn) {
+        uint8_t id_pk[32];
+        mock_churn_peer_keys(peer_id, id_pk, public_key); // Returns Ed25519 signing key
+    } else {
+        memset(public_key, 0xCC, 32);
+    }
+    return true;
+}
+
+__attribute__((weak))
+uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    return 0;
+}
+
+__attribute__((weak))
+size_t tox_group_peer_get_name_size(const Tox *tox, uint32_t group_number, uint32_t peer_id, Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    (void)peer_id;
+    if (error) *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    return 4;
+}
+
+__attribute__((weak))
+bool tox_group_peer_get_name(const Tox *tox, uint32_t group_number, uint32_t peer_id, uint8_t *name, Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    if (name == NULL) return false;
+    name[0] = 'n';
+    name[1] = (uint8_t)((peer_id >> 8) & 0xFF);
+    name[2] = (uint8_t)(peer_id & 0xFF);
+    name[3] = '!';
+    return true;
+}
+
+__attribute__((weak))
+uint32_t tox_group_peer_by_public_key(const Tox *tox, uint32_t group_number, const uint8_t *public_key, Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    return 1;
+}
+
+__attribute__((weak))
+bool tox_group_send_custom_packet(const Tox *tox, uint32_t group_number, bool lossless, const uint8_t *data, size_t length, Tox_Err_Group_Send_Custom_Packet *error)
+{
+    (void)tox;
+    (void)group_number;
+    (void)lossless;
+    if (error) *error = TOX_ERR_GROUP_SEND_CUSTOM_PACKET_OK;
+    return true;
+}
+
+__attribute__((weak))
+Tox_Connection tox_group_peer_get_connection_status(const Tox *tox, uint32_t group_number, uint32_t peer_id,
+        Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    (void)peer_id;
+    if (error) *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    return TOX_CONNECTION_NONE;
+}
+
+__attribute__((weak))
+Tox_Group_Role tox_group_peer_get_role(const Tox *tox, uint32_t group_number, uint32_t peer_id,
+                                       Tox_Err_Group_Peer_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    (void)peer_id;
+    if (error) *error = TOX_ERR_GROUP_PEER_QUERY_OK;
+    return (Tox_Group_Role)1;
+}
+
+__attribute__((weak))
+Tox_Group_Role tox_group_self_get_role(const Tox *tox, uint32_t group_number, Tox_Err_Group_Self_Query *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_SELF_QUERY_OK;
+    return (Tox_Group_Role)0;
+}
+
+__attribute__((weak))
+bool tox_group_get_founder_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key, Tox_Err_Group_State_Queries *error)
+{
+    (void)tox;
+    (void)group_number;
+    if (error) *error = TOX_ERR_GROUP_STATE_QUERIES_OK;
+    if (public_key == NULL) return false;
+    
+    /* 
+     * Use a distinct, deterministic pattern for the founder identity key.
+     * 0xF0 is used here to represent "FounDer". 
+     */
+    memset(public_key, 0xF0, 32);
+    return true;
+}
+
+/******************************************************************************
+ * toxencryptsave mocks
+ *
+ * Mock encryption uses a simple XOR with the passphrase for testing purposes.
+ * The real implementation uses scrypt + XSalsa20-Poly1305.
+ *
+ * Encrypted format (mock):
+ *   [4 bytes magic "TOXE"] [32 bytes salt (zeroed)] [24 bytes nonce (zeroed)]
+ *   [16 bytes MAC placeholder] [payload XORed with passphrase]
+ *
+ * TOX_PASS_ENCRYPTION_EXTRA_LENGTH = 80 = 4 + 32 + 24 + 16 + 4 (padding)
+ * We use exactly 80 bytes of overhead to match the real API contract.
+ *****************************************************************************/
+
+#define MOCK_TOX_ENC_MAGIC "TOXE"
+#define MOCK_TOX_ENC_MAGIC_LEN 4
+#define MOCK_TOX_ENC_OVERHEAD 80  /* must match TOX_PASS_ENCRYPTION_EXTRA_LENGTH */
+
+bool tox_is_data_encrypted(const uint8_t *data)
+{
+    if (data == NULL) return false;
+    return memcmp(data, MOCK_TOX_ENC_MAGIC, MOCK_TOX_ENC_MAGIC_LEN) == 0;
+}
+
+bool tox_pass_encrypt(const uint8_t *plaintext, size_t plaintext_len,
+                      const uint8_t *passphrase, size_t passphrase_len,
+                      uint8_t *ciphertext, Tox_Err_Encryption *error)
+{
+    if (!plaintext || !ciphertext || (!passphrase && passphrase_len > 0)) {
+        if (error) *error = TOX_ERR_ENCRYPTION_NULL;
+        return false;
+    }
+
+    if (plaintext_len == 0) {
+        if (error) *error = TOX_ERR_ENCRYPTION_NULL;
+        return false;
+    }
+
+    /* Write 80-byte header */
+    memset(ciphertext, 0, MOCK_TOX_ENC_OVERHEAD);
+    memcpy(ciphertext, MOCK_TOX_ENC_MAGIC, MOCK_TOX_ENC_MAGIC_LEN);
+
+    /* XOR payload with passphrase (repeating key) */
+    uint8_t *out = ciphertext + MOCK_TOX_ENC_OVERHEAD;
+    for (size_t i = 0; i < plaintext_len; i++) {
+        if (passphrase && passphrase_len > 0) {
+            out[i] = plaintext[i] ^ passphrase[i % passphrase_len];
+        } else {
+            out[i] = plaintext[i];
+        }
+    }
+
+    if (error) *error = TOX_ERR_ENCRYPTION_OK;
+    return true;
+}
+
+bool tox_pass_decrypt(const uint8_t *ciphertext, size_t ciphertext_len,
+                      const uint8_t *passphrase, size_t passphrase_len,
+                      uint8_t *plaintext, Tox_Err_Decryption *error)
+{
+    if (!ciphertext || !plaintext) {
+        if (error) *error = TOX_ERR_DECRYPTION_NULL;
+        return false;
+    }
+
+    if (ciphertext_len < MOCK_TOX_ENC_OVERHEAD) {
+        if (error) *error = TOX_ERR_DECRYPTION_INVALID_LENGTH;
+        return false;
+    }
+
+    if (memcmp(ciphertext, MOCK_TOX_ENC_MAGIC, MOCK_TOX_ENC_MAGIC_LEN) != 0) {
+        if (error) *error = TOX_ERR_DECRYPTION_BAD_FORMAT;
+        return false;
+    }
+
+    size_t payload_len = ciphertext_len - MOCK_TOX_ENC_OVERHEAD;
+    const uint8_t *in = ciphertext + MOCK_TOX_ENC_OVERHEAD;
+
+    /* Reverse XOR */
+    for (size_t i = 0; i < payload_len; i++) {
+        if (passphrase && passphrase_len > 0) {
+            plaintext[i] = in[i] ^ passphrase[i % passphrase_len];
+        } else {
+            plaintext[i] = in[i];
+        }
+    }
+
+    if (error) *error = TOX_ERR_DECRYPTION_OK;
+    return true;
+}
+
+/******************************************************************************
+Dummy Tox Instance
+******************************************************************************/
+
+typedef struct DummyTox { int dummy; } DummyTox;
+
+__attribute__((weak))
+Tox *create_dummy_tox(void) {
+    static DummyTox t;
+    return (Tox *)&t;
+}

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -2,7 +2,8 @@ lib_LTLIBRARIES += libtoxcore.la
 
 libtoxcore_la_include_HEADERS = \
                         ../toxcore/tox.h \
-                        ../toxutil/toxutil.h
+                        ../toxutil/toxutil.h \
+                        ../ngc_ppeerlist/mid_roster.h
 
 libtoxcore_la_includedir = $(includedir)/tox
 
@@ -117,7 +118,8 @@ libtoxcore_la_SOURCES = ../third_party/cmp/cmp.c \
                         ../toxcore/TCP_connection.c \
                         ../toxcore/list.c \
                         ../toxcore/list.h \
-                        ../toxutil/toxutil.c
+                        ../toxutil/toxutil.c \
+                        ../ngc_ppeerlist/mid_roster.c
 
 libtoxcore_la_CFLAGS =  -I$(top_srcdir) \
                         -I$(top_srcdir)/toxcore \

--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -350,6 +350,33 @@ void gc_get_self_public_key(const GC_Chat *chat, uint8_t *public_key)
     }
 }
 
+void gc_get_self_signing_secret_key(const GC_Chat *chat, uint8_t *secret_key)
+{
+    if (secret_key != nullptr) {
+        memcpy(secret_key, get_sig_sk(chat->self_secret_key), SIG_SECRET_KEY_SIZE);
+    }
+}
+
+void gc_get_self_signing_public_key(const GC_Chat *chat, uint8_t *public_key)
+{
+    if (public_key == nullptr) {
+        return;
+    }
+
+    /*
+     * Peer 0 is always self.
+     */
+    const GC_Connection *gconn = get_gc_connection(chat, 0);
+
+    if (gconn == nullptr) {
+        return;
+    }
+
+    memcpy(public_key,
+           get_sig_pk(gconn->addr.public_key),
+           SIG_PUBLIC_KEY_SIZE);
+}
+
 /** @brief Sets self extended public key to `ext_public_key`.
  *
  * If `ext_public_key` is null this function has no effect.
@@ -687,6 +714,31 @@ static int get_peer_number_of_peer_id(const GC_Chat *chat, uint32_t peer_id)
     }
 
     return -1;
+}
+
+bool gc_get_peer_signing_public_key(const GC_Chat *chat,
+                                    uint32_t peer_id,
+                                    uint8_t *public_key)
+{
+    const int peer_number = get_peer_number_of_peer_id(chat, peer_id);
+
+    if (peer_number == -1) {
+        return false;
+    }
+
+    const GC_Connection *gconn = get_gc_connection(chat, peer_number);
+
+    if (gconn == nullptr) {
+        return false;
+    }
+
+    if (public_key != nullptr) {
+        memcpy(public_key,
+               get_sig_pk(gconn->addr.public_key),
+               SIG_PUBLIC_KEY_SIZE);
+    }
+
+    return true;
 }
 
 /** @brief Returns a unique peer ID.
@@ -2534,6 +2586,13 @@ uint8_t gc_get_role(const GC_Chat *chat, uint32_t peer_id)
     }
 
     return peer->role;
+}
+
+void gc_get_founder_public_key(const GC_Chat *chat, uint8_t *public_key)
+{
+    if (public_key != nullptr) {
+        memcpy(public_key, get_enc_key(chat->shared_state.founder_public_key), ENC_PUBLIC_KEY_SIZE);
+    }
 }
 
 void gc_get_chat_id(const GC_Chat *chat, uint8_t *dest)

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -357,6 +357,35 @@ uint32_t gc_get_self_peer_id(const GC_Chat *chat);
 non_null(1) nullable(2)
 void gc_get_self_public_key(const GC_Chat *chat, uint8_t *public_key);
 
+/**
+ * Copies the client's group Ed25519 secret signing key to `secret_key`.
+ *
+ * `secret_key` must have room for SIG_SECRET_KEY_SIZE bytes.
+ */
+non_null() nullable(2)
+void gc_get_self_signing_secret_key(const GC_Chat *chat, uint8_t *secret_key);
+
+/**
+ * Copies self Ed25519 group signing public key to `public_key`.
+ *
+ * If `public_key` is null this function has no effect.
+ */
+non_null(1) nullable(2)
+void gc_get_self_signing_public_key(const GC_Chat *chat, uint8_t *public_key);
+
+/**
+ * Copies the Ed25519 signing public key of peer `peer_id` to `public_key`.
+ *
+ * If `public_key` is null this function has no effect.
+ *
+ * Returns true on success.
+ * Returns false if the peer is not found.
+ */
+non_null(1) nullable(3)
+bool gc_get_peer_signing_public_key(const GC_Chat *chat,
+                                    uint32_t peer_id,
+                                    uint8_t *public_key);
+
 /** @brief Copies nick designated by `peer_id` to `name`.
  *
  * Call `gc_get_peer_nick_size` to determine the allocation size for the `name` parameter.
@@ -443,6 +472,10 @@ uint8_t gc_get_status(const GC_Chat *chat, uint32_t peer_id);
  */
 non_null()
 uint8_t gc_get_role(const GC_Chat *chat, uint32_t peer_id);
+
+
+void gc_get_founder_public_key(const GC_Chat *chat, uint8_t *public_key);
+
 
 /** @brief Sets the role of peer_id. role must be one of: GR_MODERATOR, GR_USER, GR_OBSERVER
  *

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -3626,6 +3626,7 @@ Tox_Group_Role tox_group_self_get_role(const Tox *tox, uint32_t group_number, To
     return (Tox_Group_Role)role;
 }
 
+
 uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_Err_Group_Self_Query *error)
 {
     assert(tox != nullptr);
@@ -3664,6 +3665,105 @@ bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_
     SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
 
     gc_get_self_public_key(chat, public_key);
+    tox_unlock(tox);
+
+    return true;
+}
+
+bool tox_group_self_get_signing_secret_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *secret_key,
+                                           Tox_Err_Group_Self_Query *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
+
+    gc_get_self_signing_secret_key(chat, secret_key);
+    tox_unlock(tox);
+
+    return true;
+}
+
+bool tox_group_self_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Self_Query *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_SELF_QUERY_OK);
+
+    gc_get_self_signing_public_key(chat, public_key);
+    tox_unlock(tox);
+
+    return true;
+}
+
+bool tox_group_peer_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint32_t peer_id,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Peer_Query *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_PEER_QUERY_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    const bool ret = gc_get_peer_signing_public_key(chat, peer_id, public_key);
+    tox_unlock(tox);
+
+    if (!ret) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_PEER_QUERY_PEER_NOT_FOUND);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_PEER_QUERY_OK);
+    return true;
+}
+
+bool tox_group_get_founder_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
+                                      Tox_Err_Group_State_Queries *error)
+{
+    assert(tox != nullptr);
+
+    tox_lock(tox);
+    const GC_Chat *chat = gc_get_group(tox->m->group_handler, group_number);
+
+    if (chat == nullptr) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_STATE_QUERIES_GROUP_NOT_FOUND);
+        tox_unlock(tox);
+        return false;
+    }
+
+    SET_ERROR_PARAMETER(error, TOX_ERR_GROUP_STATE_QUERIES_OK);
+
+    gc_get_founder_public_key(chat, public_key);
     tox_unlock(tox);
 
     return true;

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -3601,6 +3601,19 @@ uint32_t tox_group_chat_id_size(void);
 
 uint32_t tox_group_peer_public_key_size(void);
 
+/**
+ * The size of an Ed25519 group signing public key.
+ */
+#define TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE 32
+
+/**
+ * The size of a peer's group secret signing key.
+ *
+ * This is the size of the Ed25519 secret signing key used for the client's
+ * group identity in an NGC group.
+ */
+#define TOX_GROUP_SIGNING_SECRET_KEY_SIZE 64
+
 
 /*******************************************************************************
  *
@@ -4182,6 +4195,53 @@ uint32_t tox_group_self_get_peer_id(const Tox *tox, uint32_t group_number, Tox_E
 bool tox_group_self_get_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
                                    Tox_Err_Group_Self_Query *error);
 
+/**
+ * Write the client's group Ed25519 signing public key designated by the given
+ * group number to a byte array.
+ *
+ * This is the public signing key that corresponds to the group secret signing
+ * key returned by tox_group_self_get_signing_secret_key().
+ *
+ * `public_key` should have room for at least TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE
+ * bytes.
+ *
+ * If `public_key` is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_self_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Self_Query *error);
+
+/**
+ * Write the client's group secret signing key designated by the given group
+ * number to a byte array.
+ *
+ * This key is the Ed25519 secret signing key for the client's group identity.
+ * It is permanently tied to the client's identity for this particular group
+ * until the client explicitly leaves the group.
+ *
+ * This key can be used to sign application-level group packets, for example
+ * membership / presence events.
+ *
+ * `secret_key` should have room for at least TOX_GROUP_SIGNING_SECRET_KEY_SIZE
+ * bytes.
+ *
+ * If `secret_key` is NULL, this function call has no effect.
+ *
+ * @param secret_key A valid memory region large enough to store the secret key.
+ *   If this parameter is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_self_get_signing_secret_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint8_t *secret_key,
+                                           Tox_Err_Group_Self_Query *error);
+
+
+
 
 /*******************************************************************************
  *
@@ -4309,6 +4369,26 @@ bool tox_group_peer_get_public_key(const Tox *tox, uint32_t group_number, uint32
 
 bool tox_group_savedpeer_get_public_key(const Tox *tox, uint32_t group_number, uint32_t slot_number, uint8_t *public_key,
                                    Tox_Err_Group_Peer_Query *error);
+
+/**
+ * Write the Ed25519 signing public key of the peer designated by `peer_id`
+ * to `public_key`.
+ *
+ * This key can be used to verify signatures created by that peer's group
+ * secret signing key.
+ *
+ * `public_key` should have room for at least TOX_GROUP_SIGNING_PUBLIC_KEY_SIZE
+ * bytes.
+ *
+ * If `public_key` is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_peer_get_signing_public_key(const Tox *tox,
+                                           uint32_t group_number,
+                                           uint32_t peer_id,
+                                           uint8_t *public_key,
+                                           Tox_Err_Group_Peer_Query *error);
 
 /**
  * @brief Return the peer number associated with that NGC Peer Public Key.
@@ -4455,6 +4535,24 @@ bool tox_group_set_topic(const Tox *tox, uint32_t group_number, const uint8_t *t
  * `group_topic` callback.
  */
 size_t tox_group_get_topic_size(const Tox *tox, uint32_t group_number, Tox_Err_Group_State_Queries *error);
+
+/**
+ * Write the group founder's public key designated by the given group number to a byte array.
+ *
+ * This key is permanently tied to the group's identity and represents the peer who originally
+ * created the group. It remains valid for the entire lifetime of the group and cannot be
+ * changed or reassigned. This key allows peers to reliably identify the group founder even
+ * when the founder is offline.
+ *
+ * `public_key` should have room for at least TOX_GROUP_PEER_PUBLIC_KEY_SIZE bytes.
+ *
+ * @param public_key A valid memory region large enough to store the public key.
+ *   If this parameter is NULL, this function call has no effect.
+ *
+ * @return true on success.
+ */
+bool tox_group_get_founder_public_key(const Tox *tox, uint32_t group_number, uint8_t *public_key,
+                                      Tox_Err_Group_State_Queries *error);
 
 /**
  * Write the topic designated by the given group number to a byte array.


### PR DESCRIPTION
Adds mid_roster, a minimal eventually consistent roster layer for Tox NGC that can track offline peers and signed LEFT tombstones.
It uses only group custom packets and Ed25519-signed presence records. Peers are authenticated by verifying the signature and the NGC identity/signing-key binding. Includes thread-safe state handling, batched roster sync, heartbeat keepalives, encrypted save/load, and simple query/callback APIs.